### PR TITLE
Add RegEngine simulator sprint features

### DIFF
--- a/AUTOPILOT_TASKS.md
+++ b/AUTOPILOT_TASKS.md
@@ -12,14 +12,14 @@ This file is the standing backlog for unattended Codex runs.
 
 ## Priority 1
 
-- [ ] Add server-sent events so the dashboard updates live without polling.
-- [ ] Add scenario presets for leafy greens supplier, fresh-cut processor, and retailer readiness demo.
-- [ ] Add replay mode for previously persisted JSONL events.
-- [ ] Add CSV bulk import for seed lots or scheduled events.
+- [x] Add server-sent events so the dashboard updates live without polling.
+- [x] Add scenario presets for leafy greens supplier, fresh-cut processor, and retailer readiness demo.
+- [x] Add replay mode for previously persisted JSONL events.
+- [x] Add CSV bulk import for seed lots or scheduled events.
 
 ## Priority 2
 
-- [ ] Add clearer lot-lineage views in the dashboard for transformed lots.
+- [x] Add clearer lot-lineage views in the dashboard for transformed lots.
 - [ ] Add richer operator-visible delivery status and retry feedback.
 - [ ] Add export presets that mimic common FDA-request slices.
 - [ ] Add deterministic scenario fixtures for demo playback.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ A mock-first FSMA 204 traceability simulator that emits **RegEngine-compatible i
 - [Quick start (local dev)](#quick-start-local-dev)
 - [Running tests](#running-tests)
 - [Delivery modes](#delivery-modes)
+- [Replay mode](#replay-mode)
+- [CSV import](#csv-import)
+- [Scenario presets](#scenario-presets)
 - [API reference](#api-reference)
 - [RegEngine payload contract](#regengine-payload-contract)
 - [Deployment](#deployment)
@@ -30,7 +33,7 @@ The generator walks lots through a realistic supply-chain lifecycle so the resul
 6. **Transformation** consumes input lots and emits a new output lot
 7. **Downstream shipping + receiving** moves transformed lots to DCs and retail
 
-Each event is persisted with `event_id`, `sha256_hash`, and `chain_hash` so the flow feels production-like, and you can trace lot lineage forward and backward through the dashboard or API.
+Each event is persisted with `event_id`, `sha256_hash`, and `chain_hash` so the flow feels production-like, and you can trace transitive lot lineage forward and backward through the dashboard or API.
 
 ## Project layout
 
@@ -42,6 +45,7 @@ app/
   mock_service.py        # Built-in mock RegEngine ingest endpoint
   models.py              # Pydantic models for config, events, payloads
   regengine_client.py    # HTTP client for live RegEngine delivery
+  scenarios.py           # Named scenario presets for product/location/flow mixes
   store.py               # Event persistence (JSONL)
   static/                # Dashboard (vanilla JS, HTML, CSS)
 .agents/skills/regengine-api-contract/
@@ -77,7 +81,9 @@ Then open:
 http://127.0.0.1:8000
 ```
 
-The dashboard lets you start/stop/step/reset the simulator, inspect recent events, trace lot lineage, and export a mock FDA request CSV. Delivery mode defaults to **`mock`** so no credentials are required.
+The dashboard lets you choose a scenario preset, start/stop/step/reset the simulator, replay the current persisted event log, import CSV seed lots or scheduled events, inspect recent events, trace lot lineage, and export a mock FDA request CSV. It subscribes to live status/event snapshots with Server-Sent Events and falls back to refresh polling if the stream disconnects. Delivery mode defaults to **`mock`** so no credentials are required.
+
+Event records are stored as JSONL at `config.persist_path` (`data/events.jsonl` by default). Existing records at that path are loaded when the app starts or when a start/reset request points at a different path; reset clears the currently configured event log. Replay reads the JSONL log without appending, duplicating, or rewriting stored events.
 
 ## Running tests
 
@@ -104,6 +110,79 @@ Sends real traffic to a RegEngine workspace. Configure from the dashboard or via
 ### `none`
 Generates and persists events locally without delivering them anywhere. Useful for seeding fixtures.
 
+## Replay mode
+
+Replay mode reads previously persisted `StoredEventRecord` JSONL lines, rebuilds the RegEngine ingest payload as:
+
+```json
+{
+  "source": "codex-simulator",
+  "events": [
+    {
+      "cte_type": "receiving",
+      "traceability_lot_code": "TLC-20260421-000003",
+      "product_description": "Romaine Lettuce",
+      "quantity": 500,
+      "unit_of_measure": "cases",
+      "location_name": "Distribution Center #4",
+      "timestamp": "2026-02-05T08:30:00Z",
+      "kdes": {}
+    }
+  ]
+}
+```
+
+By default, `POST /api/simulate/replay` uses the current `config.persist_path`, `config.source`, and `config.delivery`. You can override the JSONL path, source, or delivery mode in the request body. Delivery still uses the same `mock`, `live`, and `none` branches as normal generation.
+
+Replay responses include `status`, `read`, `replayed`, `posted`, `failed`, `source`, `persist_path`, `delivery_mode`, and any delivery `response` or `error`. Replay does not create new stored records.
+
+## CSV import
+
+`POST /api/import/csv` accepts CSV text and imports either scheduled RegEngine-shaped events or seed lots. Valid rows are delivered through the selected delivery mode and persisted as `StoredEventRecord` JSONL entries. Invalid rows are skipped, with deterministic row-level errors in the response. The default dashboard/API delivery remains **`mock`** unless you explicitly submit a different `delivery` object.
+
+Request body:
+
+```json
+{
+  "import_type": "scheduled_events",
+  "csv_text": "cte_type,traceability_lot_code,...",
+  "source": "codex-simulator",
+  "delivery": {
+    "mode": "mock"
+  }
+}
+```
+
+For `scheduled_events`, each row must include the current RegEngine event fields:
+
+```text
+cte_type,traceability_lot_code,product_description,quantity,unit_of_measure,location_name,timestamp
+```
+
+Optional `kdes` may be a JSON object. Additional non-empty columns are imported as KDEs, so columns such as `source_traceability_lot_code`, `input_traceability_lot_codes`, `reference_document_type`, and `reference_document_number` preserve lineage and FDA-export context. `parent_lot_codes` is optional and can be a JSON array or a `|`, `;`, or comma-separated list.
+
+For `seed_lots`, each row must include:
+
+```text
+traceability_lot_code,product_description,quantity,unit_of_measure,location_name
+```
+
+Seed lots become valid `harvesting` events. Optional `timestamp`, `harvest_date`, `field_name`, `immediate_subsequent_recipient`, reference document columns, `kdes` JSON, and other KDE columns are preserved. If no timestamp is supplied, the import time is used.
+
+Import responses include `status`, `total`, `accepted`, `rejected`, `stored`, `posted`, `failed`, `lot_codes`, and `errors[]` with row number, field, and message.
+
+## Scenario presets
+
+Use `config.scenario` to pick a deterministic product/location/flow mix without changing the RegEngine ingest payload shape. Supported values:
+
+| Scenario | Value | Demo emphasis |
+|---|---|---|
+| Leafy greens supplier | `leafy_greens_supplier` | Farm-origin leafy greens through cooling, packout, and outbound cold chain |
+| Fresh-cut processor | `fresh_cut_processor` | Ingredient lots routed into processor inventory and transformed into fresh-cut outputs |
+| Retailer readiness demo | `retailer_readiness_demo` | Retail-ready cases moving quickly through DC receiving and store-level receipts |
+
+Scenario selection is available in the dashboard, in `SimulationConfig`, and via `GET /api/scenarios`. The default is `leafy_greens_supplier`, and delivery still defaults to **`mock`**.
+
 ## API reference
 
 ### Simulator control
@@ -111,11 +190,15 @@ Generates and persists events locally without delivering them anywhere. Useful f
 | Method | Path | Purpose |
 |---|---|---|
 | `GET` | `/api/health` | Liveness probe + current config snapshot |
+| `GET` | `/api/scenarios` | List available scenario presets |
 | `GET` | `/api/simulate/status` | Running state, config, and aggregate stats |
 | `POST` | `/api/simulate/start` | Start the loop (accepts a `config` body) |
 | `POST` | `/api/simulate/stop` | Stop the loop |
 | `POST` | `/api/simulate/step` | Emit one batch synchronously |
+| `POST` | `/api/simulate/replay` | Replay persisted JSONL events through the configured delivery mode |
 | `POST` | `/api/simulate/reset` | Clear state and persisted events |
+| `GET` | `/api/simulate/stream` | Server-Sent Events snapshots for live dashboard updates |
+| `POST` | `/api/import/csv` | Bulk import scheduled events or seed lots from CSV text |
 
 ### Inspection
 
@@ -139,6 +222,7 @@ curl -X POST http://127.0.0.1:8000/api/simulate/start \
   -d '{
     "config": {
       "source": "codex-simulator",
+      "scenario": "fresh_cut_processor",
       "interval_seconds": 1.0,
       "batch_size": 3,
       "seed": 204,
@@ -153,6 +237,20 @@ curl -X POST http://127.0.0.1:8000/api/simulate/start \
   }'
 ```
 
+### Example: reset into a retailer readiness scenario
+
+```bash
+curl -X POST http://127.0.0.1:8000/api/simulate/reset \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "scenario": "retailer_readiness_demo",
+    "batch_size": 3,
+    "seed": 204,
+    "persist_path": "data/events.jsonl"
+  }'
+curl -X POST http://127.0.0.1:8000/api/simulate/step
+```
+
 ### Example: step once and inspect events
 
 ```bash
@@ -160,11 +258,41 @@ curl -X POST http://127.0.0.1:8000/api/simulate/step
 curl http://127.0.0.1:8000/api/events
 ```
 
+### Example: replay the current persisted log
+
+```bash
+curl -X POST http://127.0.0.1:8000/api/simulate/replay
+```
+
+### Example: replay another JSONL file without delivery
+
+```bash
+curl -X POST http://127.0.0.1:8000/api/simulate/replay \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "persist_path": "data/events.jsonl",
+    "source": "codex-simulator",
+    "delivery": {
+      "mode": "none"
+    }
+  }'
+```
+
+### Example: subscribe to live dashboard updates
+
+```bash
+curl -N http://127.0.0.1:8000/api/simulate/stream
+```
+
+Each SSE `snapshot` includes a monotonic `revision`, the same status payload returned by `/api/simulate/status`, and recent event records from `/api/events`. Use `limit` to control the number of recent events and `once=true` for a one-shot smoke check.
+
 ### Example: trace a lot
 
 ```bash
 curl http://127.0.0.1:8000/api/lineage/TLC-20260421-000003
 ```
+
+The lineage response keeps the original `records[]` event timeline and adds `nodes[]` plus `edges[]` so transformed outputs can be displayed as a lot graph. `nodes[]` summarizes each related lot, and `edges[]` links source/input lot codes to downstream packed or transformed lots.
 
 ## RegEngine payload contract
 

--- a/app/controller.py
+++ b/app/controller.py
@@ -1,19 +1,35 @@
 from __future__ import annotations
 
 import asyncio
+from dataclasses import dataclass
+from datetime import UTC, datetime
 from typing import Any
 
+from .csv_importer import parse_csv_import
 from .engine import LegitFlowEngine
 from .mock_service import MockRegEngineService
 from .models import (
+    CSVImportRequest,
+    CSVImportResponse,
     DestinationMode,
     IngestPayload,
+    ReplayRequest,
+    ReplayResponse,
     SimulationConfig,
     StepResponse,
     StoredEventRecord,
 )
 from .regengine_client import LiveRegEngineClient
 from .store import EventStore
+
+
+@dataclass(slots=True)
+class DeliveryOutcome:
+    response: dict[str, Any] | None = None
+    delivery_status: str = "generated"
+    posted: int = 0
+    failed: int = 0
+    error_message: str | None = None
 
 
 class SimulationController:
@@ -32,17 +48,28 @@ class SimulationController:
         self._task: asyncio.Task[None] | None = None
         self._stop_event = asyncio.Event()
         self._lock = asyncio.Lock()
+        self._revision = 0
+        self._change_condition = asyncio.Condition()
 
     @property
     def running(self) -> bool:
         return self._task is not None and not self._task.done()
 
+    @property
+    def revision(self) -> int:
+        return self._revision
+
     async def start(self, config: SimulationConfig) -> None:
-        self.config = config
-        if self.running:
-            return
-        self._stop_event = asyncio.Event()
-        self._task = asyncio.create_task(self._run_loop())
+        async with self._lock:
+            previous_config = self.config
+            self.config = config
+            self.store.configure(config.persist_path)
+            if not self.running and (config.seed != previous_config.seed or config.scenario != previous_config.scenario):
+                self.engine.reset(config.seed, scenario=config.scenario)
+            if not self.running:
+                self._stop_event = asyncio.Event()
+                self._task = asyncio.create_task(self._run_loop())
+        await self._publish_update()
 
     async def stop(self) -> None:
         if not self.running:
@@ -51,17 +78,21 @@ class SimulationController:
         assert self._task is not None
         await self._task
         self._task = None
+        await self._publish_update()
 
     async def shutdown(self) -> None:
         await self.stop()
 
     async def reset(self, config: SimulationConfig | None = None) -> None:
         await self.stop()
-        if config is not None:
-            self.config = config
-        self.engine.reset(self.config.seed)
-        self.store.reset()
-        self.mock_service.reset()
+        async with self._lock:
+            if config is not None:
+                self.config = config
+            self.store.configure(self.config.persist_path)
+            self.engine.reset(self.config.seed, scenario=self.config.scenario)
+            self.store.reset()
+            self.mock_service.reset()
+        await self._publish_update()
 
     async def step(self, batch_size: int | None = None) -> StepResponse:
         async with self._lock:
@@ -74,30 +105,10 @@ class SimulationController:
                 lineages.append(parent_lot_codes)
 
             payload = IngestPayload(source=self.config.source, events=events)
-            response: dict[str, Any] | None = None
-            delivery_status = "generated"
-            error_message: str | None = None
-            posted = 0
-            failed = 0
-
-            try:
-                if self.config.delivery.mode == DestinationMode.MOCK:
-                    response = self.mock_service.ingest(payload).model_dump(mode="json")
-                    delivery_status = "posted"
-                    posted = len(events)
-                elif self.config.delivery.mode == DestinationMode.LIVE:
-                    response = await self.live_client.ingest(payload, self.config)
-                    delivery_status = "posted"
-                    posted = len(events)
-                else:
-                    posted = 0
-            except Exception as exc:  # pragma: no cover - exercised by live integration, not unit tests
-                delivery_status = "failed"
-                error_message = str(exc)
-                failed = len(events)
+            outcome = await self._deliver_payload(payload, self.config)
 
             stored_records: list[StoredEventRecord] = []
-            response_events = (response or {}).get("events", []) if response else []
+            response_events = (outcome.response or {}).get("events", []) if outcome.response else []
             for index, event in enumerate(events):
                 event_response = response_events[index] if index < len(response_events) else None
                 stored_records.append(
@@ -106,24 +117,154 @@ class SimulationController:
                         event=event,
                         parent_lot_codes=lineages[index],
                         destination_mode=self.config.delivery.mode,
-                        delivery_status=delivery_status,
+                        delivery_status=outcome.delivery_status,
                         delivery_response=event_response,
-                        error=error_message,
+                        error=outcome.error_message,
                     )
                 )
             self.store.add_many(stored_records)
 
-            if delivery_status == "generated":
-                posted = 0
-                failed = 0
-            elif delivery_status == "failed":
-                posted = 0
-            return StepResponse(
+            result = StepResponse(
                 generated=len(events),
-                posted=posted,
-                failed=failed,
+                posted=outcome.posted,
+                failed=outcome.failed,
                 lot_codes=[event.traceability_lot_code for event in events],
-                response=response,
+                response=outcome.response,
+            )
+        await self._publish_update()
+        return result
+
+    async def replay(self, request: ReplayRequest | None = None) -> ReplayResponse:
+        request = request or ReplayRequest()
+        async with self._lock:
+            persist_path = request.persist_path or self.config.persist_path
+            source = request.source or self.config.source
+            delivery = request.delivery or self.config.delivery
+            replay_config = self.config.model_copy(
+                update={
+                    "source": source,
+                    "delivery": delivery,
+                },
+                deep=True,
+            )
+            records = self.store.read_persisted_records(persist_path)
+            events = [record.event for record in records]
+
+            if not events:
+                result = ReplayResponse(
+                    status="empty",
+                    read=0,
+                    replayed=0,
+                    posted=0,
+                    failed=0,
+                    source=source,
+                    persist_path=persist_path,
+                    delivery_mode=delivery.mode,
+                )
+            else:
+                payload = IngestPayload(source=source, events=events)
+                outcome = await self._deliver_payload(payload, replay_config)
+                replay_status = {
+                    "posted": "posted",
+                    "failed": "failed",
+                    "generated": "rebuilt",
+                }[outcome.delivery_status]
+                result = ReplayResponse(
+                    status=replay_status,
+                    read=len(records),
+                    replayed=len(events),
+                    posted=outcome.posted,
+                    failed=outcome.failed,
+                    source=source,
+                    persist_path=persist_path,
+                    delivery_mode=delivery.mode,
+                    response=outcome.response,
+                    error=outcome.error_message,
+                )
+        await self._publish_update()
+        return result
+
+    async def import_csv(self, request: CSVImportRequest) -> CSVImportResponse:
+        async with self._lock:
+            source = request.source or self.config.source
+            delivery = request.delivery or self.config.delivery
+            import_config = self.config.model_copy(
+                update={
+                    "source": source,
+                    "delivery": delivery,
+                },
+                deep=True,
+            )
+            parsed = parse_csv_import(
+                request.import_type,
+                request.csv_text,
+                default_timestamp=datetime.now(UTC),
+            )
+
+            outcome = DeliveryOutcome()
+            stored_records: list[StoredEventRecord] = []
+            if parsed.events:
+                payload = IngestPayload(source=source, events=parsed.events)
+                outcome = await self._deliver_payload(payload, import_config)
+                response_events = (outcome.response or {}).get("events", []) if outcome.response else []
+                for index, event in enumerate(parsed.events):
+                    event_response = response_events[index] if index < len(response_events) else None
+                    stored_records.append(
+                        StoredEventRecord(
+                            payload_source=source,
+                            event=event,
+                            parent_lot_codes=parsed.parent_lot_codes[index],
+                            destination_mode=delivery.mode,
+                            delivery_status=outcome.delivery_status,
+                            delivery_response=event_response,
+                            error=outcome.error_message,
+                        )
+                    )
+                self.store.add_many(stored_records)
+
+            rejected = parsed.total - len(parsed.events)
+            if outcome.delivery_status == "failed":
+                status = "delivery_failed"
+            elif parsed.events and parsed.errors:
+                status = "partial"
+            elif parsed.events:
+                status = "accepted"
+            else:
+                status = "rejected"
+
+            result = CSVImportResponse(
+                status=status,
+                import_type=request.import_type,
+                total=parsed.total,
+                accepted=len(parsed.events),
+                rejected=rejected,
+                stored=len(stored_records),
+                posted=outcome.posted,
+                failed=outcome.failed,
+                source=source,
+                delivery_mode=delivery.mode,
+                lot_codes=[event.traceability_lot_code for event in parsed.events],
+                errors=parsed.errors,
+                response=outcome.response,
+                error=outcome.error_message,
+            )
+        await self._publish_update()
+        return result
+
+    async def _deliver_payload(self, payload: IngestPayload, config: SimulationConfig) -> DeliveryOutcome:
+        try:
+            if config.delivery.mode == DestinationMode.MOCK:
+                response = self.mock_service.ingest(payload).model_dump(mode="json")
+                return DeliveryOutcome(response=response, delivery_status="posted", posted=len(payload.events))
+            if config.delivery.mode == DestinationMode.LIVE:
+                response = await self.live_client.ingest(payload, config)
+                return DeliveryOutcome(response=response, delivery_status="posted", posted=len(payload.events))
+            return DeliveryOutcome()
+        except Exception as exc:  # pragma: no cover - exercised by live integration, not unit tests
+            return DeliveryOutcome(
+                delivery_status="failed",
+                failed=len(payload.events),
+                error_message=str(exc),
             )
 
     async def _run_loop(self) -> None:
@@ -132,7 +273,30 @@ class SimulationController:
             if self.config.interval_seconds <= 0:
                 await asyncio.sleep(0)
             else:
-                await asyncio.sleep(self.config.interval_seconds)
+                try:
+                    await asyncio.wait_for(self._stop_event.wait(), timeout=self.config.interval_seconds)
+                except asyncio.TimeoutError:
+                    continue
+
+    async def _publish_update(self) -> None:
+        async with self._change_condition:
+            self._revision += 1
+            self._change_condition.notify_all()
+
+    async def wait_for_revision(self, revision: int, timeout: float = 15.0) -> int:
+        async with self._change_condition:
+            await asyncio.wait_for(
+                self._change_condition.wait_for(lambda: self._revision != revision),
+                timeout=timeout,
+            )
+            return self._revision
+
+    def snapshot(self, event_limit: int = 100) -> dict[str, Any]:
+        return {
+            "revision": self._revision,
+            "status": self.status(),
+            "events": [record.model_dump(mode="json") for record in self.store.recent(limit=event_limit)],
+        }
 
     def status(self) -> dict[str, Any]:
         return {

--- a/app/csv_importer.py
+++ b/app/csv_importer.py
@@ -1,0 +1,382 @@
+from __future__ import annotations
+
+import csv
+import io
+import json
+import re
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+
+from pydantic import ValidationError
+
+from .models import CSVImportError, CSVImportType, CTEType, RegEngineEvent
+
+
+EVENT_REQUIRED_FIELDS = (
+    "cte_type",
+    "traceability_lot_code",
+    "product_description",
+    "quantity",
+    "unit_of_measure",
+    "location_name",
+    "timestamp",
+)
+SEED_REQUIRED_FIELDS = (
+    "traceability_lot_code",
+    "product_description",
+    "quantity",
+    "unit_of_measure",
+    "location_name",
+)
+CONTROL_FIELDS = {
+    "source",
+    "parent_lot_codes",
+    "import_type",
+}
+TOP_LEVEL_EVENT_FIELDS = set(EVENT_REQUIRED_FIELDS)
+LIST_KDE_FIELDS = {
+    "input_traceability_lot_codes",
+    "input_products",
+}
+
+
+@dataclass(slots=True)
+class ParsedCSVImport:
+    total: int
+    events: list[RegEngineEvent]
+    parent_lot_codes: list[list[str]]
+    errors: list[CSVImportError]
+
+
+def parse_csv_import(
+    import_type: CSVImportType,
+    csv_text: str,
+    default_timestamp: datetime | None = None,
+) -> ParsedCSVImport:
+    default_timestamp = _ensure_timezone(default_timestamp or datetime.now(UTC))
+    if not csv_text.strip():
+        return ParsedCSVImport(
+            total=0,
+            events=[],
+            parent_lot_codes=[],
+            errors=[CSVImportError(row=0, field="csv_text", message="CSV content is empty")],
+        )
+
+    reader = csv.DictReader(io.StringIO(csv_text.lstrip("\ufeff")), skipinitialspace=True)
+    header_errors = _header_errors(reader.fieldnames)
+    if header_errors:
+        return ParsedCSVImport(total=0, events=[], parent_lot_codes=[], errors=header_errors)
+
+    total = 0
+    events: list[RegEngineEvent] = []
+    parent_lot_codes: list[list[str]] = []
+    errors: list[CSVImportError] = []
+
+    for row_number, raw_row in enumerate(reader, start=2):
+        row = _normalize_row(raw_row)
+        if _is_blank(row):
+            continue
+        total += 1
+        if import_type == CSVImportType.SCHEDULED_EVENTS:
+            event, parents, row_errors = _parse_scheduled_event(row, row_number)
+        else:
+            event, parents, row_errors = _parse_seed_lot(row, row_number, default_timestamp)
+
+        if row_errors:
+            errors.extend(row_errors)
+            continue
+        assert event is not None
+        events.append(event)
+        parent_lot_codes.append(parents)
+
+    if total == 0 and not errors:
+        errors.append(CSVImportError(row=0, field="csv_text", message="CSV contains no data rows"))
+
+    return ParsedCSVImport(total=total, events=events, parent_lot_codes=parent_lot_codes, errors=errors)
+
+
+def _parse_scheduled_event(
+    row: dict[str, str],
+    row_number: int,
+) -> tuple[RegEngineEvent | None, list[str], list[CSVImportError]]:
+    errors = _missing_required(row, row_number, EVENT_REQUIRED_FIELDS)
+    if errors:
+        return None, [], errors
+
+    quantity = _parse_quantity(row["quantity"], row_number, errors)
+    timestamp = _parse_timestamp(row["timestamp"], row_number, "timestamp", errors)
+    cte_type = _parse_cte_type(row["cte_type"], row_number, errors)
+    kdes = _parse_kdes(row, row_number, errors)
+
+    if errors:
+        return None, [], errors
+
+    return _build_event(
+        row=row,
+        row_number=row_number,
+        cte_type=cte_type,
+        quantity=quantity,
+        timestamp=timestamp,
+        kdes=kdes,
+        parent_lot_codes=_derive_parent_lot_codes(row, kdes),
+    )
+
+
+def _parse_seed_lot(
+    row: dict[str, str],
+    row_number: int,
+    default_timestamp: datetime,
+) -> tuple[RegEngineEvent | None, list[str], list[CSVImportError]]:
+    errors = _missing_required(row, row_number, SEED_REQUIRED_FIELDS)
+    if errors:
+        return None, [], errors
+
+    quantity = _parse_quantity(row["quantity"], row_number, errors)
+    timestamp = (
+        _parse_timestamp(row["timestamp"], row_number, "timestamp", errors)
+        if row.get("timestamp")
+        else default_timestamp
+    )
+    kdes = _parse_kdes(row, row_number, errors)
+
+    if errors:
+        return None, [], errors
+
+    kdes.setdefault("harvest_date", timestamp.date().isoformat())
+    kdes.setdefault("farm_location", row["location_name"])
+    if row.get("field_name"):
+        kdes.setdefault("field_name", row["field_name"])
+    if row.get("immediate_subsequent_recipient"):
+        kdes.setdefault("immediate_subsequent_recipient", row["immediate_subsequent_recipient"])
+    kdes.setdefault("reference_document_type", "Seed Lot Import")
+    kdes.setdefault("reference_document_number", f"CSV-{row['traceability_lot_code']}")
+    kdes.setdefault("traceability_lot_code_source_reference", f"CSV-SEED-{row['traceability_lot_code']}")
+
+    return _build_event(
+        row=row,
+        row_number=row_number,
+        cte_type=CTEType.HARVESTING,
+        quantity=quantity,
+        timestamp=timestamp,
+        kdes=kdes,
+        parent_lot_codes=[],
+    )
+
+
+def _build_event(
+    row: dict[str, str],
+    row_number: int,
+    cte_type: CTEType | None,
+    quantity: float | None,
+    timestamp: datetime | None,
+    kdes: dict[str, Any],
+    parent_lot_codes: list[str],
+) -> tuple[RegEngineEvent | None, list[str], list[CSVImportError]]:
+    errors: list[CSVImportError] = []
+    if cte_type is None or quantity is None or timestamp is None:
+        return None, [], errors
+
+    try:
+        event = RegEngineEvent(
+            cte_type=cte_type,
+            traceability_lot_code=row["traceability_lot_code"],
+            product_description=row["product_description"],
+            quantity=quantity,
+            unit_of_measure=row["unit_of_measure"],
+            location_name=row["location_name"],
+            timestamp=timestamp,
+            kdes=kdes,
+        )
+    except ValidationError as exc:
+        for error in exc.errors():
+            location = error.get("loc", ())
+            field = ".".join(str(part) for part in location) if location else None
+            errors.append(
+                CSVImportError(row=row_number, field=field, message=str(error.get("msg", "Invalid value")))
+            )
+        return None, [], errors
+
+    return event, parent_lot_codes, []
+
+
+def _header_errors(fieldnames: list[str] | None) -> list[CSVImportError]:
+    if not fieldnames:
+        return [CSVImportError(row=1, field="header", message="CSV header row is required")]
+
+    normalized = [_normalize_header(fieldname or "") for fieldname in fieldnames]
+    if any(not fieldname for fieldname in normalized):
+        return [CSVImportError(row=1, field="header", message="CSV header names cannot be blank")]
+
+    duplicates = sorted({fieldname for fieldname in normalized if normalized.count(fieldname) > 1})
+    if duplicates:
+        return [
+            CSVImportError(
+                row=1,
+                field="header",
+                message=f"Duplicate CSV header after normalization: {', '.join(duplicates)}",
+            )
+        ]
+    return []
+
+
+def _normalize_row(raw_row: dict[str | None, str | None]) -> dict[str, str]:
+    normalized: dict[str, str] = {}
+    for key, value in raw_row.items():
+        if key is None:
+            continue
+        normalized[_normalize_header(key)] = (value or "").strip()
+    return normalized
+
+
+def _normalize_header(header: str) -> str:
+    normalized = header.strip().lstrip("\ufeff").lower()
+    normalized = re.sub(r"[^a-z0-9]+", "_", normalized)
+    return normalized.strip("_")
+
+
+def _is_blank(row: dict[str, str]) -> bool:
+    return all(value == "" for value in row.values())
+
+
+def _missing_required(
+    row: dict[str, str],
+    row_number: int,
+    required_fields: tuple[str, ...],
+) -> list[CSVImportError]:
+    return [
+        CSVImportError(row=row_number, field=field, message=f"Missing required field: {field}")
+        for field in required_fields
+        if not row.get(field)
+    ]
+
+
+def _parse_quantity(value: str, row_number: int, errors: list[CSVImportError]) -> float | None:
+    try:
+        quantity = float(value)
+    except ValueError:
+        errors.append(CSVImportError(row=row_number, field="quantity", message="Quantity must be numeric"))
+        return None
+
+    if quantity <= 0:
+        errors.append(CSVImportError(row=row_number, field="quantity", message="Quantity must be greater than 0"))
+        return None
+    return quantity
+
+
+def _parse_timestamp(
+    value: str,
+    row_number: int,
+    field: str,
+    errors: list[CSVImportError],
+) -> datetime | None:
+    try:
+        if re.fullmatch(r"\d{4}-\d{2}-\d{2}", value):
+            parsed = datetime.fromisoformat(f"{value}T00:00:00+00:00")
+        else:
+            parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        errors.append(CSVImportError(row=row_number, field=field, message="Timestamp must be ISO 8601"))
+        return None
+    return _ensure_timezone(parsed)
+
+
+def _ensure_timezone(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value
+
+
+def _parse_cte_type(value: str, row_number: int, errors: list[CSVImportError]) -> CTEType | None:
+    try:
+        return CTEType(value)
+    except ValueError:
+        allowed = ", ".join(cte.value for cte in CTEType)
+        errors.append(CSVImportError(row=row_number, field="cte_type", message=f"Unsupported cte_type: {value}. Expected one of: {allowed}"))
+        return None
+
+
+def _parse_kdes(
+    row: dict[str, str],
+    row_number: int,
+    errors: list[CSVImportError],
+) -> dict[str, Any]:
+    kdes: dict[str, Any] = {}
+    raw_kdes = row.get("kdes", "")
+    if raw_kdes:
+        try:
+            parsed = json.loads(raw_kdes)
+        except json.JSONDecodeError as exc:
+            errors.append(CSVImportError(row=row_number, field="kdes", message=f"KDEs must be a JSON object: {exc.msg}"))
+        else:
+            if not isinstance(parsed, dict):
+                errors.append(CSVImportError(row=row_number, field="kdes", message="KDEs must be a JSON object"))
+            else:
+                kdes.update(parsed)
+
+    excluded_fields = TOP_LEVEL_EVENT_FIELDS | CONTROL_FIELDS | {"kdes", "timestamp"}
+    for field, value in row.items():
+        if not value or field in excluded_fields:
+            continue
+        if field.startswith("kde_"):
+            kdes[field.removeprefix("kde_")] = _coerce_kde_value(field.removeprefix("kde_"), value)
+        else:
+            kdes[field] = _coerce_kde_value(field, value)
+    return kdes
+
+
+def _coerce_kde_value(field: str, value: str) -> Any:
+    if field in LIST_KDE_FIELDS:
+        return _parse_list(value)
+    if value.startswith("[") or value.startswith("{"):
+        try:
+            return json.loads(value)
+        except json.JSONDecodeError:
+            return value
+    return value
+
+
+def _derive_parent_lot_codes(row: dict[str, str], kdes: dict[str, Any]) -> list[str]:
+    candidates: list[str] = []
+    if row.get("parent_lot_codes"):
+        candidates.extend(_parse_list(row["parent_lot_codes"]))
+
+    source_lot_code = kdes.get("source_traceability_lot_code")
+    if isinstance(source_lot_code, str):
+        candidates.append(source_lot_code)
+
+    input_lot_codes = kdes.get("input_traceability_lot_codes")
+    if isinstance(input_lot_codes, str):
+        parsed_input_lot_codes = _parse_list(input_lot_codes)
+        kdes["input_traceability_lot_codes"] = parsed_input_lot_codes
+        candidates.extend(parsed_input_lot_codes)
+    elif isinstance(input_lot_codes, list):
+        candidates.extend(str(lot_code) for lot_code in input_lot_codes if str(lot_code).strip())
+
+    return _dedupe(candidates)
+
+
+def _parse_list(value: str) -> list[str]:
+    value = value.strip()
+    if not value:
+        return []
+    if value.startswith("["):
+        try:
+            parsed = json.loads(value)
+        except json.JSONDecodeError:
+            parsed = None
+        if isinstance(parsed, list):
+            return [str(item).strip() for item in parsed if str(item).strip()]
+
+    parts = re.split(r"[|;,]", value)
+    return [part.strip() for part in parts if part.strip()]
+
+
+def _dedupe(values: list[str]) -> list[str]:
+    seen: set[str] = set()
+    deduped: list[str] = []
+    for value in values:
+        if value not in seen:
+            deduped.append(value)
+            seen.add(value)
+    return deduped

--- a/app/engine.py
+++ b/app/engine.py
@@ -4,16 +4,9 @@ import random
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
 from itertools import count
-from typing import Any, Iterable
 
 from .models import CTEType, RegEngineEvent
-
-
-@dataclass(slots=True)
-class Location:
-    name: str
-    location_type: str
-    gln: str
+from .scenarios import Location, ProductSpec, ScenarioId, get_scenario
 
 
 @dataclass(slots=True)
@@ -49,53 +42,32 @@ class LegitFlowEngine:
     Each event aligns with the shape shown in RegEngine's current ingest docs.
     """
 
-    def __init__(self, seed: int | None = 204) -> None:
+    def __init__(
+        self,
+        seed: int | None = 204,
+        scenario: ScenarioId | str = ScenarioId.LEAFY_GREENS_SUPPLIER,
+    ) -> None:
         self._initial_seed = seed
-        self.reset(seed)
+        self._initial_scenario = ScenarioId(scenario)
+        self.reset(seed, scenario=scenario)
 
-    def reset(self, seed: int | None = None) -> None:
+    def reset(self, seed: int | None = None, scenario: ScenarioId | str | None = None) -> None:
         self.rng = random.Random(seed if seed is not None else self._initial_seed)
         self._lot_counter = count(1)
         self._ref_counter = count(1)
         self._time_cursor = datetime.now(UTC) - timedelta(hours=12)
+        self.scenario = get_scenario(scenario or self._initial_scenario)
+        self.scenario_id = self.scenario.id
 
-        self.farms = [
-            Location("Valley Fresh Farms", "farm", "0850000001001"),
-            Location("Desert Bloom Farm", "farm", "0850000001002"),
-            Location("Riverbend Organics", "farm", "0850000001003"),
-        ]
-        self.coolers = [
-            Location("Salinas Cooling Hub", "cooler", "0850000002001"),
-            Location("Imperial Pre-Cool Facility", "cooler", "0850000002002"),
-        ]
-        self.packers = [
-            Location("FreshPack Central", "packer", "0850000003001"),
-            Location("GreenLeaf Packing House", "packer", "0850000003002"),
-        ]
-        self.processors = [
-            Location("ReadyFresh Processing Plant", "processor", "0850000004001"),
-            Location("DeliMix Plant", "processor", "0850000004002"),
-        ]
-        self.dcs = [
-            Location("Distribution Center #4", "dc", "0850000005001"),
-            Location("Distribution Center #7", "dc", "0850000005002"),
-        ]
-        self.retailers = [
-            Location("Retail Store #4521", "retail", "0850000006001"),
-            Location("Retail Store #3189", "retail", "0850000006002"),
-        ]
-        self.products = [
-            {"name": "Romaine Lettuce", "unit": "cases", "category": "leafy_greens"},
-            {"name": "Spinach", "unit": "cases", "category": "leafy_greens"},
-            {"name": "Cucumbers", "unit": "cases", "category": "produce"},
-            {"name": "Tomatoes", "unit": "cases", "category": "produce"},
-        ]
-        self.transformation_outputs = [
-            "Fresh Cut Salad Mix",
-            "Deli Salad Base",
-            "Leafy Greens Blend",
-        ]
-        self.carriers = ["SwiftChain Logistics", "ColdRoute Freight", "BlueLine Transport"]
+        self.farms = list(self.scenario.farms)
+        self.coolers = list(self.scenario.coolers)
+        self.packers = list(self.scenario.packers)
+        self.processors = list(self.scenario.processors)
+        self.dcs = list(self.scenario.dcs)
+        self.retailers = list(self.scenario.retailers)
+        self.products = list(self.scenario.products)
+        self.transformation_outputs = list(self.scenario.transformation_outputs)
+        self.carriers = list(self.scenario.carriers)
 
         self.harvested: list[Lot] = []
         self.cooled: list[Lot] = []
@@ -128,8 +100,9 @@ class LegitFlowEngine:
             return self._transform()
         raise RuntimeError(f"Unhandled action: {action}")
 
-    def snapshot(self) -> dict[str, int]:
+    def snapshot(self) -> dict[str, int | str]:
         return {
+            "scenario": self.scenario_id.value,
             "harvested": len(self.harvested),
             "cooled": len(self.cooled),
             "packed": len(self.packed),
@@ -142,26 +115,26 @@ class LegitFlowEngine:
 
     def _choose_action(self) -> str:
         weighted_actions: list[str] = []
-        if len(self.harvested) < 3:
-            weighted_actions.extend(["harvest"] * 5)
+        weights = self.scenario.action_weights
+        if len(self.harvested) < self.scenario.harvest_target:
+            weighted_actions.extend(["harvest"] * weights["harvest"])
         if self.harvested:
-            weighted_actions.extend(["cool"] * 2)
-            weighted_actions.extend(["initial_pack"] * 2)
+            weighted_actions.extend(["cool"] * weights["cool"])
         if self.cooled:
-            weighted_actions.extend(["initial_pack"] * 4)
+            weighted_actions.extend(["initial_pack"] * weights["initial_pack"])
         if self.packed or self.transformed or self.dc_inventory:
-            weighted_actions.extend(["ship"] * 4)
+            weighted_actions.extend(["ship"] * weights["ship"])
         if self.in_transit:
-            weighted_actions.extend(["receive"] * 5)
-        if len(self.processor_inventory) >= 2:
-            weighted_actions.extend(["transform"] * 3)
+            weighted_actions.extend(["receive"] * weights["receive"])
+        if len(self.processor_inventory) >= self.scenario.transform_min_lots:
+            weighted_actions.extend(["transform"] * weights["transform"])
         if not weighted_actions:
             weighted_actions.append("harvest")
         return self.rng.choice(weighted_actions)
 
     def _harvest(self) -> tuple[RegEngineEvent, list[str]]:
         farm = self.rng.choice(self.farms)
-        product = self.rng.choice(self.products)
+        product: ProductSpec = self.rng.choice(self.products)
         lot_code = self._make_lot_code(prefix="TLC")
         quantity = self._quantity(120, 640)
         timestamp = self._advance_time(15, 90)
@@ -169,9 +142,9 @@ class LegitFlowEngine:
 
         lot = Lot(
             lot_code=lot_code,
-            product_description=product["name"],
+            product_description=product.name,
             quantity=quantity,
-            unit_of_measure=product["unit"],
+            unit_of_measure=product.unit,
             current_location=farm.name,
             stage="harvested",
             origin_location=farm.name,
@@ -231,8 +204,9 @@ class LegitFlowEngine:
         return event, [lot.lot_code]
 
     def _initial_pack(self) -> tuple[RegEngineEvent, list[str]]:
-        source_pool = self.cooled if self.cooled else self.harvested
-        source_lot = source_pool.pop(self.rng.randrange(len(source_pool)))
+        if not self.cooled:
+            raise RuntimeError("Initial packing requires a cooled source lot")
+        source_lot = self.cooled.pop(self.rng.randrange(len(self.cooled)))
         packer = self.rng.choice(self.packers)
         packed_lot_code = self._make_lot_code(prefix="TLC")
         packed_quantity = self._quantity(source_lot.quantity * 0.92, source_lot.quantity * 1.02)
@@ -289,7 +263,7 @@ class LegitFlowEngine:
         carrier = self.rng.choice(self.carriers)
 
         if stage_name == "packed":
-            if self.rng.random() < 0.45:
+            if self.rng.random() < self.scenario.packed_to_processor_probability:
                 destination = self.rng.choice(self.processors)
                 next_stage = "processor_inventory"
             else:
@@ -370,7 +344,7 @@ class LegitFlowEngine:
         return event, lot.parents or [lot.lot_code]
 
     def _transform(self) -> tuple[RegEngineEvent, list[str]]:
-        sample_size = min(len(self.processor_inventory), self.rng.choice([2, 2, 3]))
+        sample_size = min(len(self.processor_inventory), self.rng.choice(self.scenario.transform_input_choices))
         inputs = self.rng.sample(self.processor_inventory, k=sample_size)
         self.processor_inventory = [lot for lot in self.processor_inventory if lot not in inputs]
 

--- a/app/main.py
+++ b/app/main.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import asyncio
 import csv
 import io
+import json
 from contextlib import asynccontextmanager
 from datetime import UTC, datetime
 from pathlib import Path
@@ -9,24 +11,31 @@ from typing import Any
 
 from fastapi import FastAPI, HTTPException, Query, Request
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import FileResponse, JSONResponse, PlainTextResponse
+from fastapi.responses import FileResponse, JSONResponse, PlainTextResponse, StreamingResponse
 from fastapi.staticfiles import StaticFiles
 
 from .controller import SimulationController
 from .engine import LegitFlowEngine
 from .mock_service import MockRegEngineService
 from .models import (
+    CSVImportRequest,
+    CSVImportResponse,
     EventListResponse,
     IngestPayload,
     LineageResponse,
     MockIngestResponse,
+    ReplayRequest,
+    ReplayResponse,
     ResetResponse,
+    ScenarioListResponse,
+    ScenarioSummary,
     SimulationConfig,
     StartRequest,
     StatusResponse,
     StepResponse,
 )
 from .regengine_client import LiveRegEngineClient
+from .scenarios import list_scenario_summaries
 from .store import EventStore
 
 
@@ -85,6 +94,54 @@ async def simulate_status() -> StatusResponse:
     return StatusResponse.model_validate(status)
 
 
+@app.get("/api/scenarios", response_model=ScenarioListResponse)
+async def list_scenarios() -> ScenarioListResponse:
+    return ScenarioListResponse(
+        scenarios=[ScenarioSummary.model_validate(summary) for summary in list_scenario_summaries()]
+    )
+
+
+def sse_message(event_name: str, payload: dict[str, Any]) -> str:
+    data = json.dumps(payload, separators=(",", ":"))
+    return f"event: {event_name}\ndata: {data}\n\n"
+
+
+@app.get("/api/simulate/stream")
+async def simulate_stream(
+    request: Request,
+    limit: int = Query(default=100, ge=1, le=500),
+    once: bool = Query(default=False),
+) -> StreamingResponse:
+    async def event_generator():
+        snapshot = controller.snapshot(event_limit=limit)
+        last_revision = snapshot["revision"]
+        yield sse_message("snapshot", snapshot)
+        if once:
+            return
+
+        while True:
+            if await request.is_disconnected():
+                break
+            try:
+                last_revision = await controller.wait_for_revision(last_revision)
+            except asyncio.TimeoutError:
+                yield ": keep-alive\n\n"
+                continue
+
+            snapshot = controller.snapshot(event_limit=limit)
+            last_revision = snapshot["revision"]
+            yield sse_message("snapshot", snapshot)
+
+    return StreamingResponse(
+        event_generator(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "X-Accel-Buffering": "no",
+        },
+    )
+
+
 @app.post("/api/simulate/start", response_model=StatusResponse)
 async def simulate_start(request: StartRequest) -> StatusResponse:
     await controller.start(request.config)
@@ -108,6 +165,16 @@ async def simulate_step(batch_size: int | None = Query(default=None, ge=1, le=10
     return await controller.step(batch_size=batch_size)
 
 
+@app.post("/api/simulate/replay", response_model=ReplayResponse)
+async def simulate_replay(request: ReplayRequest | None = None) -> ReplayResponse:
+    return await controller.replay(request)
+
+
+@app.post("/api/import/csv", response_model=CSVImportResponse)
+async def import_csv(request: CSVImportRequest) -> CSVImportResponse:
+    return await controller.import_csv(request)
+
+
 @app.get("/api/events", response_model=EventListResponse)
 async def list_events(limit: int = Query(default=100, ge=1, le=500)) -> EventListResponse:
     return EventListResponse(events=store.recent(limit=limit))
@@ -118,7 +185,12 @@ async def get_lineage(traceability_lot_code: str) -> LineageResponse:
     records = store.lineage(traceability_lot_code)
     if not records:
         raise HTTPException(status_code=404, detail="No records found for that lot code")
-    return LineageResponse(traceability_lot_code=traceability_lot_code, records=records)
+    return LineageResponse(
+        traceability_lot_code=traceability_lot_code,
+        records=records,
+        nodes=store.lineage_nodes(records),
+        edges=store.lineage_edges(records),
+    )
 
 
 @app.post("/api/mock/regengine/ingest", response_model=MockIngestResponse)

--- a/app/models.py
+++ b/app/models.py
@@ -7,6 +7,8 @@ from uuid import uuid4
 
 from pydantic import BaseModel, Field, HttpUrl, field_validator
 
+from .scenarios import ScenarioId
+
 
 class CTEType(str, Enum):
     HARVESTING = "harvesting"
@@ -21,6 +23,11 @@ class DestinationMode(str, Enum):
     MOCK = "mock"
     LIVE = "live"
     NONE = "none"
+
+
+class CSVImportType(str, Enum):
+    SCHEDULED_EVENTS = "scheduled_events"
+    SEED_LOTS = "seed_lots"
 
 
 class RegEngineEvent(BaseModel):
@@ -48,6 +55,7 @@ class DeliveryConfig(BaseModel):
 
 class SimulationConfig(BaseModel):
     source: str = "codex-simulator"
+    scenario: ScenarioId = ScenarioId.LEAFY_GREENS_SUPPLIER
     interval_seconds: float = 1.5
     batch_size: int = 3
     seed: int | None = 204
@@ -109,6 +117,16 @@ class StatusResponse(BaseModel):
     stats: dict[str, Any]
 
 
+class ScenarioSummary(BaseModel):
+    id: ScenarioId
+    label: str
+    description: str
+
+
+class ScenarioListResponse(BaseModel):
+    scenarios: list[ScenarioSummary]
+
+
 class StepResponse(BaseModel):
     generated: int
     posted: int
@@ -117,13 +135,81 @@ class StepResponse(BaseModel):
     response: dict[str, Any] | None = None
 
 
+class ReplayRequest(BaseModel):
+    persist_path: str | None = None
+    source: str | None = None
+    delivery: DeliveryConfig | None = None
+
+
+class ReplayResponse(BaseModel):
+    status: Literal["empty", "posted", "rebuilt", "failed"]
+    read: int
+    replayed: int
+    posted: int
+    failed: int
+    source: str
+    persist_path: str
+    delivery_mode: DestinationMode
+    response: dict[str, Any] | None = None
+    error: str | None = None
+
+
+class CSVImportRequest(BaseModel):
+    import_type: CSVImportType
+    csv_text: str
+    source: str | None = None
+    delivery: DeliveryConfig | None = None
+
+
+class CSVImportError(BaseModel):
+    row: int
+    field: str | None = None
+    message: str
+
+
+class CSVImportResponse(BaseModel):
+    status: Literal["accepted", "partial", "rejected", "delivery_failed"]
+    import_type: CSVImportType
+    total: int
+    accepted: int
+    rejected: int
+    stored: int
+    posted: int
+    failed: int
+    source: str
+    delivery_mode: DestinationMode
+    lot_codes: list[str]
+    errors: list[CSVImportError] = Field(default_factory=list)
+    response: dict[str, Any] | None = None
+    error: str | None = None
+
+
 class ResetResponse(BaseModel):
     status: str
+
+
+class LineageNode(BaseModel):
+    lot_code: str
+    product_description: str
+    event_count: int
+    cte_types: list[CTEType]
+    first_seen: datetime
+    last_seen: datetime
+    locations: list[str]
+
+
+class LineageEdge(BaseModel):
+    source_lot_code: str
+    target_lot_code: str
+    cte_type: CTEType
+    event_sequence_no: int
 
 
 class LineageResponse(BaseModel):
     traceability_lot_code: str
     records: list[StoredEventRecord]
+    nodes: list[LineageNode]
+    edges: list[LineageEdge]
 
 
 class EventListResponse(BaseModel):

--- a/app/regengine_client.py
+++ b/app/regengine_client.py
@@ -8,7 +8,7 @@ import httpx
 from .models import IngestPayload, SimulationConfig
 
 
-DEFAULT_LIVE_INGEST_ENDPOINT = "https://regengine.co/api/ingestion/api/v1/webhooks/ingest"
+DEFAULT_LIVE_INGEST_ENDPOINT = "https://www.regengine.co/api/v1/webhooks/ingest"
 
 
 class LiveRegEngineClient:

--- a/app/scenarios.py
+++ b/app/scenarios.py
@@ -1,0 +1,229 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Mapping
+
+
+class ScenarioId(str, Enum):
+    LEAFY_GREENS_SUPPLIER = "leafy_greens_supplier"
+    FRESH_CUT_PROCESSOR = "fresh_cut_processor"
+    RETAILER_READINESS_DEMO = "retailer_readiness_demo"
+
+
+@dataclass(frozen=True, slots=True)
+class Location:
+    name: str
+    location_type: str
+    gln: str
+
+
+@dataclass(frozen=True, slots=True)
+class ProductSpec:
+    name: str
+    unit: str
+    category: str
+
+
+@dataclass(frozen=True, slots=True)
+class ScenarioPreset:
+    id: ScenarioId
+    label: str
+    description: str
+    farms: tuple[Location, ...]
+    coolers: tuple[Location, ...]
+    packers: tuple[Location, ...]
+    processors: tuple[Location, ...]
+    dcs: tuple[Location, ...]
+    retailers: tuple[Location, ...]
+    products: tuple[ProductSpec, ...]
+    transformation_outputs: tuple[str, ...]
+    carriers: tuple[str, ...]
+    action_weights: Mapping[str, int]
+    harvest_target: int = 3
+    packed_to_processor_probability: float = 0.45
+    transform_input_choices: tuple[int, ...] = (2, 2, 3)
+
+    @property
+    def transform_min_lots(self) -> int:
+        return min(self.transform_input_choices)
+
+
+SCENARIO_PRESETS: dict[ScenarioId, ScenarioPreset] = {
+    ScenarioId.LEAFY_GREENS_SUPPLIER: ScenarioPreset(
+        id=ScenarioId.LEAFY_GREENS_SUPPLIER,
+        label="Leafy greens supplier",
+        description="Farm-origin leafy greens flowing through cooling, packout, and outbound cold-chain shipments.",
+        farms=(
+            Location("Valley Fresh Farms", "farm", "0850000001001"),
+            Location("Desert Bloom Farm", "farm", "0850000001002"),
+            Location("Riverbend Organics", "farm", "0850000001003"),
+        ),
+        coolers=(
+            Location("Salinas Cooling Hub", "cooler", "0850000002001"),
+            Location("Imperial Pre-Cool Facility", "cooler", "0850000002002"),
+        ),
+        packers=(
+            Location("FreshPack Central", "packer", "0850000003001"),
+            Location("GreenLeaf Packing House", "packer", "0850000003002"),
+        ),
+        processors=(
+            Location("ReadyFresh Processing Plant", "processor", "0850000004001"),
+            Location("DeliMix Plant", "processor", "0850000004002"),
+        ),
+        dcs=(
+            Location("Distribution Center #4", "dc", "0850000005001"),
+            Location("Distribution Center #7", "dc", "0850000005002"),
+        ),
+        retailers=(
+            Location("Retail Store #4521", "retail", "0850000006001"),
+            Location("Retail Store #3189", "retail", "0850000006002"),
+        ),
+        products=(
+            ProductSpec("Romaine Lettuce", "cases", "leafy_greens"),
+            ProductSpec("Green Leaf Lettuce", "cases", "leafy_greens"),
+            ProductSpec("Spinach", "cases", "leafy_greens"),
+            ProductSpec("Spring Mix", "cases", "leafy_greens"),
+        ),
+        transformation_outputs=(
+            "Leafy Greens Blend",
+            "Romaine Chopped Salad Base",
+            "Spring Mix Salad Base",
+        ),
+        carriers=("SwiftChain Logistics", "ColdRoute Freight", "BlueLine Transport"),
+        action_weights={
+            "harvest": 5,
+            "cool": 4,
+            "initial_pack": 4,
+            "ship": 4,
+            "receive": 5,
+            "transform": 4,
+        },
+        harvest_target=3,
+        packed_to_processor_probability=0.45,
+    ),
+    ScenarioId.FRESH_CUT_PROCESSOR: ScenarioPreset(
+        id=ScenarioId.FRESH_CUT_PROCESSOR,
+        label="Fresh-cut processor",
+        description="Ingredient lots routed into processor inventory, transformed into fresh-cut outputs, then shipped onward.",
+        farms=(
+            Location("Valley Fresh Farms", "farm", "0850000001001"),
+            Location("Coastal Leaf Farm", "farm", "0850000001011"),
+            Location("Desert Bloom Farm", "farm", "0850000001002"),
+        ),
+        coolers=(
+            Location("Salinas Cooling Hub", "cooler", "0850000002001"),
+            Location("Coastal Cold Chain", "cooler", "0850000002011"),
+        ),
+        packers=(
+            Location("Processor Intake Packout", "packer", "0850000003011"),
+            Location("GreenLeaf Packing House", "packer", "0850000003002"),
+        ),
+        processors=(
+            Location("ReadyFresh Processing Plant", "processor", "0850000004001"),
+            Location("Urban Greens Fresh-Cut", "processor", "0850000004011"),
+        ),
+        dcs=(
+            Location("Foodservice DC #12", "dc", "0850000005011"),
+            Location("Regional Cold DC #3", "dc", "0850000005012"),
+        ),
+        retailers=(
+            Location("Cafe Commissary #88", "retail", "0850000006011"),
+            Location("Retail Store #4521", "retail", "0850000006001"),
+        ),
+        products=(
+            ProductSpec("Romaine Lettuce", "cases", "leafy_greens"),
+            ProductSpec("Spinach", "cases", "leafy_greens"),
+            ProductSpec("Green Cabbage", "cases", "produce"),
+            ProductSpec("Shredding Carrots", "cases", "produce"),
+        ),
+        transformation_outputs=(
+            "Fresh Cut Salad Mix",
+            "Caesar Salad Kit",
+            "Deli Salad Base",
+            "Shredded Lettuce Foodservice Pack",
+        ),
+        carriers=("ColdRoute Freight", "PrepLine Logistics", "SwiftChain Logistics"),
+        action_weights={
+            "harvest": 4,
+            "cool": 4,
+            "initial_pack": 5,
+            "ship": 6,
+            "receive": 6,
+            "transform": 8,
+        },
+        harvest_target=4,
+        packed_to_processor_probability=0.85,
+        transform_input_choices=(2, 2, 3),
+    ),
+    ScenarioId.RETAILER_READINESS_DEMO: ScenarioPreset(
+        id=ScenarioId.RETAILER_READINESS_DEMO,
+        label="Retailer readiness demo",
+        description="Retail-ready produce flows quickly through DC receiving and store-level downstream receipts.",
+        farms=(
+            Location("SunCoast Produce Ranch", "farm", "0850000001021"),
+            Location("Valley Fresh Farms", "farm", "0850000001001"),
+            Location("Riverbend Organics", "farm", "0850000001003"),
+        ),
+        coolers=(
+            Location("Retail Cold Dock West", "cooler", "0850000002021"),
+            Location("Salinas Cooling Hub", "cooler", "0850000002001"),
+        ),
+        packers=(
+            Location("Retail Ready Packout", "packer", "0850000003021"),
+            Location("FreshPack Central", "packer", "0850000003001"),
+        ),
+        processors=(
+            Location("ReadyFresh Processing Plant", "processor", "0850000004001"),
+            Location("Meal Kit Prep Center", "processor", "0850000004021"),
+        ),
+        dcs=(
+            Location("Retail DC West", "dc", "0850000005021"),
+            Location("Retail DC East", "dc", "0850000005022"),
+        ),
+        retailers=(
+            Location("Retail Store #4521", "retail", "0850000006001"),
+            Location("Retail Store #3189", "retail", "0850000006002"),
+            Location("Urban Market #22", "retail", "0850000006021"),
+        ),
+        products=(
+            ProductSpec("Romaine Hearts Retail Pack", "cases", "retail_ready"),
+            ProductSpec("Baby Spinach Clamshells", "cases", "retail_ready"),
+            ProductSpec("Spring Mix Clamshells", "cases", "retail_ready"),
+            ProductSpec("Cucumber Snack Packs", "cases", "retail_ready"),
+        ),
+        transformation_outputs=(
+            "Retail Caesar Salad Kit",
+            "Grab-and-Go Salad Bowl",
+            "Retail Chopped Greens Kit",
+        ),
+        carriers=("StoreLane Logistics", "ColdRoute Freight", "BlueLine Transport"),
+        action_weights={
+            "harvest": 4,
+            "cool": 3,
+            "initial_pack": 5,
+            "ship": 7,
+            "receive": 8,
+            "transform": 2,
+        },
+        harvest_target=3,
+        packed_to_processor_probability=0.1,
+        transform_input_choices=(2, 2),
+    ),
+}
+
+
+def get_scenario(scenario_id: ScenarioId | str | None = None) -> ScenarioPreset:
+    normalized = ScenarioId(scenario_id or ScenarioId.LEAFY_GREENS_SUPPLIER)
+    return SCENARIO_PRESETS[normalized]
+
+
+def list_scenario_summaries() -> list[dict[str, str]]:
+    return [
+        {
+            "id": preset.id.value,
+            "label": preset.label,
+            "description": preset.description,
+        }
+        for preset in SCENARIO_PRESETS.values()
+    ]

--- a/app/static/app.js
+++ b/app/static/app.js
@@ -1,10 +1,19 @@
 const state = {
   status: null,
   events: [],
+  eventSource: null,
+  fallbackTimer: null,
+  statusHoldUntil: 0,
+  scenarioLabels: {
+    leafy_greens_supplier: 'Leafy greens supplier',
+    fresh_cut_processor: 'Fresh-cut processor',
+    retailer_readiness_demo: 'Retailer readiness demo',
+  },
 };
 
 const ids = {
   source: document.getElementById('source'),
+  scenario: document.getElementById('scenario'),
   interval: document.getElementById('interval'),
   batchSize: document.getElementById('batchSize'),
   seed: document.getElementById('seed'),
@@ -12,6 +21,9 @@ const ids = {
   endpoint: document.getElementById('endpoint'),
   apiKey: document.getElementById('apiKey'),
   tenantId: document.getElementById('tenantId'),
+  csvImportType: document.getElementById('csvImportType'),
+  csvFile: document.getElementById('csvFile'),
+  importResults: document.getElementById('importResults'),
   statusMessage: document.getElementById('statusMessage'),
   statsGrid: document.getElementById('statsGrid'),
   eventsBody: document.getElementById('eventsBody'),
@@ -19,9 +31,10 @@ const ids = {
   lineageResults: document.getElementById('lineageResults'),
 };
 
-function setStatus(message, tone = 'neutral') {
+function setStatus(message, tone = 'neutral', holdMs = 0) {
   ids.statusMessage.textContent = message;
   ids.statusMessage.dataset.tone = tone;
+  state.statusHoldUntil = holdMs > 0 ? Date.now() + holdMs : 0;
 }
 
 function buildConfig() {
@@ -31,6 +44,7 @@ function buildConfig() {
   const seedValue = ids.seed.value.trim();
   return {
     source: ids.source.value.trim() || 'codex-simulator',
+    scenario: ids.scenario.value,
     interval_seconds: Number(ids.interval.value || 1.5),
     batch_size: Number(ids.batchSize.value || 3),
     seed: seedValue === '' ? null : Number(seedValue),
@@ -60,11 +74,35 @@ async function api(path, options = {}) {
   return response.text();
 }
 
+function scenarioLabel(scenarioId) {
+  return state.scenarioLabels[scenarioId] || scenarioId || 'Unknown';
+}
+
+function renderScenarioOptions(scenarios) {
+  const selected = ids.scenario.value || 'leafy_greens_supplier';
+  state.scenarioLabels = Object.fromEntries(scenarios.map((scenario) => [scenario.id, scenario.label]));
+  ids.scenario.innerHTML = scenarios
+    .map(
+      (scenario) => `
+        <option value="${escapeHtml(scenario.id)}">${escapeHtml(scenario.label)}</option>
+      `,
+    )
+    .join('');
+  ids.scenario.value = state.scenarioLabels[selected] ? selected : scenarios[0]?.id || 'leafy_greens_supplier';
+}
+
+async function loadScenarios() {
+  const payload = await api('/api/scenarios');
+  renderScenarioOptions(payload.scenarios || []);
+}
+
 function renderStats(status) {
   const stats = status?.stats || {};
   const engine = stats.engine || {};
+  const scenarioId = status?.config?.scenario || ids.scenario.value;
   const cards = [
     ['Loop status', status?.running ? 'Running' : 'Stopped'],
+    ['Scenario', scenarioLabel(scenarioId)],
     ['Total records', stats.total_records ?? 0],
     ['Unique lots', stats.unique_lots ?? 0],
     ['Persist path', stats.persist_path ?? 'data/events.jsonl'],
@@ -92,6 +130,24 @@ function escapeHtml(text) {
     .replaceAll('>', '&gt;')
     .replaceAll('"', '&quot;')
     .replaceAll("'", '&#39;');
+}
+
+function cteLabel(cteType) {
+  return String(cteType || 'event').replaceAll('_', ' ');
+}
+
+function formatDateTime(value) {
+  return escapeHtml(new Date(value).toLocaleString());
+}
+
+function formatKdeValue(value) {
+  if (Array.isArray(value)) {
+    return value.join(', ');
+  }
+  if (value && typeof value === 'object') {
+    return JSON.stringify(value);
+  }
+  return value ?? '';
 }
 
 function renderEvents(events) {
@@ -128,23 +184,95 @@ function renderEvents(events) {
   });
 }
 
-function renderLineage(records, traceabilityLotCode) {
+function renderLineage(payload, traceabilityLotCode) {
+  const records = payload.records || [];
   if (!records.length) {
     ids.lineageResults.innerHTML = `<p class="note">No lineage found for ${escapeHtml(traceabilityLotCode)}.</p>`;
     return;
   }
-  ids.lineageResults.innerHTML = records
+  const nodes = payload.nodes || [];
+  const edges = payload.edges || [];
+  const nodeByLot = new Map(nodes.map((node) => [node.lot_code, node]));
+  const locations = new Set(records.map((record) => record.event.location_name));
+  const transformations = records.filter((record) => record.event.cte_type === 'transformation').length;
+  const queriedNode = nodeByLot.get(traceabilityLotCode);
+  const stats = [
+    ['Lots', nodes.length || new Set(records.map((record) => record.event.traceability_lot_code)).size],
+    ['Events', records.length],
+    ['Links', edges.length],
+    ['Transformations', transformations],
+  ];
+
+  const summary = queriedNode
+    ? `
+      <div class="lineage-focus">
+        <span>Focused lot</span>
+        <strong>${escapeHtml(queriedNode.lot_code)}</strong>
+        <p>${escapeHtml(queriedNode.product_description)}</p>
+      </div>
+    `
+    : '';
+
+  const statMarkup = stats
+    .map(
+      ([label, value]) => `
+        <div class="lineage-stat">
+          <span>${label}</span>
+          <strong>${escapeHtml(value)}</strong>
+        </div>
+      `,
+    )
+    .join('');
+
+  const nodeMarkup = nodes
+    .map(
+      (node) => `
+        <article class="lineage-lot${node.lot_code === traceabilityLotCode ? ' is-current' : ''}">
+          <header>
+            <span>${escapeHtml(node.lot_code)}</span>
+            <strong>${escapeHtml(node.event_count)} event(s)</strong>
+          </header>
+          <p>${escapeHtml(node.product_description)}</p>
+          <small>${escapeHtml((node.cte_types || []).map(cteLabel).join(' -> '))}</small>
+          <small>${escapeHtml((node.locations || []).join(' -> '))}</small>
+        </article>
+      `,
+    )
+    .join('');
+
+  const edgeMarkup = edges.length
+    ? edges
+        .map((edge) => {
+          const source = nodeByLot.get(edge.source_lot_code);
+          const target = nodeByLot.get(edge.target_lot_code);
+          return `
+            <li>
+              <button class="link-button" data-lineage-lot="${escapeHtml(edge.source_lot_code)}">
+                ${escapeHtml(source?.product_description || edge.source_lot_code)}
+              </button>
+              <span class="flow-arrow">-&gt;</span>
+              <button class="link-button" data-lineage-lot="${escapeHtml(edge.target_lot_code)}">
+                ${escapeHtml(target?.product_description || edge.target_lot_code)}
+              </button>
+              <span class="flow-meta">${escapeHtml(cteLabel(edge.cte_type))}</span>
+            </li>
+          `;
+        })
+        .join('')
+    : `<li class="note">This lot has a same-lot timeline with no downstream output links yet.</li>`;
+
+  const timelineMarkup = records
     .map((record) => {
       const event = record.event;
       const kdes = Object.entries(event.kdes || {})
         .slice(0, 6)
-        .map(([key, value]) => `<li><strong>${escapeHtml(key)}:</strong> ${escapeHtml(Array.isArray(value) ? value.join(', ') : value)}</li>`)
+        .map(([key, value]) => `<li><strong>${escapeHtml(key)}:</strong> ${escapeHtml(formatKdeValue(value))}</li>`)
         .join('');
       return `
         <article class="lineage-card">
           <header>
-            <h3>${escapeHtml(event.cte_type)}</h3>
-            <span>${escapeHtml(new Date(event.timestamp).toLocaleString())}</span>
+            <h3>${escapeHtml(cteLabel(event.cte_type))}</h3>
+            <span>${formatDateTime(event.timestamp)}</span>
           </header>
           <p><strong>Lot:</strong> ${escapeHtml(event.traceability_lot_code)}</p>
           <p><strong>Product:</strong> ${escapeHtml(event.product_description)}</p>
@@ -154,15 +282,119 @@ function renderLineage(records, traceabilityLotCode) {
       `;
     })
     .join('');
+
+  ids.lineageResults.innerHTML = `
+    <div class="lineage-overview">
+      ${summary}
+      <div class="lineage-stats">${statMarkup}</div>
+      <p class="note">${escapeHtml(locations.size)} location(s) represented in this lineage trace.</p>
+    </div>
+    <div class="lineage-flow">
+      <h3>Lot flow</h3>
+      <div class="lineage-lots">${nodeMarkup}</div>
+      <ul>${edgeMarkup}</ul>
+    </div>
+    <div class="lineage-timeline">
+      <h3>Event timeline</h3>
+      <div class="lineage-cards">${timelineMarkup}</div>
+    </div>
+  `;
+
+  ids.lineageResults.querySelectorAll('[data-lineage-lot]').forEach((button) => {
+    button.addEventListener('click', async () => {
+      ids.lotLookup.value = button.dataset.lineageLot;
+      await lookupLineage();
+    });
+  });
+}
+
+function renderImportResult(result) {
+  const tone = result.status === 'accepted' ? 'success' : result.status === 'delivery_failed' ? 'error' : 'neutral';
+  const errors = (result.errors || []).slice(0, 8);
+  const errorList = errors
+    .map((error) => {
+      const field = error.field ? ` ${escapeHtml(error.field)}:` : '';
+      return `<li>Row ${escapeHtml(error.row)}${field} ${escapeHtml(error.message)}</li>`;
+    })
+    .join('');
+  ids.importResults.innerHTML = `
+    <div class="import-summary" data-tone="${tone}">
+      Accepted ${escapeHtml(result.accepted)} of ${escapeHtml(result.total)} row(s).
+      Stored ${escapeHtml(result.stored)}; posted ${escapeHtml(result.posted)}; rejected ${escapeHtml(result.rejected)}.
+      ${result.error ? `<span>${escapeHtml(result.error)}</span>` : ''}
+    </div>
+    ${errorList ? `<ul>${errorList}</ul>` : ''}
+  `;
+}
+
+function renderSnapshot(status, events) {
+  state.status = status;
+  state.events = events;
+  renderStats(status);
+  renderEvents(events);
+  if (Date.now() >= state.statusHoldUntil) {
+    setStatus(status.running ? 'Simulator loop is running.' : 'Simulator loop is stopped.');
+  }
 }
 
 async function refresh() {
   const [status, events] = await Promise.all([api('/api/simulate/status'), api('/api/events?limit=100')]);
-  state.status = status;
-  state.events = events.events;
-  renderStats(status);
-  renderEvents(events.events);
-  setStatus(status.running ? 'Simulator loop is running.' : 'Simulator loop is stopped.');
+  renderSnapshot(status, events.events);
+}
+
+function stopFallbackPolling() {
+  if (state.fallbackTimer) {
+    clearInterval(state.fallbackTimer);
+    state.fallbackTimer = null;
+  }
+}
+
+function startFallbackPolling() {
+  if (state.fallbackTimer) {
+    return;
+  }
+  state.fallbackTimer = setInterval(() => {
+    refresh().catch((error) => {
+      setStatus(error.message, 'error', 5000);
+    });
+  }, 2000);
+}
+
+function applyStreamSnapshot(payload) {
+  if (!payload || !payload.status || !Array.isArray(payload.events)) {
+    return;
+  }
+  renderSnapshot(payload.status, payload.events);
+}
+
+function connectLiveUpdates() {
+  if (!('EventSource' in window)) {
+    startFallbackPolling();
+    return;
+  }
+
+  state.eventSource = new EventSource('/api/simulate/stream?limit=100');
+
+  state.eventSource.addEventListener('open', () => {
+    stopFallbackPolling();
+  });
+
+  state.eventSource.addEventListener('snapshot', (event) => {
+    try {
+      applyStreamSnapshot(JSON.parse(event.data));
+    } catch (error) {
+      setStatus(error.message, 'error', 5000);
+    }
+  });
+
+  state.eventSource.addEventListener('error', () => {
+    if (state.eventSource) {
+      state.eventSource.close();
+      state.eventSource = null;
+    }
+    setStatus('Live update stream disconnected. Falling back to refresh.', 'error', 5000);
+    startFallbackPolling();
+  });
 }
 
 async function startLoop() {
@@ -171,30 +403,80 @@ async function startLoop() {
       method: 'POST',
       body: JSON.stringify({ config: buildConfig() }),
     });
-    setStatus('Started simulator loop.', 'success');
+    setStatus('Started simulator loop.', 'success', 2500);
     await refresh();
   } catch (error) {
-    setStatus(error.message, 'error');
+    setStatus(error.message, 'error', 5000);
   }
 }
 
 async function stopLoop() {
   try {
     await api('/api/simulate/stop', { method: 'POST' });
-    setStatus('Stopped simulator loop.', 'success');
+    setStatus('Stopped simulator loop.', 'success', 2500);
     await refresh();
   } catch (error) {
-    setStatus(error.message, 'error');
+    setStatus(error.message, 'error', 5000);
   }
 }
 
 async function stepOnce() {
   try {
     const result = await api('/api/simulate/step', { method: 'POST' });
-    setStatus(`Generated ${result.generated} event(s).`, 'success');
+    setStatus(`Generated ${result.generated} event(s).`, 'success', 2500);
     await refresh();
   } catch (error) {
-    setStatus(error.message, 'error');
+    setStatus(error.message, 'error', 5000);
+  }
+}
+
+async function replayCurrentLog() {
+  try {
+    const result = await api('/api/simulate/replay', { method: 'POST' });
+    const path = result.persist_path || 'current log';
+    if (result.status === 'empty') {
+      setStatus(`No persisted events found at ${path}.`, 'error', 5000);
+    } else if (result.status === 'failed') {
+      setStatus(`Replay failed for ${result.failed} event(s): ${result.error || 'delivery error'}`, 'error', 5000);
+    } else if (result.status === 'rebuilt') {
+      setStatus(`Rebuilt ${result.replayed} event(s) from ${path}; delivery mode is none.`, 'success', 3500);
+    } else {
+      setStatus(`Replayed ${result.posted} event(s) from ${path}.`, 'success', 3500);
+    }
+    await refresh();
+  } catch (error) {
+    setStatus(error.message, 'error', 5000);
+  }
+}
+
+async function importCsv() {
+  const file = ids.csvFile.files[0];
+  if (!file) {
+    setStatus('Choose a CSV file first.', 'error', 5000);
+    return;
+  }
+  try {
+    const config = buildConfig();
+    const result = await api('/api/import/csv', {
+      method: 'POST',
+      body: JSON.stringify({
+        import_type: ids.csvImportType.value,
+        csv_text: await file.text(),
+        source: config.source,
+        delivery: config.delivery,
+      }),
+    });
+    renderImportResult(result);
+    if (result.status === 'delivery_failed') {
+      setStatus(`Imported ${result.accepted} row(s), but delivery failed: ${result.error || 'delivery error'}`, 'error', 7000);
+    } else if (result.rejected > 0) {
+      setStatus(`Imported ${result.accepted} row(s); rejected ${result.rejected}.`, 'error', 7000);
+    } else {
+      setStatus(`Imported ${result.accepted} CSV row(s).`, 'success', 3500);
+    }
+    await refresh();
+  } catch (error) {
+    setStatus(error.message, 'error', 5000);
   }
 }
 
@@ -205,42 +487,43 @@ async function resetState() {
       body: JSON.stringify(buildConfig()),
     });
     ids.lineageResults.innerHTML = '';
-    setStatus('Reset simulator state and persisted event log.', 'success');
+    setStatus('Reset simulator state and persisted event log.', 'success', 2500);
     await refresh();
   } catch (error) {
-    setStatus(error.message, 'error');
+    setStatus(error.message, 'error', 5000);
   }
 }
 
 async function lookupLineage() {
   const lotCode = ids.lotLookup.value.trim();
   if (!lotCode) {
-    setStatus('Enter a lot code first.', 'error');
+    setStatus('Enter a lot code first.', 'error', 5000);
     return;
   }
   try {
     const payload = await api(`/api/lineage/${encodeURIComponent(lotCode)}`);
-    renderLineage(payload.records, lotCode);
-    setStatus(`Loaded lineage for ${lotCode}.`, 'success');
+    renderLineage(payload, lotCode);
+    setStatus(`Loaded lineage for ${lotCode}.`, 'success', 2500);
   } catch (error) {
     ids.lineageResults.innerHTML = `<p class="note">${escapeHtml(error.message)}</p>`;
-    setStatus(error.message, 'error');
+    setStatus(error.message, 'error', 5000);
   }
 }
 
 document.getElementById('startBtn').addEventListener('click', startLoop);
 document.getElementById('stopBtn').addEventListener('click', stopLoop);
 document.getElementById('stepBtn').addEventListener('click', stepOnce);
+document.getElementById('replayBtn').addEventListener('click', replayCurrentLog);
+document.getElementById('importCsvBtn').addEventListener('click', importCsv);
 document.getElementById('resetBtn').addEventListener('click', resetState);
 document.getElementById('refreshBtn').addEventListener('click', refresh);
 document.getElementById('lineageBtn').addEventListener('click', lookupLineage);
 
-setInterval(() => {
-  refresh().catch((error) => {
-    setStatus(error.message, 'error');
-  });
-}, 2000);
-
+loadScenarios().catch((error) => {
+  setStatus(error.message, 'error', 5000);
+});
+connectLiveUpdates();
 refresh().catch((error) => {
-  setStatus(error.message, 'error');
+  setStatus(error.message, 'error', 5000);
+  startFallbackPolling();
 });

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -31,6 +31,14 @@
             <input id="source" name="source" value="codex-simulator" />
           </label>
           <label>
+            Scenario preset
+            <select id="scenario" name="scenario">
+              <option value="leafy_greens_supplier" selected>Leafy greens supplier</option>
+              <option value="fresh_cut_processor">Fresh-cut processor</option>
+              <option value="retailer_readiness_demo">Retailer readiness demo</option>
+            </select>
+          </label>
+          <label>
             Interval seconds
             <input id="interval" name="interval" type="number" min="0" step="0.1" value="1.5" />
           </label>
@@ -67,9 +75,33 @@
           <button class="button" id="startBtn" type="button">Start loop</button>
           <button class="button secondary" id="stopBtn" type="button">Stop</button>
           <button class="button secondary" id="stepBtn" type="button">Single batch</button>
+          <button class="button secondary" id="replayBtn" type="button">Replay current log</button>
           <button class="button danger" id="resetBtn" type="button">Reset state</button>
         </div>
         <p class="note" id="statusMessage">Ready.</p>
+      </section>
+
+      <section class="panel">
+        <div class="section-head">
+          <h2>CSV bulk import</h2>
+        </div>
+        <div class="grid two-up">
+          <label>
+            CSV type
+            <select id="csvImportType" name="csvImportType">
+              <option value="scheduled_events" selected>Scheduled events</option>
+              <option value="seed_lots">Seed lots</option>
+            </select>
+          </label>
+          <label>
+            CSV file
+            <input id="csvFile" name="csvFile" type="file" accept=".csv,text/csv" />
+          </label>
+        </div>
+        <div class="actions">
+          <button class="button secondary" id="importCsvBtn" type="button">Import CSV</button>
+        </div>
+        <div id="importResults" class="import-results"></div>
       </section>
 
       <section class="grid stats-grid" id="statsGrid"></section>

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -205,17 +205,100 @@ th {
 }
 
 .lineage-results {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-  gap: 14px;
   margin-top: 16px;
 }
 
+.lineage-overview,
+.lineage-flow,
+.lineage-timeline {
+  margin-top: 14px;
+}
+
+.lineage-overview {
+  display: grid;
+  grid-template-columns: minmax(220px, 1fr) 2fr;
+  gap: 14px;
+  align-items: stretch;
+}
+
+.lineage-focus,
+.lineage-stat,
+.lineage-lot,
 .lineage-card {
   padding: 16px;
-  border-radius: 14px;
+  border-radius: 8px;
   background: rgba(255, 255, 255, 0.03);
   border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.lineage-focus span,
+.lineage-stat span,
+.lineage-lot small {
+  display: block;
+  color: var(--muted);
+}
+
+.lineage-focus strong,
+.lineage-stat strong {
+  display: block;
+  margin-top: 6px;
+  font-size: 1.1rem;
+}
+
+.lineage-focus p,
+.lineage-lot p {
+  margin-bottom: 0;
+}
+
+.lineage-stats,
+.lineage-lots,
+.lineage-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 10px;
+}
+
+.lineage-lot {
+  border-color: rgba(110, 168, 254, 0.18);
+}
+
+.lineage-lot.is-current {
+  border-color: var(--accent);
+}
+
+.lineage-lot header {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.lineage-flow ul {
+  display: grid;
+  gap: 8px;
+  margin: 14px 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.lineage-flow li {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 10px 12px;
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.flow-arrow,
+.flow-meta {
+  color: var(--muted);
+}
+
+.flow-meta {
+  margin-left: auto;
+  text-transform: uppercase;
+  font-size: 0.78rem;
 }
 
 .lineage-card header {
@@ -229,6 +312,36 @@ th {
   margin: 12px 0 0;
   padding-left: 18px;
   color: var(--muted);
+}
+
+.import-results {
+  margin-top: 14px;
+  color: var(--muted);
+}
+
+.import-summary {
+  padding: 12px 14px;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.import-summary span {
+  display: block;
+  margin-top: 6px;
+}
+
+.import-summary[data-tone="success"] {
+  color: var(--success);
+}
+
+.import-summary[data-tone="error"] {
+  color: var(--danger);
+}
+
+.import-results ul {
+  margin: 10px 0 0;
+  padding-left: 20px;
 }
 
 .note[data-tone="error"],
@@ -247,7 +360,8 @@ th {
   }
 
   .grid.two-up,
-  .stats-grid {
+  .stats-grid,
+  .lineage-overview {
     grid-template-columns: 1fr;
   }
 }

--- a/app/store.py
+++ b/app/store.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from threading import RLock
 from typing import Any, Iterable
 
-from .models import DestinationMode, StoredEventRecord
+from .models import LineageEdge, LineageNode, StoredEventRecord
 
 
 class EventStore:
@@ -16,7 +16,39 @@ class EventStore:
         self._records: deque[StoredEventRecord] = deque(maxlen=max_records)
         self._counter = 0
         self._lock = RLock()
+        self._load_from_disk()
+
+    def configure(self, persist_path: str) -> None:
+        with self._lock:
+            self.persist_path = Path(persist_path)
+            self._load_from_disk()
+
+    def _load_from_disk(self) -> None:
         self.persist_path.parent.mkdir(parents=True, exist_ok=True)
+        records = self.read_persisted_records(str(self.persist_path))
+        loaded_records: deque[StoredEventRecord] = deque(records, maxlen=self.max_records)
+        counter = max((record.sequence_no for record in records), default=0)
+
+        self._records = deque(reversed(loaded_records), maxlen=self.max_records)
+        self._counter = counter
+
+    def read_persisted_records(self, persist_path: str | None = None) -> list[StoredEventRecord]:
+        path = Path(persist_path) if persist_path else self.persist_path
+        records: list[StoredEventRecord] = []
+
+        with self._lock:
+            if path.exists():
+                with path.open("r", encoding="utf-8") as handle:
+                    for line_number, line in enumerate(handle, start=1):
+                        if not line.strip():
+                            continue
+                        try:
+                            records.append(StoredEventRecord.model_validate_json(line))
+                        except ValueError as exc:
+                            raise ValueError(
+                                f"Could not load stored event record from {path}:{line_number}"
+                            ) from exc
+        return records
 
     def reset(self) -> None:
         with self._lock:
@@ -61,16 +93,98 @@ class EventStore:
     def lineage(self, traceability_lot_code: str) -> list[StoredEventRecord]:
         with self._lock:
             records = list(self._records)
-        matched = [
-            record
-            for record in records
-            if record.event.traceability_lot_code == traceability_lot_code
-            or traceability_lot_code in record.parent_lot_codes
-            or traceability_lot_code in record.event.kdes.get("input_traceability_lot_codes", [])
-            or record.event.kdes.get("source_traceability_lot_code") == traceability_lot_code
-        ]
+        child_to_parents: dict[str, set[str]] = {}
+        parent_to_children: dict[str, set[str]] = {}
+        for record in records:
+            child_lot_code = record.event.traceability_lot_code
+            child_to_parents.setdefault(child_lot_code, set())
+            for parent_lot_code in self._parent_lot_codes(record):
+                if parent_lot_code == child_lot_code:
+                    continue
+                child_to_parents[child_lot_code].add(parent_lot_code)
+                parent_to_children.setdefault(parent_lot_code, set()).add(child_lot_code)
+
+        related_lot_codes = {traceability_lot_code}
+        pending = [traceability_lot_code]
+        while pending:
+            current_lot_code = pending.pop()
+            neighbors = child_to_parents.get(current_lot_code, set()) | parent_to_children.get(
+                current_lot_code, set()
+            )
+            for neighbor in neighbors:
+                if neighbor not in related_lot_codes:
+                    related_lot_codes.add(neighbor)
+                    pending.append(neighbor)
+
+        matched = [record for record in records if record.event.traceability_lot_code in related_lot_codes]
         matched.sort(key=lambda record: record.event.timestamp)
         return matched
+
+    def lineage_nodes(self, records: Iterable[StoredEventRecord]) -> list[LineageNode]:
+        lots: dict[str, list[StoredEventRecord]] = {}
+        for record in records:
+            lots.setdefault(record.event.traceability_lot_code, []).append(record)
+
+        nodes: list[LineageNode] = []
+        for lot_code, lot_records in lots.items():
+            ordered = sorted(lot_records, key=lambda record: record.event.timestamp)
+            event = ordered[-1].event
+            cte_types = []
+            for record in ordered:
+                if record.event.cte_type not in cte_types:
+                    cte_types.append(record.event.cte_type)
+            locations = []
+            for record in ordered:
+                if record.event.location_name not in locations:
+                    locations.append(record.event.location_name)
+            nodes.append(
+                LineageNode(
+                    lot_code=lot_code,
+                    product_description=event.product_description,
+                    event_count=len(ordered),
+                    cte_types=cte_types,
+                    first_seen=ordered[0].event.timestamp,
+                    last_seen=ordered[-1].event.timestamp,
+                    locations=locations,
+                )
+            )
+        nodes.sort(key=lambda node: (node.first_seen, node.lot_code))
+        return nodes
+
+    def lineage_edges(self, records: Iterable[StoredEventRecord]) -> list[LineageEdge]:
+        record_list = list(records)
+        related_lot_codes = {record.event.traceability_lot_code for record in record_list}
+        edges: list[LineageEdge] = []
+        seen_edges: set[tuple[str, str, int]] = set()
+
+        for record in sorted(record_list, key=lambda item: (item.event.timestamp, item.sequence_no)):
+            target_lot_code = record.event.traceability_lot_code
+            for source_lot_code in sorted(self._parent_lot_codes(record)):
+                if source_lot_code == target_lot_code or source_lot_code not in related_lot_codes:
+                    continue
+                edge_key = (source_lot_code, target_lot_code, record.sequence_no)
+                if edge_key in seen_edges:
+                    continue
+                seen_edges.add(edge_key)
+                edges.append(
+                    LineageEdge(
+                        source_lot_code=source_lot_code,
+                        target_lot_code=target_lot_code,
+                        cte_type=record.event.cte_type,
+                        event_sequence_no=record.sequence_no,
+                    )
+                )
+        return edges
+
+    def _parent_lot_codes(self, record: StoredEventRecord) -> set[str]:
+        parent_lot_codes = set(record.parent_lot_codes)
+        source_lot_code = record.event.kdes.get("source_traceability_lot_code")
+        if isinstance(source_lot_code, str):
+            parent_lot_codes.add(source_lot_code)
+        input_lot_codes = record.event.kdes.get("input_traceability_lot_codes", [])
+        if isinstance(input_lot_codes, list):
+            parent_lot_codes.update(lot_code for lot_code in input_lot_codes if isinstance(lot_code, str))
+        return parent_lot_codes
 
     def all_between(self, start_date: str | None = None, end_date: str | None = None) -> list[StoredEventRecord]:
         with self._lock:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,6 +1,11 @@
+import asyncio
+import json
+
 from fastapi.testclient import TestClient
 
 from app.main import app, controller
+from app.models import SimulationConfig
+from app.scenarios import ScenarioId, get_scenario
 
 
 client = TestClient(app)
@@ -10,7 +15,7 @@ def setup_function() -> None:
     # reset shared app state between tests
     import asyncio
 
-    asyncio.run(controller.reset())
+    asyncio.run(controller.reset(SimulationConfig()))
 
 
 def test_single_step_generates_mock_events():
@@ -28,6 +33,65 @@ def test_single_step_generates_mock_events():
     assert "cte_type" in first_event
     assert "traceability_lot_code" in first_event
     assert "kdes" in first_event
+
+
+def test_sse_stream_emits_initial_snapshot():
+    response = client.get("/api/simulate/stream?limit=5&once=true")
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/event-stream")
+    lines = [line for line in response.text.splitlines() if line]
+
+    assert lines[0] == "event: snapshot"
+    data_line = next(line for line in lines if line.startswith("data: "))
+    payload = json.loads(data_line.removeprefix("data: "))
+    assert payload["revision"] == controller.revision
+    assert payload["status"]["running"] is False
+    assert payload["events"] == []
+
+
+def test_scenario_catalog_endpoint_lists_supported_presets():
+    response = client.get("/api/scenarios")
+
+    assert response.status_code == 200
+    scenarios = response.json()["scenarios"]
+    assert [scenario["id"] for scenario in scenarios] == [
+        "leafy_greens_supplier",
+        "fresh_cut_processor",
+        "retailer_readiness_demo",
+    ]
+    assert all(scenario["label"] for scenario in scenarios)
+
+
+def test_controller_revision_notifies_after_step():
+    async def wait_for_step_update() -> dict:
+        starting_revision = controller.revision
+        waiter = asyncio.create_task(controller.wait_for_revision(starting_revision, timeout=1.0))
+        await controller.step(batch_size=1)
+        observed_revision = await waiter
+        return controller.snapshot(event_limit=5) | {"observed_revision": observed_revision}
+
+    snapshot = asyncio.run(wait_for_step_update())
+
+    assert snapshot["observed_revision"] == snapshot["revision"]
+    assert snapshot["status"]["stats"]["total_records"] == 1
+    assert len(snapshot["events"]) == 1
+
+
+def test_stop_interrupts_long_interval_sleep(tmp_path):
+    async def start_and_stop() -> bool:
+        await controller.start(
+            SimulationConfig(
+                interval_seconds=60,
+                batch_size=1,
+                seed=204,
+                persist_path=str(tmp_path / "long-interval-events.jsonl"),
+            )
+        )
+        await asyncio.wait_for(controller.stop(), timeout=1.0)
+        return controller.running
+
+    assert asyncio.run(start_and_stop()) is False
 
 
 def test_mock_ingest_endpoint_returns_hashes():
@@ -67,3 +131,313 @@ def test_fda_export_shape_contains_expected_columns():
     assert "Traceability Lot Code" in csv_text
     assert "Location Identifier (GLN)" in csv_text
     assert "Reference Document Number" in csv_text
+
+
+def test_start_applies_configured_persist_path_and_keeps_mock_default(tmp_path):
+    custom_path = tmp_path / "start-events.jsonl"
+    response = client.post(
+        "/api/simulate/start",
+        json={
+            "config": {
+                "interval_seconds": 0.01,
+                "batch_size": 1,
+                "seed": 204,
+                "persist_path": str(custom_path),
+            }
+        },
+    )
+    try:
+        assert response.status_code == 200
+        body = response.json()
+        assert body["config"]["persist_path"] == str(custom_path)
+        assert body["config"]["delivery"]["mode"] == "mock"
+        assert body["stats"]["persist_path"] == str(custom_path)
+    finally:
+        client.post("/api/simulate/stop")
+
+
+def test_reset_applies_configured_persist_path_for_next_step(tmp_path):
+    custom_path = tmp_path / "reset-events.jsonl"
+    response = client.post(
+        "/api/simulate/reset",
+        json={
+            "batch_size": 1,
+            "seed": 204,
+            "persist_path": str(custom_path),
+        },
+    )
+    assert response.status_code == 200
+
+    status = client.get("/api/simulate/status").json()
+    assert status["config"]["persist_path"] == str(custom_path)
+    assert status["config"]["delivery"]["mode"] == "mock"
+    assert status["stats"]["persist_path"] == str(custom_path)
+
+    step_response = client.post("/api/simulate/step")
+    assert step_response.status_code == 200
+    assert step_response.json()["generated"] == 1
+    assert custom_path.exists()
+    assert len(custom_path.read_text(encoding="utf-8").splitlines()) == 1
+
+
+def test_replay_current_persisted_log_posts_without_rewriting_records(tmp_path):
+    custom_path = tmp_path / "replay-events.jsonl"
+    reset_response = client.post(
+        "/api/simulate/reset",
+        json={
+            "batch_size": 2,
+            "seed": 204,
+            "persist_path": str(custom_path),
+        },
+    )
+    assert reset_response.status_code == 200
+    step_response = client.post("/api/simulate/step")
+    assert step_response.status_code == 200
+
+    original_log = custom_path.read_text(encoding="utf-8")
+    original_events = client.get("/api/events?limit=10").json()["events"]
+
+    response = client.post("/api/simulate/replay")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "posted"
+    assert body["read"] == 2
+    assert body["replayed"] == 2
+    assert body["posted"] == 2
+    assert body["failed"] == 0
+    assert body["delivery_mode"] == "mock"
+    assert body["persist_path"] == str(custom_path)
+    assert body["response"]["total"] == 2
+
+    assert custom_path.read_text(encoding="utf-8") == original_log
+    assert client.get("/api/events?limit=10").json()["events"] == original_events
+
+
+def test_replay_accepts_override_path_and_delivery_none(tmp_path):
+    current_path = tmp_path / "current-events.jsonl"
+    override_path = tmp_path / "override-events.jsonl"
+    client.post(
+        "/api/simulate/reset",
+        json={
+            "batch_size": 1,
+            "seed": 204,
+            "persist_path": str(current_path),
+        },
+    )
+    client.post("/api/simulate/step")
+    override_path.write_text(current_path.read_text(encoding="utf-8"), encoding="utf-8")
+    original_override_log = override_path.read_text(encoding="utf-8")
+
+    response = client.post(
+        "/api/simulate/replay",
+        json={
+            "persist_path": str(override_path),
+            "source": "replay-suite",
+            "delivery": {"mode": "none"},
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "rebuilt"
+    assert body["read"] == 1
+    assert body["replayed"] == 1
+    assert body["posted"] == 0
+    assert body["failed"] == 0
+    assert body["source"] == "replay-suite"
+    assert body["delivery_mode"] == "none"
+    assert body["persist_path"] == str(override_path)
+    assert body["response"] is None
+    assert override_path.read_text(encoding="utf-8") == original_override_log
+
+
+def test_replay_missing_log_returns_empty_counts(tmp_path):
+    missing_path = tmp_path / "missing-events.jsonl"
+
+    response = client.post("/api/simulate/replay", json={"persist_path": str(missing_path)})
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "empty"
+    assert body["read"] == 0
+    assert body["replayed"] == 0
+    assert body["posted"] == 0
+    assert body["failed"] == 0
+    assert body["persist_path"] == str(missing_path)
+
+
+def test_csv_import_scheduled_events_stores_valid_rows_and_reports_errors(tmp_path):
+    custom_path = tmp_path / "csv-events.jsonl"
+    client.post(
+        "/api/simulate/reset",
+        json={
+            "batch_size": 1,
+            "seed": 204,
+            "persist_path": str(custom_path),
+        },
+    )
+    csv_text = """cte_type,traceability_lot_code,product_description,quantity,unit_of_measure,location_name,timestamp,source_traceability_lot_code,kdes
+harvesting,TLC-CSV-HARVEST,Romaine Lettuce,120,cases,Valley Fresh Farms,2026-02-05T08:00:00Z,,"{""harvest_date"":""2026-02-05""}"
+initial_packing,TLC-CSV-PACKED,Romaine Lettuce,112,cases,Coastal Packhouse,2026-02-05T10:00:00Z,TLC-CSV-HARVEST,"{""pack_date"":""2026-02-05""}"
+receiving,TLC-CSV-BAD,Romaine Lettuce,,cases,Distribution Center #4,2026-02-05T12:00:00Z,,
+"""
+
+    response = client.post(
+        "/api/import/csv",
+        json={
+            "import_type": "scheduled_events",
+            "csv_text": csv_text,
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "partial"
+    assert body["total"] == 3
+    assert body["accepted"] == 2
+    assert body["rejected"] == 1
+    assert body["stored"] == 2
+    assert body["posted"] == 2
+    assert body["delivery_mode"] == "mock"
+    assert body["errors"] == [
+        {"row": 4, "field": "quantity", "message": "Missing required field: quantity"}
+    ]
+
+    events = client.get("/api/events?limit=10").json()["events"]
+    assert len(events) == 2
+    assert events[0]["event"]["traceability_lot_code"] == "TLC-CSV-PACKED"
+    assert events[0]["parent_lot_codes"] == ["TLC-CSV-HARVEST"]
+    assert set(events[0]["event"]) == {
+        "cte_type",
+        "traceability_lot_code",
+        "product_description",
+        "quantity",
+        "unit_of_measure",
+        "location_name",
+        "timestamp",
+        "kdes",
+    }
+
+    lineage_response = client.get("/api/lineage/TLC-CSV-PACKED").json()
+    lineage = lineage_response["records"]
+    assert [record["event"]["traceability_lot_code"] for record in lineage] == [
+        "TLC-CSV-HARVEST",
+        "TLC-CSV-PACKED",
+    ]
+    assert [node["lot_code"] for node in lineage_response["nodes"]] == [
+        "TLC-CSV-HARVEST",
+        "TLC-CSV-PACKED",
+    ]
+    assert lineage_response["edges"] == [
+        {
+            "source_lot_code": "TLC-CSV-HARVEST",
+            "target_lot_code": "TLC-CSV-PACKED",
+            "cte_type": "initial_packing",
+            "event_sequence_no": 2,
+        }
+    ]
+
+
+def test_csv_import_seed_lots_builds_harvesting_events_with_none_delivery(tmp_path):
+    custom_path = tmp_path / "seed-events.jsonl"
+    client.post(
+        "/api/simulate/reset",
+        json={
+            "batch_size": 1,
+            "seed": 204,
+            "persist_path": str(custom_path),
+        },
+    )
+    csv_text = """traceability_lot_code,product_description,quantity,unit_of_measure,location_name,timestamp,field_name,immediate_subsequent_recipient
+TLC-SEED-001,Spinach,80,cases,Valley Fresh Farms,2026-02-06T09:15:00Z,Field-9,Central Coast Cooler
+"""
+
+    response = client.post(
+        "/api/import/csv",
+        json={
+            "import_type": "seed_lots",
+            "csv_text": csv_text,
+            "source": "seed-suite",
+            "delivery": {"mode": "none"},
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "accepted"
+    assert body["accepted"] == 1
+    assert body["rejected"] == 0
+    assert body["posted"] == 0
+    assert body["delivery_mode"] == "none"
+
+    record = client.get("/api/events?limit=1").json()["events"][0]
+    event = record["event"]
+    assert record["payload_source"] == "seed-suite"
+    assert record["delivery_status"] == "generated"
+    assert event["cte_type"] == "harvesting"
+    assert event["traceability_lot_code"] == "TLC-SEED-001"
+    assert event["kdes"]["harvest_date"] == "2026-02-06"
+    assert event["kdes"]["farm_location"] == "Valley Fresh Farms"
+    assert event["kdes"]["field_name"] == "Field-9"
+    assert event["kdes"]["reference_document_number"] == "CSV-TLC-SEED-001"
+
+
+def test_reset_applies_scenario_config_and_keeps_mock_delivery_default(tmp_path):
+    custom_path = tmp_path / "retailer-events.jsonl"
+    response = client.post(
+        "/api/simulate/reset",
+        json={
+            "scenario": "retailer_readiness_demo",
+            "batch_size": 1,
+            "seed": 204,
+            "persist_path": str(custom_path),
+        },
+    )
+    assert response.status_code == 200
+
+    status = client.get("/api/simulate/status").json()
+    assert status["config"]["scenario"] == "retailer_readiness_demo"
+    assert status["config"]["delivery"]["mode"] == "mock"
+    assert status["stats"]["engine"]["scenario"] == "retailer_readiness_demo"
+
+    step_response = client.post("/api/simulate/step")
+    assert step_response.status_code == 200
+    events = client.get("/api/events?limit=1").json()["events"]
+    expected_products = {product.name for product in get_scenario(ScenarioId.RETAILER_READINESS_DEMO).products}
+
+    assert events[0]["event"]["product_description"] in expected_products
+
+
+def test_start_applies_scenario_change_even_with_existing_records(tmp_path):
+    custom_path = tmp_path / "scenario-switch-events.jsonl"
+    client.post(
+        "/api/simulate/reset",
+        json={
+            "scenario": "leafy_greens_supplier",
+            "batch_size": 1,
+            "seed": 204,
+            "persist_path": str(custom_path),
+        },
+    )
+    client.post("/api/simulate/step")
+
+    response = client.post(
+        "/api/simulate/start",
+        json={
+            "config": {
+                "scenario": "fresh_cut_processor",
+                "interval_seconds": 10,
+                "batch_size": 1,
+                "seed": 204,
+                "persist_path": str(custom_path),
+            }
+        },
+    )
+    try:
+        assert response.status_code == 200
+        status = response.json()
+        assert status["config"]["scenario"] == "fresh_cut_processor"
+        assert status["stats"]["engine"]["scenario"] == "fresh_cut_processor"
+    finally:
+        client.post("/api/simulate/stop")

--- a/tests/test_csv_importer.py
+++ b/tests/test_csv_importer.py
@@ -1,0 +1,53 @@
+from datetime import UTC, datetime
+
+from app.csv_importer import parse_csv_import
+from app.models import CSVImportType
+
+
+def test_parse_seed_lot_uses_deterministic_default_timestamp():
+    parsed = parse_csv_import(
+        CSVImportType.SEED_LOTS,
+        """traceability_lot_code,product_description,quantity,unit_of_measure,location_name
+TLC-SEED-DEFAULT,Romaine Hearts,42,cases,Valley Fresh Farms
+""",
+        default_timestamp=datetime(2026, 2, 7, 11, 30, tzinfo=UTC),
+    )
+
+    assert parsed.total == 1
+    assert len(parsed.events) == 1
+    assert parsed.errors == []
+    event = parsed.events[0]
+    assert event.timestamp == datetime(2026, 2, 7, 11, 30, tzinfo=UTC)
+    assert event.kdes["harvest_date"] == "2026-02-07"
+    assert event.kdes["reference_document_number"] == "CSV-TLC-SEED-DEFAULT"
+
+
+def test_parse_scheduled_event_reports_invalid_cte_timestamp_and_kdes():
+    parsed = parse_csv_import(
+        CSVImportType.SCHEDULED_EVENTS,
+        """cte_type,traceability_lot_code,product_description,quantity,unit_of_measure,location_name,timestamp,kdes
+packing,TLC-BAD,Romaine Lettuce,10,cases,Coastal Packhouse,not-a-date,"[]"
+""",
+    )
+
+    assert parsed.total == 1
+    assert parsed.events == []
+    assert [(error.row, error.field) for error in parsed.errors] == [
+        (2, "timestamp"),
+        (2, "cte_type"),
+        (2, "kdes"),
+    ]
+
+
+def test_parse_scheduled_event_derives_parent_lots_from_kde_columns():
+    parsed = parse_csv_import(
+        CSVImportType.SCHEDULED_EVENTS,
+        """cte_type,traceability_lot_code,product_description,quantity,unit_of_measure,location_name,timestamp,kde_input_traceability_lot_codes
+transformation,TLC-OUT,Fresh Cut Salad Mix,50,cases,ReadyFresh Processing Plant,2026-02-07T12:00:00Z,TLC-IN-1|TLC-IN-2
+""",
+    )
+
+    assert parsed.total == 1
+    assert parsed.errors == []
+    assert parsed.parent_lot_codes == [["TLC-IN-1", "TLC-IN-2"]]
+    assert parsed.events[0].kdes["input_traceability_lot_codes"] == ["TLC-IN-1", "TLC-IN-2"]

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -2,18 +2,40 @@ from app.engine import LegitFlowEngine
 from app.models import CTEType
 
 
-def test_engine_emits_supported_ctes_and_lineage():
+def test_initial_packing_sources_previously_cooled_lots():
     engine = LegitFlowEngine(seed=204)
+    cooled_lots = set()
+    packing_seen = False
+
+    for _ in range(80):
+        event, parents = engine.next_event()
+
+        if event.cte_type == CTEType.COOLING:
+            cooled_lots.add(event.traceability_lot_code)
+        elif event.cte_type == CTEType.INITIAL_PACKING:
+            packing_seen = True
+            source_lot_code = event.kdes["source_traceability_lot_code"]
+            assert parents == [source_lot_code]
+            assert source_lot_code in cooled_lots
+
+    assert packing_seen
+
+
+def test_engine_emits_all_supported_ctes_and_lineage():
+    engine = LegitFlowEngine(seed=204)
+    expected_ctes = set(CTEType)
     seen = set()
     parent_links = 0
-    for _ in range(80):
+
+    for _ in range(160):
         event, parents = engine.next_event()
         seen.add(event.cte_type)
         if parents:
             parent_links += 1
-    assert CTEType.HARVESTING in seen
-    assert CTEType.SHIPPING in seen
-    assert CTEType.RECEIVING in seen
+        if seen == expected_ctes and parent_links > 0:
+            break
+
+    assert seen == expected_ctes
     assert parent_links > 0
 
 

--- a/tests/test_regengine_client.py
+++ b/tests/test_regengine_client.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime
+from typing import Any
+
+from app.models import CTEType, IngestPayload, RegEngineEvent, SimulationConfig
+from app.regengine_client import DEFAULT_LIVE_INGEST_ENDPOINT, LiveRegEngineClient
+
+
+class FakeResponse:
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> dict[str, Any]:
+        return {"accepted": 1}
+
+
+class RecordingAsyncClient:
+    calls: list[dict[str, Any]] = []
+
+    def __init__(self, *, timeout: float) -> None:
+        self.timeout = timeout
+
+    async def __aenter__(self) -> "RecordingAsyncClient":
+        return self
+
+    async def __aexit__(self, exc_type: object, exc: object, tb: object) -> None:
+        return None
+
+    async def post(self, endpoint: str, *, headers: dict[str, str], json: dict[str, Any]) -> FakeResponse:
+        self.calls.append(
+            {
+                "endpoint": endpoint,
+                "headers": headers,
+                "json": json,
+                "timeout": self.timeout,
+            }
+        )
+        return FakeResponse()
+
+
+def make_payload() -> IngestPayload:
+    return IngestPayload(
+        source="erp",
+        events=[
+            RegEngineEvent(
+                cte_type=CTEType.RECEIVING,
+                traceability_lot_code="00012345678901-LOT-2026-001",
+                product_description="Romaine Lettuce",
+                quantity=500,
+                unit_of_measure="cases",
+                location_name="Distribution Center #4",
+                timestamp=datetime(2026, 2, 5, 8, 30, tzinfo=UTC),
+                kdes={
+                    "receive_date": "2026-02-05",
+                    "receiving_location": "Distribution Center #4",
+                    "ship_from_location": "Valley Fresh Farms",
+                },
+            )
+        ],
+    )
+
+
+def make_live_config(endpoint: str | None = None) -> SimulationConfig:
+    return SimulationConfig(
+        delivery={
+            "mode": "live",
+            "endpoint": endpoint,
+            "api_key": "test-api-key",
+            "tenant_id": "test-tenant-id",
+        }
+    )
+
+
+def run_ingest(monkeypatch: Any, config: SimulationConfig) -> dict[str, Any]:
+    RecordingAsyncClient.calls = []
+    monkeypatch.setattr("app.regengine_client.httpx.AsyncClient", RecordingAsyncClient)
+
+    result = asyncio.run(LiveRegEngineClient().ingest(make_payload(), config))
+
+    assert result == {"accepted": 1}
+    assert len(RecordingAsyncClient.calls) == 1
+    return RecordingAsyncClient.calls[0]
+
+
+def test_live_client_uses_documented_default_endpoint(monkeypatch: Any) -> None:
+    call = run_ingest(monkeypatch, make_live_config())
+
+    assert call["endpoint"] == DEFAULT_LIVE_INGEST_ENDPOINT
+    assert call["endpoint"] == "https://www.regengine.co/api/v1/webhooks/ingest"
+
+
+def test_live_client_uses_configured_endpoint_override(monkeypatch: Any) -> None:
+    override = "https://partner.example.test/regengine/ingest"
+
+    call = run_ingest(monkeypatch, make_live_config(endpoint=override))
+
+    assert call["endpoint"] == override
+
+
+def test_live_client_sends_required_headers_and_contract_payload(monkeypatch: Any) -> None:
+    call = run_ingest(monkeypatch, make_live_config())
+
+    assert call["headers"]["Content-Type"] == "application/json"
+    assert call["headers"]["X-RegEngine-API-Key"] == "test-api-key"
+    assert call["headers"]["X-Tenant-ID"] == "test-tenant-id"
+
+    payload = call["json"]
+    assert set(payload) == {"source", "events"}
+    assert payload["source"] == "erp"
+    assert len(payload["events"]) == 1
+
+    event = payload["events"][0]
+    assert set(event) == {
+        "cte_type",
+        "traceability_lot_code",
+        "product_description",
+        "quantity",
+        "unit_of_measure",
+        "location_name",
+        "timestamp",
+        "kdes",
+    }
+    assert event == {
+        "cte_type": "receiving",
+        "traceability_lot_code": "00012345678901-LOT-2026-001",
+        "product_description": "Romaine Lettuce",
+        "quantity": 500.0,
+        "unit_of_measure": "cases",
+        "location_name": "Distribution Center #4",
+        "timestamp": "2026-02-05T08:30:00Z",
+        "kdes": {
+            "receive_date": "2026-02-05",
+            "receiving_location": "Distribution Center #4",
+            "ship_from_location": "Valley Fresh Farms",
+        },
+    }

--- a/tests/test_scenarios.py
+++ b/tests/test_scenarios.py
@@ -1,0 +1,70 @@
+from collections import Counter
+
+from app.engine import LegitFlowEngine
+from app.models import CTEType
+from app.scenarios import ScenarioId, get_scenario, list_scenario_summaries
+
+
+def event_signature(scenario: ScenarioId) -> list[tuple[str, str, str, tuple[str, ...]]]:
+    engine = LegitFlowEngine(seed=204, scenario=scenario)
+    signature = []
+    for _ in range(40):
+        event, parents = engine.next_event()
+        signature.append(
+            (
+                event.cte_type.value,
+                event.product_description,
+                event.location_name,
+                tuple(parents),
+            )
+        )
+    return signature
+
+
+def test_scenario_catalog_lists_required_presets():
+    summaries = list_scenario_summaries()
+
+    assert [summary["id"] for summary in summaries] == [
+        "leafy_greens_supplier",
+        "fresh_cut_processor",
+        "retailer_readiness_demo",
+    ]
+    assert all(summary["label"] for summary in summaries)
+    assert all(summary["description"] for summary in summaries)
+
+
+def test_scenario_generation_is_deterministic_for_seed():
+    assert event_signature(ScenarioId.FRESH_CUT_PROCESSOR) == event_signature(ScenarioId.FRESH_CUT_PROCESSOR)
+    assert event_signature(ScenarioId.FRESH_CUT_PROCESSOR) != event_signature(ScenarioId.RETAILER_READINESS_DEMO)
+
+
+def test_scenario_presets_produce_distinct_product_and_flow_mixes():
+    events_by_scenario = {}
+    for scenario in ScenarioId:
+        engine = LegitFlowEngine(seed=204, scenario=scenario)
+        events_by_scenario[scenario] = [engine.next_event()[0] for _ in range(160)]
+
+    leafy_products = {product.name for product in get_scenario(ScenarioId.LEAFY_GREENS_SUPPLIER).products}
+    retailer_products = {product.name for product in get_scenario(ScenarioId.RETAILER_READINESS_DEMO).products}
+    fresh_cut_outputs = set(get_scenario(ScenarioId.FRESH_CUT_PROCESSOR).transformation_outputs)
+
+    leafy_harvests = {
+        event.product_description
+        for event in events_by_scenario[ScenarioId.LEAFY_GREENS_SUPPLIER]
+        if event.cte_type == CTEType.HARVESTING
+    }
+    retailer_harvests = {
+        event.product_description
+        for event in events_by_scenario[ScenarioId.RETAILER_READINESS_DEMO]
+        if event.cte_type == CTEType.HARVESTING
+    }
+    fresh_cut_products = {event.product_description for event in events_by_scenario[ScenarioId.FRESH_CUT_PROCESSOR]}
+    fresh_cut_counts = Counter(event.cte_type for event in events_by_scenario[ScenarioId.FRESH_CUT_PROCESSOR])
+    retailer_locations = {event.location_name for event in events_by_scenario[ScenarioId.RETAILER_READINESS_DEMO]}
+
+    assert leafy_harvests <= leafy_products
+    assert retailer_harvests <= retailer_products
+    assert leafy_harvests.isdisjoint(retailer_harvests)
+    assert fresh_cut_products & fresh_cut_outputs
+    assert fresh_cut_counts[CTEType.TRANSFORMATION] > 0
+    assert {"Retail DC West", "Retail Store #4521"} <= retailer_locations

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -1,0 +1,115 @@
+from datetime import UTC, datetime, timedelta
+
+from app.models import CTEType, DestinationMode, RegEngineEvent, StoredEventRecord
+from app.store import EventStore
+
+
+BASE_TIME = datetime(2026, 2, 5, 8, 30, tzinfo=UTC)
+
+
+def make_record(
+    lot_code: str,
+    cte_type: CTEType,
+    minutes: int,
+    parent_lot_codes: list[str] | None = None,
+    kdes: dict | None = None,
+) -> StoredEventRecord:
+    return StoredEventRecord(
+        payload_source="test-suite",
+        event=RegEngineEvent(
+            cte_type=cte_type,
+            traceability_lot_code=lot_code,
+            product_description="Romaine Lettuce",
+            quantity=100,
+            unit_of_measure="cases",
+            location_name="Valley Fresh Farms",
+            timestamp=BASE_TIME + timedelta(minutes=minutes),
+            kdes=kdes or {},
+        ),
+        parent_lot_codes=parent_lot_codes or [],
+        destination_mode=DestinationMode.NONE,
+        delivery_status="generated",
+    )
+
+
+def test_store_loads_existing_jsonl_records_on_initialization(tmp_path):
+    persist_path = tmp_path / "events.jsonl"
+    store = EventStore(persist_path=str(persist_path))
+    store.add_many(
+        [
+            make_record("TLC-RELOAD-000001", CTEType.HARVESTING, 0),
+            make_record("TLC-RELOAD-000002", CTEType.COOLING, 10),
+        ]
+    )
+
+    reloaded = EventStore(persist_path=str(persist_path))
+    recent = reloaded.recent()
+
+    assert [record.event.traceability_lot_code for record in recent] == [
+        "TLC-RELOAD-000002",
+        "TLC-RELOAD-000001",
+    ]
+    assert [record.sequence_no for record in recent] == [2, 1]
+
+    stored = reloaded.add_many([make_record("TLC-RELOAD-000003", CTEType.SHIPPING, 20)])
+    assert stored[0].sequence_no == 3
+
+
+def test_lineage_for_transformed_output_includes_upstream_history_and_direct_query(tmp_path):
+    store = EventStore(persist_path=str(tmp_path / "events.jsonl"))
+    records = [
+        make_record("TLC-HARVEST-A", CTEType.HARVESTING, 0),
+        make_record("TLC-HARVEST-B", CTEType.HARVESTING, 5),
+        make_record(
+            "TLC-PACKED-A",
+            CTEType.INITIAL_PACKING,
+            10,
+            parent_lot_codes=["TLC-HARVEST-A"],
+            kdes={"source_traceability_lot_code": "TLC-HARVEST-A"},
+        ),
+        make_record(
+            "TLC-PACKED-B",
+            CTEType.INITIAL_PACKING,
+            15,
+            parent_lot_codes=["TLC-HARVEST-B"],
+            kdes={"source_traceability_lot_code": "TLC-HARVEST-B"},
+        ),
+        make_record(
+            "TLC-TRANSFORMED",
+            CTEType.TRANSFORMATION,
+            40,
+            parent_lot_codes=["TLC-PACKED-A", "TLC-PACKED-B"],
+            kdes={"input_traceability_lot_codes": ["TLC-PACKED-A", "TLC-PACKED-B"]},
+        ),
+    ]
+    store.add_many(records)
+
+    output_lineage = store.lineage("TLC-TRANSFORMED")
+    assert [record.event.traceability_lot_code for record in output_lineage] == [
+        "TLC-HARVEST-A",
+        "TLC-HARVEST-B",
+        "TLC-PACKED-A",
+        "TLC-PACKED-B",
+        "TLC-TRANSFORMED",
+    ]
+    assert [node.lot_code for node in store.lineage_nodes(output_lineage)] == [
+        "TLC-HARVEST-A",
+        "TLC-HARVEST-B",
+        "TLC-PACKED-A",
+        "TLC-PACKED-B",
+        "TLC-TRANSFORMED",
+    ]
+    assert [
+        (edge.source_lot_code, edge.target_lot_code, edge.cte_type.value)
+        for edge in store.lineage_edges(output_lineage)
+    ] == [
+        ("TLC-HARVEST-A", "TLC-PACKED-A", "initial_packing"),
+        ("TLC-HARVEST-B", "TLC-PACKED-B", "initial_packing"),
+        ("TLC-PACKED-A", "TLC-TRANSFORMED", "transformation"),
+        ("TLC-PACKED-B", "TLC-TRANSFORMED", "transformation"),
+    ]
+
+    direct_input_lineage = store.lineage("TLC-PACKED-A")
+    direct_input_lots = [record.event.traceability_lot_code for record in direct_input_lineage]
+    assert "TLC-PACKED-A" in direct_input_lots
+    assert "TLC-TRANSFORMED" in direct_input_lots


### PR DESCRIPTION
## Summary
- Fix RegEngine live endpoint default, JSONL reload, configured persist path usage, cooling-before-pack flow, and transitive lot lineage
- Add SSE dashboard updates, scenario presets, replay mode, CSV import, and clearer transformed-lot lineage graph views
- Expand README/backlog docs and deterministic API/store/engine/client/scenario/import tests

## Verification
- pytest
- node --check app/static/app.js
- git diff --check
- Browser smoke: reset, step, start, stop, CSV setup, transformed lineage view