### PR TITLE
Add FDA export presets

### DIFF
--- a/AUTOPILOT_TASKS.md
+++ b/AUTOPILOT_TASKS.md
@@ -21,7 +21,7 @@ This file is the standing backlog for unattended Codex runs.
 
 - [x] Add clearer lot-lineage views in the dashboard for transformed lots.
 - [x] Add richer operator-visible delivery status and retry feedback.
-- [ ] Add export presets that mimic common FDA-request slices.
+- [x] Add export presets that mimic common FDA-request slices.
 - [ ] Add deterministic scenario fixtures for demo playback.
 
 ## Priority 3

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A mock-first FSMA 204 traceability simulator that emits **RegEngine-compatible i
 - [Replay mode](#replay-mode)
 - [CSV import](#csv-import)
 - [Scenario presets](#scenario-presets)
+- [FDA export presets](#fda-export-presets)
 - [API reference](#api-reference)
 - [RegEngine payload contract](#regengine-payload-contract)
 - [Deployment](#deployment)
@@ -41,6 +42,7 @@ Each event is persisted with `event_id`, `sha256_hash`, and `chain_hash` so the 
 app/
   controller.py          # Simulator lifecycle (start/stop/step/reset)
   engine.py              # CTE generation and lot lineage logic
+  fda_export.py          # FDA-request CSV export presets and rendering
   main.py                # FastAPI app and route wiring
   mock_service.py        # Built-in mock RegEngine ingest endpoint
   models.py              # Pydantic models for config, events, payloads
@@ -81,7 +83,7 @@ Then open:
 http://127.0.0.1:8000
 ```
 
-The dashboard lets you choose a scenario preset, start/stop/step/reset the simulator, replay the current persisted event log, import CSV seed lots or scheduled events, inspect recent events, trace lot lineage, and export a mock FDA request CSV. It subscribes to live status/event snapshots with Server-Sent Events and falls back to refresh polling if the stream disconnects. Delivery mode defaults to **`mock`** so no credentials are required.
+The dashboard lets you choose a scenario preset, start/stop/step/reset the simulator, replay the current persisted event log, import CSV seed lots or scheduled events, inspect recent events, trace lot lineage, and export mock FDA request CSV presets. It subscribes to live status/event snapshots with Server-Sent Events and falls back to refresh polling if the stream disconnects. Delivery mode defaults to **`mock`** so no credentials are required.
 
 Event records are stored as JSONL at `config.persist_path` (`data/events.jsonl` by default). Existing records at that path are loaded when the app starts or when a start/reset request points at a different path; reset clears the currently configured event log. Replay reads the JSONL log without appending, duplicating, or rewriting stored events.
 
@@ -185,6 +187,15 @@ Use `config.scenario` to pick a deterministic product/location/flow mix without 
 
 Scenario selection is available in the dashboard, in `SimulationConfig`, and via `GET /api/scenarios`. The default is `leafy_greens_supplier`, and delivery still defaults to **`mock`**.
 
+## FDA export presets
+
+`GET /api/mock/regengine/export/fda-request` still returns the same 11-column FDA request CSV and remains backward compatible with optional `start_date` and `end_date` filters. It now also accepts:
+
+- `preset`: one of `all_records`, `lot_trace`, `shipment_handoff`, `receiving_log`, or `transformation_batches`
+- `traceability_lot_code`: optional for most presets, required for `lot_trace`
+
+If a lot code is supplied, the export is scoped to that lot's transitive lineage before applying the preset filter. `GET /api/mock/regengine/export/presets` returns the preset catalog used by the dashboard.
+
 ## API reference
 
 ### Simulator control
@@ -215,6 +226,7 @@ Scenario selection is available in the dashboard, in `SimulationConfig`, and via
 | Method | Path | Purpose |
 |---|---|---|
 | `POST` | `/api/mock/regengine/ingest` | Accepts RegEngine-shaped payloads |
+| `GET` | `/api/mock/regengine/export/presets` | List FDA request export presets |
 | `GET` | `/api/mock/regengine/export/fda-request` | Mock 11-column FDA request CSV |
 
 ### Example: start the simulator in live mode
@@ -308,6 +320,12 @@ curl http://127.0.0.1:8000/api/lineage/TLC-20260421-000003
 ```
 
 The lineage response keeps the original `records[]` event timeline and adds `nodes[]` plus `edges[]` so transformed outputs can be displayed as a lot graph. `nodes[]` summarizes each related lot, and `edges[]` links source/input lot codes to downstream packed or transformed lots.
+
+### Example: export a lot-trace FDA request slice
+
+```bash
+curl "http://127.0.0.1:8000/api/mock/regengine/export/fda-request?preset=lot_trace&traceability_lot_code=TLC-20260421-000003"
+```
 
 ## RegEngine payload contract
 

--- a/app/fda_export.py
+++ b/app/fda_export.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import csv
+import io
+from dataclasses import dataclass
+from typing import Callable, Iterable
+
+from .models import CTEType, FDAExportPreset, StoredEventRecord
+
+
+FDA_EXPORT_COLUMNS = [
+    "Traceability Lot Code",
+    "Traceability Lot Code Description",
+    "Product Description",
+    "Quantity",
+    "Unit of Measure",
+    "Location Description",
+    "Location Identifier (GLN)",
+    "Date",
+    "Time",
+    "Reference Document Type",
+    "Reference Document Number",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class FDAExportPresetDefinition:
+    id: FDAExportPreset
+    label: str
+    description: str
+    requires_lot_code: bool = False
+    cte_types: frozenset[CTEType] | None = None
+
+
+FDA_EXPORT_PRESETS = {
+    FDAExportPreset.ALL_RECORDS: FDAExportPresetDefinition(
+        id=FDAExportPreset.ALL_RECORDS,
+        label="All records",
+        description="Full FDA-request export for the selected date range.",
+    ),
+    FDAExportPreset.LOT_TRACE: FDAExportPresetDefinition(
+        id=FDAExportPreset.LOT_TRACE,
+        label="Lot trace",
+        description="Forward and backward lineage for one Traceability Lot Code.",
+        requires_lot_code=True,
+    ),
+    FDAExportPreset.SHIPMENT_HANDOFF: FDAExportPresetDefinition(
+        id=FDAExportPreset.SHIPMENT_HANDOFF,
+        label="Shipment handoff",
+        description="Shipping and receiving records with reference documents.",
+        cte_types=frozenset({CTEType.SHIPPING, CTEType.RECEIVING}),
+    ),
+    FDAExportPreset.RECEIVING_LOG: FDAExportPresetDefinition(
+        id=FDAExportPreset.RECEIVING_LOG,
+        label="Receiving log",
+        description="Receiving records for destination-focused FDA requests.",
+        cte_types=frozenset({CTEType.RECEIVING}),
+    ),
+    FDAExportPreset.TRANSFORMATION_BATCHES: FDAExportPresetDefinition(
+        id=FDAExportPreset.TRANSFORMATION_BATCHES,
+        label="Transformation batches",
+        description="Transformation events for batch and input-lot review.",
+        cte_types=frozenset({CTEType.TRANSFORMATION}),
+    ),
+}
+
+
+def list_fda_export_preset_summaries() -> list[dict[str, object]]:
+    return [
+        {
+            "id": preset.id,
+            "label": preset.label,
+            "description": preset.description,
+            "requires_lot_code": preset.requires_lot_code,
+        }
+        for preset in FDA_EXPORT_PRESETS.values()
+    ]
+
+
+def apply_fda_export_preset(
+    records: Iterable[StoredEventRecord],
+    preset_id: FDAExportPreset,
+) -> list[StoredEventRecord]:
+    definition = FDA_EXPORT_PRESETS[preset_id]
+    filtered = list(records)
+    if definition.cte_types is not None:
+        filtered = [record for record in filtered if record.event.cte_type in definition.cte_types]
+    return sorted(filtered, key=lambda record: record.event.timestamp)
+
+
+def render_fda_request_csv(
+    records: Iterable[StoredEventRecord],
+    location_gln: Callable[[str], str],
+) -> str:
+    output = io.StringIO()
+    writer = csv.DictWriter(output, fieldnames=FDA_EXPORT_COLUMNS)
+    writer.writeheader()
+    for record in records:
+        event = record.event
+        writer.writerow(
+            {
+                "Traceability Lot Code": event.traceability_lot_code,
+                "Traceability Lot Code Description": event.cte_type.value,
+                "Product Description": event.product_description,
+                "Quantity": event.quantity,
+                "Unit of Measure": event.unit_of_measure,
+                "Location Description": event.location_name,
+                "Location Identifier (GLN)": location_gln(event.location_name),
+                "Date": event.timestamp.date().isoformat(),
+                "Time": event.timestamp.time().isoformat(timespec="seconds"),
+                "Reference Document Type": event.kdes.get("reference_document_type", ""),
+                "Reference Document Number": event.kdes.get("reference_document_number", ""),
+            }
+        )
+    return output.getvalue()
+
+
+def export_filename(preset_id: FDAExportPreset) -> str:
+    return f"fda_request_{preset_id.value}.csv"

--- a/app/main.py
+++ b/app/main.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import csv
-import io
 import json
 from contextlib import asynccontextmanager
 from datetime import UTC, datetime
@@ -16,6 +14,13 @@ from fastapi.staticfiles import StaticFiles
 
 from .controller import SimulationController
 from .engine import LegitFlowEngine
+from .fda_export import (
+    FDA_EXPORT_PRESETS,
+    apply_fda_export_preset,
+    export_filename,
+    list_fda_export_preset_summaries,
+    render_fda_request_csv,
+)
 from .mock_service import MockRegEngineService
 from .models import (
     CSVImportRequest,
@@ -23,6 +28,9 @@ from .models import (
     DeliveryRetryRequest,
     DeliveryRetryResponse,
     EventListResponse,
+    FDAExportPreset,
+    FDAExportPresetListResponse,
+    FDAExportPresetSummary,
     IngestPayload,
     LineageResponse,
     MockIngestResponse,
@@ -205,49 +213,57 @@ async def mock_regengine_ingest(payload: IngestPayload) -> MockIngestResponse:
     return mock_service.ingest(payload)
 
 
+@app.get("/api/mock/regengine/export/presets", response_model=FDAExportPresetListResponse)
+async def mock_fda_request_export_presets() -> FDAExportPresetListResponse:
+    return FDAExportPresetListResponse(
+        presets=[
+            FDAExportPresetSummary.model_validate(summary)
+            for summary in list_fda_export_preset_summaries()
+        ]
+    )
+
+
 @app.get("/api/mock/regengine/export/fda-request")
 async def mock_fda_request_export(
     start_date: str | None = Query(default=None, description="Inclusive YYYY-MM-DD"),
     end_date: str | None = Query(default=None, description="Inclusive YYYY-MM-DD"),
+    preset: FDAExportPreset = Query(default=FDAExportPreset.ALL_RECORDS),
+    traceability_lot_code: str | None = Query(default=None),
 ) -> PlainTextResponse:
-    columns = [
-        "Traceability Lot Code",
-        "Traceability Lot Code Description",
-        "Product Description",
-        "Quantity",
-        "Unit of Measure",
-        "Location Description",
-        "Location Identifier (GLN)",
-        "Date",
-        "Time",
-        "Reference Document Type",
-        "Reference Document Number",
-    ]
-    output = io.StringIO()
-    writer = csv.DictWriter(output, fieldnames=columns)
-    writer.writeheader()
-    for record in store.all_between(start_date=start_date, end_date=end_date):
-        event = record.event
-        writer.writerow(
-            {
-                "Traceability Lot Code": event.traceability_lot_code,
-                "Traceability Lot Code Description": event.cte_type.value,
-                "Product Description": event.product_description,
-                "Quantity": event.quantity,
-                "Unit of Measure": event.unit_of_measure,
-                "Location Description": event.location_name,
-                "Location Identifier (GLN)": engine.location_gln(event.location_name),
-                "Date": event.timestamp.date().isoformat(),
-                "Time": event.timestamp.time().isoformat(timespec="seconds"),
-                "Reference Document Type": event.kdes.get("reference_document_type", ""),
-                "Reference Document Number": event.kdes.get("reference_document_number", ""),
-            }
-        )
+    definition = FDA_EXPORT_PRESETS[preset]
+    if definition.requires_lot_code and not traceability_lot_code:
+        raise HTTPException(status_code=400, detail="traceability_lot_code is required for this export preset")
+
+    if traceability_lot_code:
+        records = store.lineage(traceability_lot_code)
+        if not records:
+            raise HTTPException(status_code=404, detail="No records found for that lot code")
+        records = _filter_records_between(records, start_date=start_date, end_date=end_date)
+    else:
+        records = store.all_between(start_date=start_date, end_date=end_date)
+    records = apply_fda_export_preset(records, preset)
+    csv_text = render_fda_request_csv(records, location_gln=engine.location_gln)
     return PlainTextResponse(
-        content=output.getvalue(),
+        content=csv_text,
         media_type="text/csv",
-        headers={"Content-Disposition": "attachment; filename=fda_request_export.csv"},
+        headers={"Content-Disposition": f"attachment; filename={export_filename(preset)}"},
     )
+
+
+def _filter_records_between(
+    records: list[Any],
+    start_date: str | None = None,
+    end_date: str | None = None,
+) -> list[Any]:
+    filtered = []
+    for record in records:
+        day = record.event.timestamp.date().isoformat()
+        if start_date and day < start_date:
+            continue
+        if end_date and day > end_date:
+            continue
+        filtered.append(record)
+    return sorted(filtered, key=lambda record: record.event.timestamp)
 
 
 @app.exception_handler(ValueError)

--- a/app/models.py
+++ b/app/models.py
@@ -30,6 +30,14 @@ class CSVImportType(str, Enum):
     SEED_LOTS = "seed_lots"
 
 
+class FDAExportPreset(str, Enum):
+    ALL_RECORDS = "all_records"
+    LOT_TRACE = "lot_trace"
+    SHIPMENT_HANDOFF = "shipment_handoff"
+    RECEIVING_LOG = "receiving_log"
+    TRANSFORMATION_BATCHES = "transformation_batches"
+
+
 class RegEngineEvent(BaseModel):
     cte_type: CTEType
     traceability_lot_code: str
@@ -128,6 +136,17 @@ class ScenarioSummary(BaseModel):
 
 class ScenarioListResponse(BaseModel):
     scenarios: list[ScenarioSummary]
+
+
+class FDAExportPresetSummary(BaseModel):
+    id: FDAExportPreset
+    label: str
+    description: str
+    requires_lot_code: bool = False
+
+
+class FDAExportPresetListResponse(BaseModel):
+    presets: list[FDAExportPresetSummary]
 
 
 class StepResponse(BaseModel):

--- a/app/static/app.js
+++ b/app/static/app.js
@@ -9,6 +9,9 @@ const state = {
     fresh_cut_processor: 'Fresh-cut processor',
     retailer_readiness_demo: 'Retailer readiness demo',
   },
+  exportPresetDescriptions: {
+    all_records: 'Full FDA-request export for the selected date range.',
+  },
 };
 
 const ids = {
@@ -24,6 +27,12 @@ const ids = {
   csvImportType: document.getElementById('csvImportType'),
   csvFile: document.getElementById('csvFile'),
   importResults: document.getElementById('importResults'),
+  exportPreset: document.getElementById('exportPreset'),
+  exportLot: document.getElementById('exportLot'),
+  exportStartDate: document.getElementById('exportStartDate'),
+  exportEndDate: document.getElementById('exportEndDate'),
+  exportDownloadLink: document.getElementById('exportDownloadLink'),
+  exportPresetDescription: document.getElementById('exportPresetDescription'),
   statusMessage: document.getElementById('statusMessage'),
   statsGrid: document.getElementById('statsGrid'),
   deliverySummary: document.getElementById('deliverySummary'),
@@ -96,6 +105,47 @@ function renderScenarioOptions(scenarios) {
 async function loadScenarios() {
   const payload = await api('/api/scenarios');
   renderScenarioOptions(payload.scenarios || []);
+}
+
+function renderExportPresetOptions(presets) {
+  const selected = ids.exportPreset.value || 'all_records';
+  state.exportPresetDescriptions = Object.fromEntries(
+    presets.map((preset) => [preset.id, preset.description]),
+  );
+  ids.exportPreset.innerHTML = presets
+    .map(
+      (preset) => `
+        <option value="${escapeHtml(preset.id)}">${escapeHtml(preset.label)}</option>
+      `,
+    )
+    .join('');
+  ids.exportPreset.value = state.exportPresetDescriptions[selected] ? selected : presets[0]?.id || 'all_records';
+  updateExportLink();
+}
+
+async function loadExportPresets() {
+  const payload = await api('/api/mock/regengine/export/presets');
+  renderExportPresetOptions(payload.presets || []);
+}
+
+function updateExportLink() {
+  const params = new URLSearchParams();
+  const preset = ids.exportPreset.value || 'all_records';
+  const lotCode = ids.exportLot.value.trim();
+  const startDate = ids.exportStartDate.value;
+  const endDate = ids.exportEndDate.value;
+  params.set('preset', preset);
+  if (lotCode) {
+    params.set('traceability_lot_code', lotCode);
+  }
+  if (startDate) {
+    params.set('start_date', startDate);
+  }
+  if (endDate) {
+    params.set('end_date', endDate);
+  }
+  ids.exportDownloadLink.href = `/api/mock/regengine/export/fda-request?${params.toString()}`;
+  ids.exportPresetDescription.textContent = state.exportPresetDescriptions[preset] || 'FDA-request CSV export.';
 }
 
 function renderStats(status) {
@@ -613,8 +663,15 @@ document.getElementById('retryFailedBtn').addEventListener('click', retryFailedD
 document.getElementById('resetBtn').addEventListener('click', resetState);
 document.getElementById('refreshBtn').addEventListener('click', refresh);
 document.getElementById('lineageBtn').addEventListener('click', lookupLineage);
+ids.exportPreset.addEventListener('change', updateExportLink);
+ids.exportLot.addEventListener('input', updateExportLink);
+ids.exportStartDate.addEventListener('change', updateExportLink);
+ids.exportEndDate.addEventListener('change', updateExportLink);
 
 loadScenarios().catch((error) => {
+  setStatus(error.message, 'error', 5000);
+});
+loadExportPresets().catch((error) => {
   setStatus(error.message, 'error', 5000);
 });
 connectLiveUpdates();

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -104,6 +104,34 @@
         <div id="importResults" class="import-results"></div>
       </section>
 
+      <section class="panel">
+        <div class="section-head">
+          <h2>FDA export presets</h2>
+          <a class="button secondary" id="exportDownloadLink" href="/api/mock/regengine/export/fda-request" target="_blank" rel="noreferrer">Download CSV</a>
+        </div>
+        <div class="grid two-up">
+          <label>
+            Export preset
+            <select id="exportPreset" name="exportPreset">
+              <option value="all_records" selected>All records</option>
+            </select>
+          </label>
+          <label>
+            Traceability Lot Code
+            <input id="exportLot" name="exportLot" placeholder="Optional unless preset requires one" />
+          </label>
+          <label>
+            Start date
+            <input id="exportStartDate" name="exportStartDate" type="date" />
+          </label>
+          <label>
+            End date
+            <input id="exportEndDate" name="exportEndDate" type="date" />
+          </label>
+        </div>
+        <p class="note" id="exportPresetDescription">Full FDA-request export for the selected date range.</p>
+      </section>
+
       <section class="grid stats-grid" id="statsGrid"></section>
 
       <section class="panel delivery-monitor">

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,4 +1,6 @@
 import asyncio
+import csv
+import io
 import json
 
 from fastapi.testclient import TestClient
@@ -131,6 +133,91 @@ def test_fda_export_shape_contains_expected_columns():
     assert "Traceability Lot Code" in csv_text
     assert "Location Identifier (GLN)" in csv_text
     assert "Reference Document Number" in csv_text
+
+
+def parse_export_rows(csv_text: str) -> list[dict[str, str]]:
+    return list(csv.DictReader(io.StringIO(csv_text)))
+
+
+def test_fda_export_presets_filter_common_request_slices(tmp_path):
+    custom_path = tmp_path / "fda-preset-events.jsonl"
+    client.post(
+        "/api/simulate/reset",
+        json={
+            "batch_size": 1,
+            "seed": 204,
+            "persist_path": str(custom_path),
+            "delivery": {"mode": "none"},
+        },
+    )
+    csv_text = """cte_type,traceability_lot_code,product_description,quantity,unit_of_measure,location_name,timestamp,source_traceability_lot_code,input_traceability_lot_codes,reference_document_type,reference_document_number
+harvesting,TLC-FDA-HARVEST,Romaine Lettuce,120,cases,Valley Fresh Farms,2026-02-05T08:00:00Z,,,Harvest Log,HAR-001
+initial_packing,TLC-FDA-PACKED,Romaine Lettuce,112,cases,Coastal Packhouse,2026-02-05T10:00:00Z,TLC-FDA-HARVEST,,Packout Record,PACK-001
+shipping,TLC-FDA-PACKED,Romaine Lettuce,112,cases,Coastal Packhouse,2026-02-05T12:00:00Z,,,Bill of Lading,BOL-001
+receiving,TLC-FDA-PACKED,Romaine Lettuce,112,cases,Distribution Center #4,2026-02-05T18:00:00Z,,,Bill of Lading,BOL-001
+transformation,TLC-FDA-OUT,Fresh Cut Salad Mix,95,cases,ReadyFresh Processing Plant,2026-02-06T09:00:00Z,,TLC-FDA-PACKED,Batch Record,BATCH-001
+"""
+    import_response = client.post(
+        "/api/import/csv",
+        json={
+            "import_type": "scheduled_events",
+            "csv_text": csv_text,
+            "delivery": {"mode": "none"},
+        },
+    )
+    assert import_response.status_code == 200
+    assert import_response.json()["accepted"] == 5
+
+    presets_response = client.get("/api/mock/regengine/export/presets")
+    assert presets_response.status_code == 200
+    preset_ids = [preset["id"] for preset in presets_response.json()["presets"]]
+    assert preset_ids == [
+        "all_records",
+        "lot_trace",
+        "shipment_handoff",
+        "receiving_log",
+        "transformation_batches",
+    ]
+
+    handoff_response = client.get("/api/mock/regengine/export/fda-request?preset=shipment_handoff")
+    assert handoff_response.status_code == 200
+    handoff_rows = parse_export_rows(handoff_response.text)
+    assert [row["Traceability Lot Code Description"] for row in handoff_rows] == [
+        "shipping",
+        "receiving",
+    ]
+    assert handoff_rows[0]["Reference Document Number"] == "BOL-001"
+    assert handoff_response.headers["content-disposition"] == (
+        "attachment; filename=fda_request_shipment_handoff.csv"
+    )
+
+    trace_response = client.get(
+        "/api/mock/regengine/export/fda-request?preset=lot_trace&traceability_lot_code=TLC-FDA-OUT"
+    )
+    assert trace_response.status_code == 200
+    trace_rows = parse_export_rows(trace_response.text)
+    assert [row["Traceability Lot Code"] for row in trace_rows] == [
+        "TLC-FDA-HARVEST",
+        "TLC-FDA-PACKED",
+        "TLC-FDA-PACKED",
+        "TLC-FDA-PACKED",
+        "TLC-FDA-OUT",
+    ]
+
+    receiving_response = client.get("/api/mock/regengine/export/fda-request?preset=receiving_log")
+    assert receiving_response.status_code == 200
+    receiving_rows = parse_export_rows(receiving_response.text)
+    assert [row["Traceability Lot Code Description"] for row in receiving_rows] == ["receiving"]
+
+    transformation_response = client.get(
+        "/api/mock/regengine/export/fda-request?preset=transformation_batches"
+    )
+    assert transformation_response.status_code == 200
+    transformation_rows = parse_export_rows(transformation_response.text)
+    assert [row["Traceability Lot Code"] for row in transformation_rows] == ["TLC-FDA-OUT"]
+
+    missing_lot_response = client.get("/api/mock/regengine/export/fda-request?preset=lot_trace")
+    assert missing_lot_response.status_code == 400
 
 
 def test_start_applies_configured_persist_path_and_keeps_mock_default(tmp_path):


### PR DESCRIPTION
## Summary
- Add FDA export preset catalog and reusable CSV rendering
- Extend the existing FDA request export with preset and lot-trace filters while keeping the default all-records behavior
- Add dashboard controls for export preset, lot code, and date filters
- Update README and backlog status

## Verification
- pytest
- node --check app/static/app.js
- git diff --check
- Browser smoke: reset, step, lineage, export preset selector, lot-trace CSV link/content