### PR TITLE
Add delivery retry feedback

### DIFF
--- a/AUTOPILOT_TASKS.md
+++ b/AUTOPILOT_TASKS.md
@@ -20,7 +20,7 @@ This file is the standing backlog for unattended Codex runs.
 ## Priority 2
 
 - [x] Add clearer lot-lineage views in the dashboard for transformed lots.
-- [ ] Add richer operator-visible delivery status and retry feedback.
+- [x] Add richer operator-visible delivery status and retry feedback.
 - [ ] Add export presets that mimic common FDA-request slices.
 - [ ] Add deterministic scenario fixtures for demo playback.
 

--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ Sends real traffic to a RegEngine workspace. Configure from the dashboard or via
 ### `none`
 Generates and persists events locally without delivering them anywhere. Useful for seeding fixtures.
 
+Every stored record tracks `delivery_status`, `destination_mode`, `delivery_attempts`, and last delivery timestamps. The dashboard delivery monitor summarizes posted, failed, generated-only, and retryable records. Failed records can be retried through the dashboard or `POST /api/delivery/retry` after switching to a working `mock` or `live` delivery configuration.
+
 ## Replay mode
 
 Replay mode reads previously persisted `StoredEventRecord` JSONL lines, rebuilds the RegEngine ingest payload as:
@@ -134,7 +136,7 @@ Replay mode reads previously persisted `StoredEventRecord` JSONL lines, rebuilds
 
 By default, `POST /api/simulate/replay` uses the current `config.persist_path`, `config.source`, and `config.delivery`. You can override the JSONL path, source, or delivery mode in the request body. Delivery still uses the same `mock`, `live`, and `none` branches as normal generation.
 
-Replay responses include `status`, `read`, `replayed`, `posted`, `failed`, `source`, `persist_path`, `delivery_mode`, and any delivery `response` or `error`. Replay does not create new stored records.
+Replay responses include `status`, `read`, `replayed`, `posted`, `failed`, `source`, `persist_path`, `delivery_mode`, `delivery_attempts`, and any delivery `response` or `error`. Replay does not create new stored records.
 
 ## CSV import
 
@@ -169,7 +171,7 @@ traceability_lot_code,product_description,quantity,unit_of_measure,location_name
 
 Seed lots become valid `harvesting` events. Optional `timestamp`, `harvest_date`, `field_name`, `immediate_subsequent_recipient`, reference document columns, `kdes` JSON, and other KDE columns are preserved. If no timestamp is supplied, the import time is used.
 
-Import responses include `status`, `total`, `accepted`, `rejected`, `stored`, `posted`, `failed`, `lot_codes`, and `errors[]` with row number, field, and message.
+Import responses include `status`, `total`, `accepted`, `rejected`, `stored`, `posted`, `failed`, `delivery_attempts`, `lot_codes`, and `errors[]` with row number, field, and message.
 
 ## Scenario presets
 
@@ -199,6 +201,7 @@ Scenario selection is available in the dashboard, in `SimulationConfig`, and via
 | `POST` | `/api/simulate/reset` | Clear state and persisted events |
 | `GET` | `/api/simulate/stream` | Server-Sent Events snapshots for live dashboard updates |
 | `POST` | `/api/import/csv` | Bulk import scheduled events or seed lots from CSV text |
+| `POST` | `/api/delivery/retry` | Retry failed stored deliveries with the current or supplied delivery config |
 
 ### Inspection
 
@@ -285,6 +288,18 @@ curl -N http://127.0.0.1:8000/api/simulate/stream
 ```
 
 Each SSE `snapshot` includes a monotonic `revision`, the same status payload returned by `/api/simulate/status`, and recent event records from `/api/events`. Use `limit` to control the number of recent events and `once=true` for a one-shot smoke check.
+
+### Example: retry failed deliveries in mock mode
+
+```bash
+curl -X POST http://127.0.0.1:8000/api/delivery/retry \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "delivery": {
+      "mode": "mock"
+    }
+  }'
+```
 
 ### Example: trace a lot
 

--- a/app/controller.py
+++ b/app/controller.py
@@ -11,6 +11,8 @@ from .mock_service import MockRegEngineService
 from .models import (
     CSVImportRequest,
     CSVImportResponse,
+    DeliveryRetryRequest,
+    DeliveryRetryResponse,
     DestinationMode,
     IngestPayload,
     ReplayRequest,
@@ -29,6 +31,9 @@ class DeliveryOutcome:
     delivery_status: str = "generated"
     posted: int = 0
     failed: int = 0
+    delivery_attempts: int = 0
+    attempted_at: datetime | None = None
+    completed_at: datetime | None = None
     error_message: str | None = None
 
 
@@ -118,6 +123,11 @@ class SimulationController:
                         parent_lot_codes=lineages[index],
                         destination_mode=self.config.delivery.mode,
                         delivery_status=outcome.delivery_status,
+                        delivery_attempts=outcome.delivery_attempts,
+                        last_delivery_attempt_at=outcome.attempted_at,
+                        last_delivery_success_at=outcome.completed_at
+                        if outcome.delivery_status == "posted"
+                        else None,
                         delivery_response=event_response,
                         error=outcome.error_message,
                     )
@@ -129,7 +139,11 @@ class SimulationController:
                 posted=outcome.posted,
                 failed=outcome.failed,
                 lot_codes=[event.traceability_lot_code for event in events],
+                delivery_status=outcome.delivery_status,
+                delivery_mode=self.config.delivery.mode,
+                delivery_attempts=outcome.delivery_attempts,
                 response=outcome.response,
+                error=outcome.error_message,
             )
         await self._publish_update()
         return result
@@ -160,6 +174,7 @@ class SimulationController:
                     source=source,
                     persist_path=persist_path,
                     delivery_mode=delivery.mode,
+                    delivery_attempts=0,
                 )
             else:
                 payload = IngestPayload(source=source, events=events)
@@ -178,6 +193,7 @@ class SimulationController:
                     source=source,
                     persist_path=persist_path,
                     delivery_mode=delivery.mode,
+                    delivery_attempts=outcome.delivery_attempts,
                     response=outcome.response,
                     error=outcome.error_message,
                 )
@@ -216,6 +232,11 @@ class SimulationController:
                             parent_lot_codes=parsed.parent_lot_codes[index],
                             destination_mode=delivery.mode,
                             delivery_status=outcome.delivery_status,
+                            delivery_attempts=outcome.delivery_attempts,
+                            last_delivery_attempt_at=outcome.attempted_at,
+                            last_delivery_success_at=outcome.completed_at
+                            if outcome.delivery_status == "posted"
+                            else None,
                             delivery_response=event_response,
                             error=outcome.error_message,
                         )
@@ -243,6 +264,7 @@ class SimulationController:
                 failed=outcome.failed,
                 source=source,
                 delivery_mode=delivery.mode,
+                delivery_attempts=outcome.delivery_attempts,
                 lot_codes=[event.traceability_lot_code for event in parsed.events],
                 errors=parsed.errors,
                 response=outcome.response,
@@ -251,19 +273,155 @@ class SimulationController:
         await self._publish_update()
         return result
 
+    async def retry_failed_delivery(
+        self,
+        request: DeliveryRetryRequest | None = None,
+    ) -> DeliveryRetryResponse:
+        request = request or DeliveryRetryRequest()
+        async with self._lock:
+            delivery = request.delivery or self.config.delivery
+            candidates = self.store.failed_delivery_records(request.record_ids, limit=request.limit)
+            requested = len(request.record_ids) if request.record_ids else len(candidates)
+            skipped = max(0, requested - len(candidates))
+
+            if not candidates:
+                result = DeliveryRetryResponse(
+                    status="empty",
+                    requested=requested,
+                    retryable=0,
+                    attempted=0,
+                    posted=0,
+                    failed=0,
+                    skipped=skipped,
+                    delivery_mode=delivery.mode,
+                    record_ids=[],
+                )
+            elif delivery.mode == DestinationMode.NONE:
+                result = DeliveryRetryResponse(
+                    status="skipped",
+                    requested=requested,
+                    retryable=len(candidates),
+                    attempted=0,
+                    posted=0,
+                    failed=0,
+                    skipped=skipped + len(candidates),
+                    delivery_mode=delivery.mode,
+                    record_ids=[record.record_id for record in candidates],
+                    error="Retry requires mock or live delivery mode.",
+                )
+            else:
+                posted = 0
+                failed = 0
+                updated_records: list[StoredEventRecord] = []
+                responses: list[dict[str, Any]] = []
+                grouped_records: dict[str, list[StoredEventRecord]] = {}
+                for record in candidates:
+                    source = request.source or record.payload_source
+                    grouped_records.setdefault(source, []).append(record)
+
+                for source, records in grouped_records.items():
+                    retry_config = self.config.model_copy(
+                        update={
+                            "source": source,
+                            "delivery": delivery,
+                        },
+                        deep=True,
+                    )
+                    payload = IngestPayload(source=source, events=[record.event for record in records])
+                    outcome = await self._deliver_payload(payload, retry_config)
+                    response_events = (outcome.response or {}).get("events", []) if outcome.response else []
+                    responses.append(
+                        {
+                            "source": source,
+                            "delivery_status": outcome.delivery_status,
+                            "posted": outcome.posted,
+                            "failed": outcome.failed,
+                            "response": outcome.response,
+                            "error": outcome.error_message,
+                        }
+                    )
+
+                    for index, record in enumerate(records):
+                        event_response = response_events[index] if index < len(response_events) else None
+                        next_attempts = record.delivery_attempts + outcome.delivery_attempts
+                        updated_records.append(
+                            record.model_copy(
+                                update={
+                                    "destination_mode": delivery.mode,
+                                    "delivery_status": outcome.delivery_status,
+                                    "delivery_attempts": next_attempts,
+                                    "last_delivery_attempt_at": outcome.attempted_at
+                                    or record.last_delivery_attempt_at,
+                                    "last_delivery_success_at": outcome.completed_at
+                                    if outcome.delivery_status == "posted"
+                                    else record.last_delivery_success_at,
+                                    "delivery_response": event_response,
+                                    "error": None
+                                    if outcome.delivery_status == "posted"
+                                    else outcome.error_message,
+                                },
+                                deep=True,
+                            )
+                        )
+                    posted += outcome.posted
+                    failed += outcome.failed
+
+                self.store.update_many(updated_records)
+                if posted and failed:
+                    status = "partial"
+                elif failed:
+                    status = "failed"
+                else:
+                    status = "posted"
+                result = DeliveryRetryResponse(
+                    status=status,
+                    requested=requested,
+                    retryable=len(candidates),
+                    attempted=len(candidates),
+                    posted=posted,
+                    failed=failed,
+                    skipped=skipped,
+                    delivery_mode=delivery.mode,
+                    record_ids=[record.record_id for record in candidates],
+                    responses=responses,
+                    error=next((item["error"] for item in responses if item.get("error")), None),
+                )
+        await self._publish_update()
+        return result
+
     async def _deliver_payload(self, payload: IngestPayload, config: SimulationConfig) -> DeliveryOutcome:
+        if config.delivery.mode == DestinationMode.NONE:
+            return DeliveryOutcome()
+
+        attempted_at = datetime.now(UTC)
         try:
             if config.delivery.mode == DestinationMode.MOCK:
                 response = self.mock_service.ingest(payload).model_dump(mode="json")
-                return DeliveryOutcome(response=response, delivery_status="posted", posted=len(payload.events))
+                return DeliveryOutcome(
+                    response=response,
+                    delivery_status="posted",
+                    posted=len(payload.events),
+                    delivery_attempts=1,
+                    attempted_at=attempted_at,
+                    completed_at=datetime.now(UTC),
+                )
             if config.delivery.mode == DestinationMode.LIVE:
                 response = await self.live_client.ingest(payload, config)
-                return DeliveryOutcome(response=response, delivery_status="posted", posted=len(payload.events))
+                return DeliveryOutcome(
+                    response=response,
+                    delivery_status="posted",
+                    posted=len(payload.events),
+                    delivery_attempts=1,
+                    attempted_at=attempted_at,
+                    completed_at=datetime.now(UTC),
+                )
             return DeliveryOutcome()
         except Exception as exc:  # pragma: no cover - exercised by live integration, not unit tests
             return DeliveryOutcome(
                 delivery_status="failed",
                 failed=len(payload.events),
+                delivery_attempts=1,
+                attempted_at=attempted_at,
                 error_message=str(exc),
             )
 

--- a/app/main.py
+++ b/app/main.py
@@ -20,6 +20,8 @@ from .mock_service import MockRegEngineService
 from .models import (
     CSVImportRequest,
     CSVImportResponse,
+    DeliveryRetryRequest,
+    DeliveryRetryResponse,
     EventListResponse,
     IngestPayload,
     LineageResponse,
@@ -173,6 +175,11 @@ async def simulate_replay(request: ReplayRequest | None = None) -> ReplayRespons
 @app.post("/api/import/csv", response_model=CSVImportResponse)
 async def import_csv(request: CSVImportRequest) -> CSVImportResponse:
     return await controller.import_csv(request)
+
+
+@app.post("/api/delivery/retry", response_model=DeliveryRetryResponse)
+async def retry_failed_delivery(request: DeliveryRetryRequest | None = None) -> DeliveryRetryResponse:
+    return await controller.retry_failed_delivery(request)
 
 
 @app.get("/api/events", response_model=EventListResponse)

--- a/app/models.py
+++ b/app/models.py
@@ -85,6 +85,9 @@ class StoredEventRecord(BaseModel):
     parent_lot_codes: list[str] = Field(default_factory=list)
     destination_mode: DestinationMode = DestinationMode.NONE
     delivery_status: Literal["generated", "posted", "failed"] = "generated"
+    delivery_attempts: int = 0
+    last_delivery_attempt_at: datetime | None = None
+    last_delivery_success_at: datetime | None = None
     delivery_response: dict[str, Any] | None = None
     error: str | None = None
     created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
@@ -132,7 +135,39 @@ class StepResponse(BaseModel):
     posted: int
     failed: int
     lot_codes: list[str]
+    delivery_status: Literal["generated", "posted", "failed"]
+    delivery_mode: DestinationMode
+    delivery_attempts: int
     response: dict[str, Any] | None = None
+    error: str | None = None
+
+
+class DeliveryRetryRequest(BaseModel):
+    record_ids: list[str] | None = None
+    limit: int = 50
+    source: str | None = None
+    delivery: DeliveryConfig | None = None
+
+    @field_validator("limit")
+    @classmethod
+    def validate_limit(cls, value: int) -> int:
+        if value < 1 or value > 500:
+            raise ValueError("limit must be between 1 and 500")
+        return value
+
+
+class DeliveryRetryResponse(BaseModel):
+    status: Literal["empty", "posted", "partial", "failed", "skipped"]
+    requested: int
+    retryable: int
+    attempted: int
+    posted: int
+    failed: int
+    skipped: int
+    delivery_mode: DestinationMode
+    record_ids: list[str]
+    responses: list[dict[str, Any]] = Field(default_factory=list)
+    error: str | None = None
 
 
 class ReplayRequest(BaseModel):
@@ -150,6 +185,7 @@ class ReplayResponse(BaseModel):
     source: str
     persist_path: str
     delivery_mode: DestinationMode
+    delivery_attempts: int = 0
     response: dict[str, Any] | None = None
     error: str | None = None
 
@@ -178,6 +214,7 @@ class CSVImportResponse(BaseModel):
     failed: int
     source: str
     delivery_mode: DestinationMode
+    delivery_attempts: int = 0
     lot_codes: list[str]
     errors: list[CSVImportError] = Field(default_factory=list)
     response: dict[str, Any] | None = None

--- a/app/static/app.js
+++ b/app/static/app.js
@@ -26,6 +26,8 @@ const ids = {
   importResults: document.getElementById('importResults'),
   statusMessage: document.getElementById('statusMessage'),
   statsGrid: document.getElementById('statsGrid'),
+  deliverySummary: document.getElementById('deliverySummary'),
+  retryFailedBtn: document.getElementById('retryFailedBtn'),
   eventsBody: document.getElementById('eventsBody'),
   lotLookup: document.getElementById('lotLookup'),
   lineageResults: document.getElementById('lineageResults'),
@@ -123,6 +125,64 @@ function renderStats(status) {
     .join('');
 }
 
+function deliveryTone(deliveryStatus) {
+  if (deliveryStatus === 'posted') {
+    return 'success';
+  }
+  if (deliveryStatus === 'failed') {
+    return 'error';
+  }
+  return 'neutral';
+}
+
+function renderDeliverySummary(status) {
+  const delivery = status?.stats?.delivery || {};
+  const retryable = Number(delivery.retryable || 0);
+  ids.retryFailedBtn.disabled = retryable < 1;
+  const cards = [
+    ['Posted', delivery.posted ?? 0, 'success'],
+    ['Failed', delivery.failed ?? 0, retryable > 0 ? 'error' : 'neutral'],
+    ['Generated only', delivery.generated ?? 0, 'neutral'],
+    ['Attempts', delivery.attempts ?? 0, 'neutral'],
+  ];
+  const lastAttempt = delivery.last_attempt_at ? new Date(delivery.last_attempt_at).toLocaleString() : 'No attempts yet';
+  const lastSuccess = delivery.last_success_at ? new Date(delivery.last_success_at).toLocaleString() : 'No successful delivery yet';
+  ids.deliverySummary.innerHTML = `
+    <div class="delivery-cards">
+      ${cards
+        .map(
+          ([label, value, tone]) => `
+            <article class="delivery-card" data-tone="${tone}">
+              <span>${escapeHtml(label)}</span>
+              <strong>${escapeHtml(value)}</strong>
+            </article>
+          `,
+        )
+        .join('')}
+    </div>
+    <dl class="delivery-details">
+      <div>
+        <dt>Last attempt</dt>
+        <dd>${escapeHtml(lastAttempt)}</dd>
+      </div>
+      <div>
+        <dt>Last success</dt>
+        <dd>${escapeHtml(lastSuccess)}</dd>
+      </div>
+      ${
+        delivery.last_error
+          ? `
+            <div>
+              <dt>Last error</dt>
+              <dd data-tone="error">${escapeHtml(delivery.last_error)}</dd>
+            </div>
+          `
+          : ''
+      }
+    </dl>
+  `;
+}
+
 function escapeHtml(text) {
   return String(text)
     .replaceAll('&', '&amp;')
@@ -154,7 +214,7 @@ function renderEvents(events) {
   if (!events.length) {
     ids.eventsBody.innerHTML = `
       <tr>
-        <td colspan="7" class="empty-state">No events yet.</td>
+        <td colspan="9" class="empty-state">No events yet.</td>
       </tr>
     `;
     return;
@@ -170,7 +230,12 @@ function renderEvents(events) {
           <td>${escapeHtml(event.product_description)}</td>
           <td>${escapeHtml(event.location_name)}</td>
           <td>${escapeHtml(new Date(event.timestamp).toLocaleString())}</td>
-          <td>${escapeHtml(record.delivery_status)}</td>
+          <td>${escapeHtml(record.destination_mode)}</td>
+          <td>${escapeHtml(record.delivery_attempts || 0)}</td>
+          <td>
+            <span class="status-pill" data-tone="${deliveryTone(record.delivery_status)}">${escapeHtml(record.delivery_status)}</span>
+            ${record.error ? `<small class="status-error">${escapeHtml(record.error)}</small>` : ''}
+          </td>
         </tr>
       `;
     })
@@ -331,6 +396,7 @@ function renderSnapshot(status, events) {
   state.status = status;
   state.events = events;
   renderStats(status);
+  renderDeliverySummary(status);
   renderEvents(events);
   if (Date.now() >= state.statusHoldUntil) {
     setStatus(status.running ? 'Simulator loop is running.' : 'Simulator loop is stopped.');
@@ -423,7 +489,35 @@ async function stopLoop() {
 async function stepOnce() {
   try {
     const result = await api('/api/simulate/step', { method: 'POST' });
-    setStatus(`Generated ${result.generated} event(s).`, 'success', 2500);
+    if (result.delivery_status === 'failed') {
+      setStatus(`Generated ${result.generated} event(s), but delivery failed: ${result.error || 'delivery error'}`, 'error', 7000);
+    } else if (result.delivery_status === 'generated') {
+      setStatus(`Generated ${result.generated} event(s) without delivery.`, 'success', 2500);
+    } else {
+      setStatus(`Generated and posted ${result.posted} event(s).`, 'success', 2500);
+    }
+    await refresh();
+  } catch (error) {
+    setStatus(error.message, 'error', 5000);
+  }
+}
+
+async function retryFailedDeliveries() {
+  try {
+    const config = buildConfig();
+    const result = await api('/api/delivery/retry', {
+      method: 'POST',
+      body: JSON.stringify({ delivery: config.delivery, source: config.source }),
+    });
+    if (result.status === 'empty') {
+      setStatus('No failed deliveries are waiting to retry.', 'success', 2500);
+    } else if (result.status === 'skipped') {
+      setStatus(result.error || 'Retry skipped.', 'error', 5000);
+    } else if (result.failed > 0) {
+      setStatus(`Retried ${result.attempted} record(s): ${result.posted} posted, ${result.failed} failed.`, 'error', 7000);
+    } else {
+      setStatus(`Retried and posted ${result.posted} failed delivery record(s).`, 'success', 3500);
+    }
     await refresh();
   } catch (error) {
     setStatus(error.message, 'error', 5000);
@@ -515,6 +609,7 @@ document.getElementById('stopBtn').addEventListener('click', stopLoop);
 document.getElementById('stepBtn').addEventListener('click', stepOnce);
 document.getElementById('replayBtn').addEventListener('click', replayCurrentLog);
 document.getElementById('importCsvBtn').addEventListener('click', importCsv);
+document.getElementById('retryFailedBtn').addEventListener('click', retryFailedDeliveries);
 document.getElementById('resetBtn').addEventListener('click', resetState);
 document.getElementById('refreshBtn').addEventListener('click', refresh);
 document.getElementById('lineageBtn').addEventListener('click', lookupLineage);

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -106,6 +106,14 @@
 
       <section class="grid stats-grid" id="statsGrid"></section>
 
+      <section class="panel delivery-monitor">
+        <div class="section-head">
+          <h2>Delivery monitor</h2>
+          <button class="button secondary" id="retryFailedBtn" type="button">Retry failed deliveries</button>
+        </div>
+        <div id="deliverySummary" class="delivery-summary"></div>
+      </section>
+
       <section class="panel">
         <div class="section-head">
           <h2>Recent events</h2>
@@ -121,6 +129,8 @@
                 <th>Product</th>
                 <th>Location</th>
                 <th>Timestamp</th>
+                <th>Mode</th>
+                <th>Attempts</th>
                 <th>Status</th>
               </tr>
             </thead>

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -158,6 +158,12 @@ select {
   filter: brightness(1.06);
 }
 
+.button:disabled {
+  cursor: not-allowed;
+  filter: grayscale(0.7);
+  opacity: 0.55;
+}
+
 .table-wrap {
   overflow-x: auto;
 }
@@ -190,6 +196,35 @@ th {
   text-transform: uppercase;
 }
 
+.status-pill {
+  display: inline-flex;
+  border-radius: 999px;
+  padding: 4px 10px;
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--muted);
+  font-size: 0.82rem;
+  text-transform: uppercase;
+}
+
+.status-pill[data-tone="success"],
+.delivery-card[data-tone="success"] {
+  background: rgba(77, 212, 172, 0.12);
+  color: var(--success);
+}
+
+.status-pill[data-tone="error"],
+.delivery-card[data-tone="error"] {
+  background: rgba(255, 107, 107, 0.12);
+  color: var(--danger);
+}
+
+.status-error {
+  display: block;
+  max-width: 320px;
+  margin-top: 6px;
+  color: var(--danger);
+}
+
 .link-button {
   background: none;
   border: none;
@@ -202,6 +237,58 @@ th {
 .empty-state {
   text-align: center;
   color: var(--muted);
+}
+
+.delivery-summary {
+  display: grid;
+  gap: 14px;
+}
+
+.delivery-cards {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.delivery-card {
+  padding: 14px;
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.delivery-card span,
+.delivery-details dt {
+  display: block;
+  color: var(--muted);
+}
+
+.delivery-card strong {
+  display: block;
+  margin-top: 6px;
+  font-size: 1.1rem;
+}
+
+.delivery-details {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+  margin: 0;
+}
+
+.delivery-details div {
+  padding: 12px 14px;
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.delivery-details dd {
+  margin: 6px 0 0;
+  word-break: break-word;
+}
+
+.delivery-details dd[data-tone="error"] {
+  color: var(--danger);
 }
 
 .lineage-results {
@@ -361,6 +448,8 @@ th {
 
   .grid.two-up,
   .stats-grid,
+  .delivery-cards,
+  .delivery-details,
   .lineage-overview {
     grid-template-columns: 1fr;
   }

--- a/app/store.py
+++ b/app/store.py
@@ -70,9 +70,52 @@ class EventStore:
                     stored.append(record)
         return stored
 
+    def update_many(self, records: Iterable[StoredEventRecord]) -> list[StoredEventRecord]:
+        replacements = {record.record_id: record for record in records}
+        if not replacements:
+            return []
+
+        with self._lock:
+            current_records = list(self._records)
+            updated_records: list[StoredEventRecord] = []
+            for record in current_records:
+                replacement = replacements.get(record.record_id)
+                if replacement:
+                    replacement.sequence_no = record.sequence_no
+                    updated_records.append(replacement)
+                else:
+                    updated_records.append(record)
+
+            self._records = deque(updated_records, maxlen=self.max_records)
+            persisted_records = sorted(updated_records, key=lambda record: record.sequence_no)
+            tmp_path = self.persist_path.with_suffix(f"{self.persist_path.suffix}.tmp")
+            with tmp_path.open("w", encoding="utf-8") as handle:
+                for record in persisted_records:
+                    handle.write(json.dumps(record.model_dump(mode="json")) + "\n")
+            tmp_path.replace(self.persist_path)
+            self._counter = max((record.sequence_no for record in persisted_records), default=0)
+
+        return [record for record in updated_records if record.record_id in replacements]
+
     def recent(self, limit: int = 100) -> list[StoredEventRecord]:
         with self._lock:
             return list(self._records)[:limit]
+
+    def failed_delivery_records(
+        self,
+        record_ids: list[str] | None = None,
+        limit: int = 50,
+    ) -> list[StoredEventRecord]:
+        record_id_filter = set(record_ids or [])
+        with self._lock:
+            records = sorted(self._records, key=lambda record: record.sequence_no)
+        failed_records = [
+            record
+            for record in records
+            if record.delivery_status == "failed"
+            and (not record_id_filter or record.record_id in record_id_filter)
+        ]
+        return failed_records[:limit]
 
     def stats(self) -> dict[str, Any]:
         with self._lock:
@@ -81,12 +124,40 @@ class EventStore:
         status_counter = Counter(record.delivery_status for record in records)
         destination_counter = Counter(record.destination_mode.value for record in records)
         unique_lots = {record.event.traceability_lot_code for record in records}
+        last_attempt_at = max(
+            (record.last_delivery_attempt_at for record in records if record.last_delivery_attempt_at),
+            default=None,
+        )
+        last_success_at = max(
+            (record.last_delivery_success_at for record in records if record.last_delivery_success_at),
+            default=None,
+        )
+        failed_records = [
+            record
+            for record in records
+            if record.delivery_status == "failed" and record.error
+        ]
+        latest_failure = max(
+            failed_records,
+            key=lambda record: record.last_delivery_attempt_at or record.created_at,
+            default=None,
+        )
         return {
             "total_records": len(records),
             "unique_lots": len(unique_lots),
             "by_cte_type": dict(cte_counter),
             "by_delivery_status": dict(status_counter),
             "by_destination": dict(destination_counter),
+            "delivery": {
+                "posted": status_counter.get("posted", 0),
+                "failed": status_counter.get("failed", 0),
+                "generated": status_counter.get("generated", 0),
+                "retryable": status_counter.get("failed", 0),
+                "attempts": sum(record.delivery_attempts for record in records),
+                "last_attempt_at": last_attempt_at.isoformat() if last_attempt_at else None,
+                "last_success_at": last_success_at.isoformat() if last_success_at else None,
+                "last_error": latest_failure.error if latest_failure else None,
+            },
             "persist_path": str(self.persist_path),
         }
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -180,6 +180,78 @@ def test_reset_applies_configured_persist_path_for_next_step(tmp_path):
     assert len(custom_path.read_text(encoding="utf-8").splitlines()) == 1
 
 
+def test_failed_live_delivery_surfaces_retry_feedback_and_can_retry_to_mock(tmp_path):
+    custom_path = tmp_path / "failed-delivery-events.jsonl"
+    client.post(
+        "/api/simulate/reset",
+        json={
+            "batch_size": 1,
+            "seed": 204,
+            "persist_path": str(custom_path),
+            "delivery": {"mode": "live"},
+        },
+    )
+
+    step_response = client.post("/api/simulate/step")
+
+    assert step_response.status_code == 200
+    step_body = step_response.json()
+    assert step_body["generated"] == 1
+    assert step_body["posted"] == 0
+    assert step_body["failed"] == 1
+    assert step_body["delivery_status"] == "failed"
+    assert step_body["delivery_mode"] == "live"
+    assert step_body["delivery_attempts"] == 1
+    assert "api_key" in step_body["error"]
+
+    status = client.get("/api/simulate/status").json()
+    assert status["stats"]["delivery"]["failed"] == 1
+    assert status["stats"]["delivery"]["retryable"] == 1
+    assert status["stats"]["delivery"]["attempts"] == 1
+    assert "api_key" in status["stats"]["delivery"]["last_error"]
+
+    failed_record = client.get("/api/events?limit=1").json()["events"][0]
+    assert failed_record["delivery_status"] == "failed"
+    assert failed_record["delivery_attempts"] == 1
+    assert failed_record["last_delivery_attempt_at"]
+    assert failed_record["last_delivery_success_at"] is None
+
+    retry_response = client.post("/api/delivery/retry", json={"delivery": {"mode": "mock"}})
+
+    assert retry_response.status_code == 200
+    retry_body = retry_response.json()
+    assert retry_body["status"] == "posted"
+    assert retry_body["requested"] == 1
+    assert retry_body["retryable"] == 1
+    assert retry_body["attempted"] == 1
+    assert retry_body["posted"] == 1
+    assert retry_body["failed"] == 0
+    assert retry_body["delivery_mode"] == "mock"
+    assert retry_body["record_ids"] == [failed_record["record_id"]]
+
+    events = client.get("/api/events?limit=10").json()["events"]
+    assert len(events) == 1
+    retried_record = events[0]
+    assert retried_record["record_id"] == failed_record["record_id"]
+    assert retried_record["delivery_status"] == "posted"
+    assert retried_record["destination_mode"] == "mock"
+    assert retried_record["delivery_attempts"] == 2
+    assert retried_record["last_delivery_success_at"]
+    assert retried_record["error"] is None
+
+
+def test_delivery_retry_empty_when_no_failed_records():
+    response = client.post("/api/delivery/retry")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "empty"
+    assert body["requested"] == 0
+    assert body["retryable"] == 0
+    assert body["attempted"] == 0
+    assert body["record_ids"] == []
+
+
 def test_replay_current_persisted_log_posts_without_rewriting_records(tmp_path):
     custom_path = tmp_path / "replay-events.jsonl"
     reset_response = client.post(

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -55,6 +55,29 @@ def test_store_loads_existing_jsonl_records_on_initialization(tmp_path):
     assert stored[0].sequence_no == 3
 
 
+def test_store_updates_delivery_retry_metadata_on_disk(tmp_path):
+    persist_path = tmp_path / "events.jsonl"
+    store = EventStore(persist_path=str(persist_path))
+    stored = store.add_many([make_record("TLC-RETRY-000001", CTEType.HARVESTING, 0)])
+    failed_record = stored[0].model_copy(
+        update={
+            "delivery_status": "failed",
+            "delivery_attempts": 1,
+            "error": "temporary outage",
+        }
+    )
+    store.update_many([failed_record])
+
+    reloaded = EventStore(persist_path=str(persist_path))
+    record = reloaded.recent()[0]
+
+    assert record.record_id == stored[0].record_id
+    assert record.sequence_no == 1
+    assert record.delivery_status == "failed"
+    assert record.delivery_attempts == 1
+    assert record.error == "temporary outage"
+
+
 def test_lineage_for_transformed_output_includes_upstream_history_and_direct_query(tmp_path):
     store = EventStore(persist_path=str(tmp_path / "events.jsonl"))
     records = [


### PR DESCRIPTION
## Summary
- Track per-record delivery attempts and last delivery timestamps
- Add /api/delivery/retry for failed stored deliveries without duplicating records
- Surface delivery monitor stats and retry controls in the dashboard
- Update README and backlog status

## Verification
- pytest
- node --check app/static/app.js
- git diff --check
- Browser smoke: reset, step, lineage, failed live delivery, retry to mock, start, stop