### PR TITLE
[codex] Add deterministic demo fixtures

### DIFF
--- a/AUTOPILOT_TASKS.md
+++ b/AUTOPILOT_TASKS.md
@@ -22,7 +22,7 @@ This file is the standing backlog for unattended Codex runs.
 - [x] Add clearer lot-lineage views in the dashboard for transformed lots.
 - [x] Add richer operator-visible delivery status and retry feedback.
 - [x] Add export presets that mimic common FDA-request slices.
-- [ ] Add deterministic scenario fixtures for demo playback.
+- [x] Add deterministic scenario fixtures for demo playback.
 
 ## Priority 3
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A mock-first FSMA 204 traceability simulator that emits **RegEngine-compatible i
 - [Replay mode](#replay-mode)
 - [CSV import](#csv-import)
 - [Scenario presets](#scenario-presets)
+- [Demo fixtures](#demo-fixtures)
 - [FDA export presets](#fda-export-presets)
 - [API reference](#api-reference)
 - [RegEngine payload contract](#regengine-payload-contract)
@@ -41,6 +42,7 @@ Each event is persisted with `event_id`, `sha256_hash`, and `chain_hash` so the 
 ```text
 app/
   controller.py          # Simulator lifecycle (start/stop/step/reset)
+  demo_fixtures.py       # Deterministic demo playback fixtures
   engine.py              # CTE generation and lot lineage logic
   fda_export.py          # FDA-request CSV export presets and rendering
   main.py                # FastAPI app and route wiring
@@ -83,7 +85,7 @@ Then open:
 http://127.0.0.1:8000
 ```
 
-The dashboard lets you choose a scenario preset, start/stop/step/reset the simulator, replay the current persisted event log, import CSV seed lots or scheduled events, inspect recent events, trace lot lineage, and export mock FDA request CSV presets. It subscribes to live status/event snapshots with Server-Sent Events and falls back to refresh polling if the stream disconnects. Delivery mode defaults to **`mock`** so no credentials are required.
+The dashboard lets you choose a scenario preset, load deterministic demo fixtures, start/stop/step/reset the simulator, replay the current persisted event log, import CSV seed lots or scheduled events, inspect recent events, trace lot lineage, and export mock FDA request CSV presets. It subscribes to live status/event snapshots with Server-Sent Events and falls back to refresh polling if the stream disconnects. Delivery mode defaults to **`mock`** so no credentials are required.
 
 Event records are stored as JSONL at `config.persist_path` (`data/events.jsonl` by default). Existing records at that path are loaded when the app starts or when a start/reset request points at a different path; reset clears the currently configured event log. Replay reads the JSONL log without appending, duplicating, or rewriting stored events.
 
@@ -187,6 +189,20 @@ Use `config.scenario` to pick a deterministic product/location/flow mix without 
 
 Scenario selection is available in the dashboard, in `SimulationConfig`, and via `GET /api/scenarios`. The default is `leafy_greens_supplier`, and delivery still defaults to **`mock`**.
 
+## Demo fixtures
+
+Use `GET /api/demo-fixtures` to list deterministic demo playback fixtures. Each fixture contains fixed RegEngine-shaped events with stable timestamps, lot codes, reference documents, and parent-lot lineage. `POST /api/demo-fixtures/{fixture_id}/load` loads a fixture into the event store and optionally delivers it through `mock`, `live`, or `none` delivery.
+
+Supported fixture IDs:
+
+| Fixture | Value | Demo emphasis |
+|---|---|---|
+| Leafy greens trace | `leafy_greens_trace` | One leafy greens lot from harvest through DC receipt |
+| Fresh-cut transformation | `fresh_cut_transformation` | Two ingredient lots transformed into one fresh-cut output lot |
+| Retailer handoff | `retailer_handoff` | Retail-ready cases through DC and store receipts |
+
+The dashboard fixture loader resets the current event log before loading the selected fixture so demos start from a known state.
+
 ## FDA export presets
 
 `GET /api/mock/regengine/export/fda-request` still returns the same 11-column FDA request CSV and remains backward compatible with optional `start_date` and `end_date` filters. It now also accepts:
@@ -204,6 +220,8 @@ If a lot code is supplied, the export is scoped to that lot's transitive lineage
 |---|---|---|
 | `GET` | `/api/health` | Liveness probe + current config snapshot |
 | `GET` | `/api/scenarios` | List available scenario presets |
+| `GET` | `/api/demo-fixtures` | List deterministic demo playback fixtures |
+| `POST` | `/api/demo-fixtures/{fixture_id}/load` | Load a deterministic fixture into the event store |
 | `GET` | `/api/simulate/status` | Running state, config, and aggregate stats |
 | `POST` | `/api/simulate/start` | Start the loop (accepts a `config` body) |
 | `POST` | `/api/simulate/stop` | Stop the loop |
@@ -271,6 +289,19 @@ curl -X POST http://127.0.0.1:8000/api/simulate/step
 ```bash
 curl -X POST http://127.0.0.1:8000/api/simulate/step
 curl http://127.0.0.1:8000/api/events
+```
+
+### Example: load a deterministic fresh-cut demo fixture
+
+```bash
+curl -X POST http://127.0.0.1:8000/api/demo-fixtures/fresh_cut_transformation/load \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "reset": true,
+    "delivery": {
+      "mode": "mock"
+    }
+  }'
 ```
 
 ### Example: replay the current persisted log

--- a/app/controller.py
+++ b/app/controller.py
@@ -6,11 +6,15 @@ from datetime import UTC, datetime
 from typing import Any
 
 from .csv_importer import parse_csv_import
+from .demo_fixtures import get_demo_fixture
 from .engine import LegitFlowEngine
 from .mock_service import MockRegEngineService
 from .models import (
     CSVImportRequest,
     CSVImportResponse,
+    DemoFixtureId,
+    DemoFixtureLoadRequest,
+    DemoFixtureLoadResponse,
     DeliveryRetryRequest,
     DeliveryRetryResponse,
     DestinationMode,
@@ -267,6 +271,74 @@ class SimulationController:
                 delivery_attempts=outcome.delivery_attempts,
                 lot_codes=[event.traceability_lot_code for event in parsed.events],
                 errors=parsed.errors,
+                response=outcome.response,
+                error=outcome.error_message,
+            )
+        await self._publish_update()
+        return result
+
+    async def load_demo_fixture(
+        self,
+        fixture_id: DemoFixtureId,
+        request: DemoFixtureLoadRequest | None = None,
+    ) -> DemoFixtureLoadResponse:
+        request = request or DemoFixtureLoadRequest()
+        fixture = get_demo_fixture(fixture_id)
+        await self.stop()
+
+        async with self._lock:
+            source = request.source or self.config.source
+            delivery = request.delivery or self.config.delivery
+            self.config = self.config.model_copy(
+                update={
+                    "source": source,
+                    "scenario": fixture.scenario,
+                    "delivery": delivery,
+                },
+                deep=True,
+            )
+            self.store.configure(self.config.persist_path)
+            self.engine.reset(self.config.seed, scenario=fixture.scenario)
+            if request.reset:
+                self.store.reset()
+                self.mock_service.reset()
+
+            events = [fixture_event.event for fixture_event in fixture.events]
+            payload = IngestPayload(source=source, events=events)
+            outcome = await self._deliver_payload(payload, self.config)
+            response_events = (outcome.response or {}).get("events", []) if outcome.response else []
+            stored_records = []
+            for index, fixture_event in enumerate(fixture.events):
+                event_response = response_events[index] if index < len(response_events) else None
+                stored_records.append(
+                    StoredEventRecord(
+                        payload_source=source,
+                        event=fixture_event.event,
+                        parent_lot_codes=list(fixture_event.parent_lot_codes),
+                        destination_mode=delivery.mode,
+                        delivery_status=outcome.delivery_status,
+                        delivery_attempts=outcome.delivery_attempts,
+                        last_delivery_attempt_at=outcome.attempted_at,
+                        last_delivery_success_at=outcome.completed_at
+                        if outcome.delivery_status == "posted"
+                        else None,
+                        delivery_response=event_response,
+                        error=outcome.error_message,
+                    )
+                )
+            self.store.add_many(stored_records)
+            result = DemoFixtureLoadResponse(
+                status="delivery_failed" if outcome.delivery_status == "failed" else "loaded",
+                fixture_id=fixture.id,
+                scenario=fixture.scenario,
+                loaded=len(events),
+                stored=len(stored_records),
+                posted=outcome.posted,
+                failed=outcome.failed,
+                source=source,
+                delivery_mode=delivery.mode,
+                delivery_attempts=outcome.delivery_attempts,
+                lot_codes=fixture.lot_codes,
                 response=outcome.response,
                 error=outcome.error_message,
             )

--- a/app/demo_fixtures.py
+++ b/app/demo_fixtures.py
@@ -1,0 +1,602 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+from .models import CTEType, DemoFixtureId, RegEngineEvent
+from .scenarios import ScenarioId
+
+
+@dataclass(frozen=True, slots=True)
+class DemoFixtureEvent:
+    event: RegEngineEvent
+    parent_lot_codes: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class DemoFixture:
+    id: DemoFixtureId
+    label: str
+    description: str
+    scenario: ScenarioId
+    events: tuple[DemoFixtureEvent, ...]
+
+    @property
+    def lot_codes(self) -> list[str]:
+        lot_codes = []
+        for fixture_event in self.events:
+            lot_code = fixture_event.event.traceability_lot_code
+            if lot_code not in lot_codes:
+                lot_codes.append(lot_code)
+        return lot_codes
+
+
+def dt(value: str) -> datetime:
+    return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(UTC)
+
+
+def event(
+    cte_type: CTEType,
+    lot_code: str,
+    product_description: str,
+    quantity: float,
+    unit_of_measure: str,
+    location_name: str,
+    timestamp: str,
+    kdes: dict,
+) -> RegEngineEvent:
+    return RegEngineEvent(
+        cte_type=cte_type,
+        traceability_lot_code=lot_code,
+        product_description=product_description,
+        quantity=quantity,
+        unit_of_measure=unit_of_measure,
+        location_name=location_name,
+        timestamp=dt(timestamp),
+        kdes=kdes,
+    )
+
+
+DEMO_FIXTURES: dict[DemoFixtureId, DemoFixture] = {
+    DemoFixtureId.LEAFY_GREENS_TRACE: DemoFixture(
+        id=DemoFixtureId.LEAFY_GREENS_TRACE,
+        label="Leafy greens trace",
+        description="Harvest through cooling, packout, shipment, and DC receipt for one leafy greens lot.",
+        scenario=ScenarioId.LEAFY_GREENS_SUPPLIER,
+        events=(
+            DemoFixtureEvent(
+                event(
+                    CTEType.HARVESTING,
+                    "TLC-DEMO-LG-HARVEST-001",
+                    "Romaine Lettuce",
+                    420,
+                    "cases",
+                    "Valley Fresh Farms",
+                    "2026-02-05T08:00:00Z",
+                    {
+                        "harvest_date": "2026-02-05",
+                        "farm_location": "Valley Fresh Farms",
+                        "field_name": "Field-7",
+                        "immediate_subsequent_recipient": "Salinas Cooling Hub",
+                        "reference_document_type": "Harvest Log",
+                        "reference_document_number": "HAR-DEMO-LG-001",
+                        "traceability_lot_code_source_reference": "SRC-DEMO-LG-001",
+                    },
+                )
+            ),
+            DemoFixtureEvent(
+                event(
+                    CTEType.COOLING,
+                    "TLC-DEMO-LG-HARVEST-001",
+                    "Romaine Lettuce",
+                    420,
+                    "cases",
+                    "Salinas Cooling Hub",
+                    "2026-02-05T09:10:00Z",
+                    {
+                        "cooling_date": "2026-02-05",
+                        "cooling_location": "Salinas Cooling Hub",
+                        "harvest_location": "Valley Fresh Farms",
+                        "reference_document_type": "Cooling Log",
+                        "reference_document_number": "COOL-DEMO-LG-001",
+                        "traceability_lot_code_source_reference": "SRC-DEMO-LG-001",
+                    },
+                )
+            ),
+            DemoFixtureEvent(
+                event(
+                    CTEType.INITIAL_PACKING,
+                    "TLC-DEMO-LG-PACK-001",
+                    "Romaine Lettuce",
+                    396,
+                    "cases",
+                    "FreshPack Central",
+                    "2026-02-05T11:30:00Z",
+                    {
+                        "pack_date": "2026-02-05",
+                        "packing_location": "FreshPack Central",
+                        "source_traceability_lot_code": "TLC-DEMO-LG-HARVEST-001",
+                        "farm_location": "Valley Fresh Farms",
+                        "reference_document_type": "Packout Record",
+                        "reference_document_number": "PACK-DEMO-LG-001",
+                        "traceability_lot_code_source_reference": "SRC-DEMO-LG-PACK-001",
+                    },
+                ),
+                parent_lot_codes=("TLC-DEMO-LG-HARVEST-001",),
+            ),
+            DemoFixtureEvent(
+                event(
+                    CTEType.SHIPPING,
+                    "TLC-DEMO-LG-PACK-001",
+                    "Romaine Lettuce",
+                    396,
+                    "cases",
+                    "FreshPack Central",
+                    "2026-02-05T14:00:00Z",
+                    {
+                        "ship_date": "2026-02-05",
+                        "ship_from_location": "FreshPack Central",
+                        "ship_to_location": "Distribution Center #4",
+                        "carrier": "ColdRoute Freight",
+                        "reference_document_type": "Bill of Lading",
+                        "reference_document_number": "BOL-DEMO-LG-001",
+                        "traceability_lot_code_source_reference": "SRC-DEMO-LG-PACK-001",
+                    },
+                )
+            ),
+            DemoFixtureEvent(
+                event(
+                    CTEType.RECEIVING,
+                    "TLC-DEMO-LG-PACK-001",
+                    "Romaine Lettuce",
+                    396,
+                    "cases",
+                    "Distribution Center #4",
+                    "2026-02-05T19:15:00Z",
+                    {
+                        "receive_date": "2026-02-05",
+                        "receiving_location": "Distribution Center #4",
+                        "ship_from_location": "FreshPack Central",
+                        "reference_document_type": "Bill of Lading",
+                        "reference_document_number": "BOL-DEMO-LG-001",
+                        "traceability_lot_code_source_reference": "SRC-DEMO-LG-PACK-001",
+                    },
+                )
+            ),
+        ),
+    ),
+    DemoFixtureId.FRESH_CUT_TRANSFORMATION: DemoFixture(
+        id=DemoFixtureId.FRESH_CUT_TRANSFORMATION,
+        label="Fresh-cut transformation",
+        description="Two ingredient lots received by a processor and transformed into a fresh-cut output lot.",
+        scenario=ScenarioId.FRESH_CUT_PROCESSOR,
+        events=(
+            DemoFixtureEvent(
+                event(
+                    CTEType.HARVESTING,
+                    "TLC-DEMO-FC-HARVEST-001",
+                    "Romaine Lettuce",
+                    300,
+                    "cases",
+                    "Valley Fresh Farms",
+                    "2026-02-06T07:45:00Z",
+                    {
+                        "harvest_date": "2026-02-06",
+                        "farm_location": "Valley Fresh Farms",
+                        "field_name": "Field-3",
+                        "immediate_subsequent_recipient": "Salinas Cooling Hub",
+                        "reference_document_type": "Harvest Log",
+                        "reference_document_number": "HAR-DEMO-FC-001",
+                        "traceability_lot_code_source_reference": "SRC-DEMO-FC-001",
+                    },
+                )
+            ),
+            DemoFixtureEvent(
+                event(
+                    CTEType.HARVESTING,
+                    "TLC-DEMO-FC-HARVEST-002",
+                    "Spinach",
+                    260,
+                    "cases",
+                    "Coastal Leaf Farm",
+                    "2026-02-06T08:05:00Z",
+                    {
+                        "harvest_date": "2026-02-06",
+                        "farm_location": "Coastal Leaf Farm",
+                        "field_name": "Field-11",
+                        "immediate_subsequent_recipient": "Coastal Cold Chain",
+                        "reference_document_type": "Harvest Log",
+                        "reference_document_number": "HAR-DEMO-FC-002",
+                        "traceability_lot_code_source_reference": "SRC-DEMO-FC-002",
+                    },
+                )
+            ),
+            DemoFixtureEvent(
+                event(
+                    CTEType.COOLING,
+                    "TLC-DEMO-FC-HARVEST-001",
+                    "Romaine Lettuce",
+                    300,
+                    "cases",
+                    "Salinas Cooling Hub",
+                    "2026-02-06T09:10:00Z",
+                    {
+                        "cooling_date": "2026-02-06",
+                        "cooling_location": "Salinas Cooling Hub",
+                        "harvest_location": "Valley Fresh Farms",
+                        "reference_document_type": "Cooling Log",
+                        "reference_document_number": "COOL-DEMO-FC-001",
+                        "traceability_lot_code_source_reference": "SRC-DEMO-FC-001",
+                    },
+                )
+            ),
+            DemoFixtureEvent(
+                event(
+                    CTEType.COOLING,
+                    "TLC-DEMO-FC-HARVEST-002",
+                    "Spinach",
+                    260,
+                    "cases",
+                    "Coastal Cold Chain",
+                    "2026-02-06T09:35:00Z",
+                    {
+                        "cooling_date": "2026-02-06",
+                        "cooling_location": "Coastal Cold Chain",
+                        "harvest_location": "Coastal Leaf Farm",
+                        "reference_document_type": "Cooling Log",
+                        "reference_document_number": "COOL-DEMO-FC-002",
+                        "traceability_lot_code_source_reference": "SRC-DEMO-FC-002",
+                    },
+                )
+            ),
+            DemoFixtureEvent(
+                event(
+                    CTEType.INITIAL_PACKING,
+                    "TLC-DEMO-FC-PACK-001",
+                    "Romaine Lettuce",
+                    288,
+                    "cases",
+                    "Processor Intake Packout",
+                    "2026-02-06T11:00:00Z",
+                    {
+                        "pack_date": "2026-02-06",
+                        "packing_location": "Processor Intake Packout",
+                        "source_traceability_lot_code": "TLC-DEMO-FC-HARVEST-001",
+                        "farm_location": "Valley Fresh Farms",
+                        "reference_document_type": "Packout Record",
+                        "reference_document_number": "PACK-DEMO-FC-001",
+                        "traceability_lot_code_source_reference": "SRC-DEMO-FC-PACK-001",
+                    },
+                ),
+                parent_lot_codes=("TLC-DEMO-FC-HARVEST-001",),
+            ),
+            DemoFixtureEvent(
+                event(
+                    CTEType.INITIAL_PACKING,
+                    "TLC-DEMO-FC-PACK-002",
+                    "Spinach",
+                    248,
+                    "cases",
+                    "Processor Intake Packout",
+                    "2026-02-06T11:20:00Z",
+                    {
+                        "pack_date": "2026-02-06",
+                        "packing_location": "Processor Intake Packout",
+                        "source_traceability_lot_code": "TLC-DEMO-FC-HARVEST-002",
+                        "farm_location": "Coastal Leaf Farm",
+                        "reference_document_type": "Packout Record",
+                        "reference_document_number": "PACK-DEMO-FC-002",
+                        "traceability_lot_code_source_reference": "SRC-DEMO-FC-PACK-002",
+                    },
+                ),
+                parent_lot_codes=("TLC-DEMO-FC-HARVEST-002",),
+            ),
+            DemoFixtureEvent(
+                event(
+                    CTEType.SHIPPING,
+                    "TLC-DEMO-FC-PACK-001",
+                    "Romaine Lettuce",
+                    288,
+                    "cases",
+                    "Processor Intake Packout",
+                    "2026-02-06T12:10:00Z",
+                    {
+                        "ship_date": "2026-02-06",
+                        "ship_from_location": "Processor Intake Packout",
+                        "ship_to_location": "ReadyFresh Processing Plant",
+                        "carrier": "PrepLine Logistics",
+                        "reference_document_type": "Bill of Lading",
+                        "reference_document_number": "BOL-DEMO-FC-001",
+                        "traceability_lot_code_source_reference": "SRC-DEMO-FC-PACK-001",
+                    },
+                )
+            ),
+            DemoFixtureEvent(
+                event(
+                    CTEType.SHIPPING,
+                    "TLC-DEMO-FC-PACK-002",
+                    "Spinach",
+                    248,
+                    "cases",
+                    "Processor Intake Packout",
+                    "2026-02-06T12:15:00Z",
+                    {
+                        "ship_date": "2026-02-06",
+                        "ship_from_location": "Processor Intake Packout",
+                        "ship_to_location": "ReadyFresh Processing Plant",
+                        "carrier": "PrepLine Logistics",
+                        "reference_document_type": "Bill of Lading",
+                        "reference_document_number": "BOL-DEMO-FC-002",
+                        "traceability_lot_code_source_reference": "SRC-DEMO-FC-PACK-002",
+                    },
+                )
+            ),
+            DemoFixtureEvent(
+                event(
+                    CTEType.RECEIVING,
+                    "TLC-DEMO-FC-PACK-001",
+                    "Romaine Lettuce",
+                    288,
+                    "cases",
+                    "ReadyFresh Processing Plant",
+                    "2026-02-06T14:30:00Z",
+                    {
+                        "receive_date": "2026-02-06",
+                        "receiving_location": "ReadyFresh Processing Plant",
+                        "ship_from_location": "Processor Intake Packout",
+                        "reference_document_type": "Bill of Lading",
+                        "reference_document_number": "BOL-DEMO-FC-001",
+                        "traceability_lot_code_source_reference": "SRC-DEMO-FC-PACK-001",
+                    },
+                )
+            ),
+            DemoFixtureEvent(
+                event(
+                    CTEType.RECEIVING,
+                    "TLC-DEMO-FC-PACK-002",
+                    "Spinach",
+                    248,
+                    "cases",
+                    "ReadyFresh Processing Plant",
+                    "2026-02-06T14:40:00Z",
+                    {
+                        "receive_date": "2026-02-06",
+                        "receiving_location": "ReadyFresh Processing Plant",
+                        "ship_from_location": "Processor Intake Packout",
+                        "reference_document_type": "Bill of Lading",
+                        "reference_document_number": "BOL-DEMO-FC-002",
+                        "traceability_lot_code_source_reference": "SRC-DEMO-FC-PACK-002",
+                    },
+                )
+            ),
+            DemoFixtureEvent(
+                event(
+                    CTEType.TRANSFORMATION,
+                    "TLC-DEMO-FC-OUT-001",
+                    "Fresh Cut Salad Mix",
+                    430,
+                    "cases",
+                    "ReadyFresh Processing Plant",
+                    "2026-02-06T17:20:00Z",
+                    {
+                        "transformation_date": "2026-02-06",
+                        "transformation_location": "ReadyFresh Processing Plant",
+                        "input_traceability_lot_codes": [
+                            "TLC-DEMO-FC-PACK-001",
+                            "TLC-DEMO-FC-PACK-002",
+                        ],
+                        "input_products": ["Romaine Lettuce", "Spinach"],
+                        "reference_document_type": "Batch Record",
+                        "reference_document_number": "BATCH-DEMO-FC-001",
+                        "yield_ratio": 0.802,
+                        "traceability_lot_code_source_reference": "SRC-DEMO-FC-OUT-001",
+                    },
+                ),
+                parent_lot_codes=("TLC-DEMO-FC-PACK-001", "TLC-DEMO-FC-PACK-002"),
+            ),
+            DemoFixtureEvent(
+                event(
+                    CTEType.SHIPPING,
+                    "TLC-DEMO-FC-OUT-001",
+                    "Fresh Cut Salad Mix",
+                    430,
+                    "cases",
+                    "ReadyFresh Processing Plant",
+                    "2026-02-06T20:00:00Z",
+                    {
+                        "ship_date": "2026-02-06",
+                        "ship_from_location": "ReadyFresh Processing Plant",
+                        "ship_to_location": "Foodservice DC #12",
+                        "carrier": "ColdRoute Freight",
+                        "reference_document_type": "Bill of Lading",
+                        "reference_document_number": "BOL-DEMO-FC-OUT-001",
+                        "traceability_lot_code_source_reference": "SRC-DEMO-FC-OUT-001",
+                    },
+                )
+            ),
+            DemoFixtureEvent(
+                event(
+                    CTEType.RECEIVING,
+                    "TLC-DEMO-FC-OUT-001",
+                    "Fresh Cut Salad Mix",
+                    430,
+                    "cases",
+                    "Foodservice DC #12",
+                    "2026-02-07T02:00:00Z",
+                    {
+                        "receive_date": "2026-02-07",
+                        "receiving_location": "Foodservice DC #12",
+                        "ship_from_location": "ReadyFresh Processing Plant",
+                        "reference_document_type": "Bill of Lading",
+                        "reference_document_number": "BOL-DEMO-FC-OUT-001",
+                        "traceability_lot_code_source_reference": "SRC-DEMO-FC-OUT-001",
+                    },
+                )
+            ),
+        ),
+    ),
+    DemoFixtureId.RETAILER_HANDOFF: DemoFixture(
+        id=DemoFixtureId.RETAILER_HANDOFF,
+        label="Retailer handoff",
+        description="Retail-ready cases moving through DC receipt, outbound shipment, and store receipt.",
+        scenario=ScenarioId.RETAILER_READINESS_DEMO,
+        events=(
+            DemoFixtureEvent(
+                event(
+                    CTEType.HARVESTING,
+                    "TLC-DEMO-RT-HARVEST-001",
+                    "Baby Spinach Clamshells",
+                    240,
+                    "cases",
+                    "SunCoast Produce Ranch",
+                    "2026-02-08T07:30:00Z",
+                    {
+                        "harvest_date": "2026-02-08",
+                        "farm_location": "SunCoast Produce Ranch",
+                        "field_name": "Field-2",
+                        "immediate_subsequent_recipient": "Retail Cold Dock West",
+                        "reference_document_type": "Harvest Log",
+                        "reference_document_number": "HAR-DEMO-RT-001",
+                        "traceability_lot_code_source_reference": "SRC-DEMO-RT-001",
+                    },
+                )
+            ),
+            DemoFixtureEvent(
+                event(
+                    CTEType.COOLING,
+                    "TLC-DEMO-RT-HARVEST-001",
+                    "Baby Spinach Clamshells",
+                    240,
+                    "cases",
+                    "Retail Cold Dock West",
+                    "2026-02-08T08:20:00Z",
+                    {
+                        "cooling_date": "2026-02-08",
+                        "cooling_location": "Retail Cold Dock West",
+                        "harvest_location": "SunCoast Produce Ranch",
+                        "reference_document_type": "Cooling Log",
+                        "reference_document_number": "COOL-DEMO-RT-001",
+                        "traceability_lot_code_source_reference": "SRC-DEMO-RT-001",
+                    },
+                )
+            ),
+            DemoFixtureEvent(
+                event(
+                    CTEType.INITIAL_PACKING,
+                    "TLC-DEMO-RT-PACK-001",
+                    "Baby Spinach Clamshells",
+                    228,
+                    "cases",
+                    "Retail Ready Packout",
+                    "2026-02-08T10:00:00Z",
+                    {
+                        "pack_date": "2026-02-08",
+                        "packing_location": "Retail Ready Packout",
+                        "source_traceability_lot_code": "TLC-DEMO-RT-HARVEST-001",
+                        "farm_location": "SunCoast Produce Ranch",
+                        "reference_document_type": "Packout Record",
+                        "reference_document_number": "PACK-DEMO-RT-001",
+                        "traceability_lot_code_source_reference": "SRC-DEMO-RT-PACK-001",
+                    },
+                ),
+                parent_lot_codes=("TLC-DEMO-RT-HARVEST-001",),
+            ),
+            DemoFixtureEvent(
+                event(
+                    CTEType.SHIPPING,
+                    "TLC-DEMO-RT-PACK-001",
+                    "Baby Spinach Clamshells",
+                    228,
+                    "cases",
+                    "Retail Ready Packout",
+                    "2026-02-08T12:15:00Z",
+                    {
+                        "ship_date": "2026-02-08",
+                        "ship_from_location": "Retail Ready Packout",
+                        "ship_to_location": "Retail DC West",
+                        "carrier": "StoreLane Logistics",
+                        "reference_document_type": "Bill of Lading",
+                        "reference_document_number": "BOL-DEMO-RT-001",
+                        "traceability_lot_code_source_reference": "SRC-DEMO-RT-PACK-001",
+                    },
+                )
+            ),
+            DemoFixtureEvent(
+                event(
+                    CTEType.RECEIVING,
+                    "TLC-DEMO-RT-PACK-001",
+                    "Baby Spinach Clamshells",
+                    228,
+                    "cases",
+                    "Retail DC West",
+                    "2026-02-08T16:00:00Z",
+                    {
+                        "receive_date": "2026-02-08",
+                        "receiving_location": "Retail DC West",
+                        "ship_from_location": "Retail Ready Packout",
+                        "reference_document_type": "Bill of Lading",
+                        "reference_document_number": "BOL-DEMO-RT-001",
+                        "traceability_lot_code_source_reference": "SRC-DEMO-RT-PACK-001",
+                    },
+                )
+            ),
+            DemoFixtureEvent(
+                event(
+                    CTEType.SHIPPING,
+                    "TLC-DEMO-RT-PACK-001",
+                    "Baby Spinach Clamshells",
+                    228,
+                    "cases",
+                    "Retail DC West",
+                    "2026-02-08T18:30:00Z",
+                    {
+                        "ship_date": "2026-02-08",
+                        "ship_from_location": "Retail DC West",
+                        "ship_to_location": "Retail Store #4521",
+                        "carrier": "StoreLane Logistics",
+                        "reference_document_type": "Transfer Order",
+                        "reference_document_number": "TO-DEMO-RT-001",
+                        "traceability_lot_code_source_reference": "SRC-DEMO-RT-PACK-001",
+                    },
+                )
+            ),
+            DemoFixtureEvent(
+                event(
+                    CTEType.RECEIVING,
+                    "TLC-DEMO-RT-PACK-001",
+                    "Baby Spinach Clamshells",
+                    228,
+                    "cases",
+                    "Retail Store #4521",
+                    "2026-02-09T05:15:00Z",
+                    {
+                        "receive_date": "2026-02-09",
+                        "receiving_location": "Retail Store #4521",
+                        "ship_from_location": "Retail DC West",
+                        "reference_document_type": "Transfer Order",
+                        "reference_document_number": "TO-DEMO-RT-001",
+                        "traceability_lot_code_source_reference": "SRC-DEMO-RT-PACK-001",
+                    },
+                )
+            ),
+        ),
+    ),
+}
+
+
+def get_demo_fixture(fixture_id: DemoFixtureId | str) -> DemoFixture:
+    return DEMO_FIXTURES[DemoFixtureId(fixture_id)]
+
+
+def list_demo_fixture_summaries() -> list[dict[str, object]]:
+    return [
+        {
+            "id": fixture.id.value,
+            "label": fixture.label,
+            "description": fixture.description,
+            "scenario": fixture.scenario.value,
+            "event_count": len(fixture.events),
+            "lot_codes": fixture.lot_codes,
+        }
+        for fixture in DEMO_FIXTURES.values()
+    ]

--- a/app/main.py
+++ b/app/main.py
@@ -13,6 +13,7 @@ from fastapi.responses import FileResponse, JSONResponse, PlainTextResponse, Str
 from fastapi.staticfiles import StaticFiles
 
 from .controller import SimulationController
+from .demo_fixtures import list_demo_fixture_summaries
 from .engine import LegitFlowEngine
 from .fda_export import (
     FDA_EXPORT_PRESETS,
@@ -25,6 +26,11 @@ from .mock_service import MockRegEngineService
 from .models import (
     CSVImportRequest,
     CSVImportResponse,
+    DemoFixtureId,
+    DemoFixtureListResponse,
+    DemoFixtureLoadRequest,
+    DemoFixtureLoadResponse,
+    DemoFixtureSummary,
     DeliveryRetryRequest,
     DeliveryRetryResponse,
     EventListResponse,
@@ -109,6 +115,24 @@ async def list_scenarios() -> ScenarioListResponse:
     return ScenarioListResponse(
         scenarios=[ScenarioSummary.model_validate(summary) for summary in list_scenario_summaries()]
     )
+
+
+@app.get("/api/demo-fixtures", response_model=DemoFixtureListResponse)
+async def list_demo_fixtures() -> DemoFixtureListResponse:
+    return DemoFixtureListResponse(
+        fixtures=[
+            DemoFixtureSummary.model_validate(summary)
+            for summary in list_demo_fixture_summaries()
+        ]
+    )
+
+
+@app.post("/api/demo-fixtures/{fixture_id}/load", response_model=DemoFixtureLoadResponse)
+async def load_demo_fixture(
+    fixture_id: DemoFixtureId,
+    request: DemoFixtureLoadRequest | None = None,
+) -> DemoFixtureLoadResponse:
+    return await controller.load_demo_fixture(fixture_id, request)
 
 
 def sse_message(event_name: str, payload: dict[str, Any]) -> str:

--- a/app/models.py
+++ b/app/models.py
@@ -38,6 +38,12 @@ class FDAExportPreset(str, Enum):
     TRANSFORMATION_BATCHES = "transformation_batches"
 
 
+class DemoFixtureId(str, Enum):
+    LEAFY_GREENS_TRACE = "leafy_greens_trace"
+    FRESH_CUT_TRANSFORMATION = "fresh_cut_transformation"
+    RETAILER_HANDOFF = "retailer_handoff"
+
+
 class RegEngineEvent(BaseModel):
     cte_type: CTEType
     traceability_lot_code: str
@@ -147,6 +153,41 @@ class FDAExportPresetSummary(BaseModel):
 
 class FDAExportPresetListResponse(BaseModel):
     presets: list[FDAExportPresetSummary]
+
+
+class DemoFixtureSummary(BaseModel):
+    id: DemoFixtureId
+    label: str
+    description: str
+    scenario: ScenarioId
+    event_count: int
+    lot_codes: list[str]
+
+
+class DemoFixtureListResponse(BaseModel):
+    fixtures: list[DemoFixtureSummary]
+
+
+class DemoFixtureLoadRequest(BaseModel):
+    reset: bool = True
+    source: str | None = None
+    delivery: DeliveryConfig | None = None
+
+
+class DemoFixtureLoadResponse(BaseModel):
+    status: Literal["loaded", "delivery_failed"]
+    fixture_id: DemoFixtureId
+    scenario: ScenarioId
+    loaded: int
+    stored: int
+    posted: int
+    failed: int
+    source: str
+    delivery_mode: DestinationMode
+    delivery_attempts: int = 0
+    lot_codes: list[str]
+    response: dict[str, Any] | None = None
+    error: str | None = None
 
 
 class StepResponse(BaseModel):

--- a/app/static/app.js
+++ b/app/static/app.js
@@ -9,6 +9,9 @@ const state = {
     fresh_cut_processor: 'Fresh-cut processor',
     retailer_readiness_demo: 'Retailer readiness demo',
   },
+  demoFixtureDescriptions: {
+    leafy_greens_trace: 'Harvest through cooling, packout, shipment, and DC receipt for one leafy greens lot.',
+  },
   exportPresetDescriptions: {
     all_records: 'Full FDA-request export for the selected date range.',
   },
@@ -27,6 +30,9 @@ const ids = {
   csvImportType: document.getElementById('csvImportType'),
   csvFile: document.getElementById('csvFile'),
   importResults: document.getElementById('importResults'),
+  demoFixture: document.getElementById('demoFixture'),
+  demoFixtureDescription: document.getElementById('demoFixtureDescription'),
+  loadFixtureBtn: document.getElementById('loadFixtureBtn'),
   exportPreset: document.getElementById('exportPreset'),
   exportLot: document.getElementById('exportLot'),
   exportStartDate: document.getElementById('exportStartDate'),
@@ -105,6 +111,32 @@ function renderScenarioOptions(scenarios) {
 async function loadScenarios() {
   const payload = await api('/api/scenarios');
   renderScenarioOptions(payload.scenarios || []);
+}
+
+function renderDemoFixtureOptions(fixtures) {
+  const selected = ids.demoFixture.value || 'leafy_greens_trace';
+  state.demoFixtureDescriptions = Object.fromEntries(
+    fixtures.map((fixture) => [fixture.id, fixture.description]),
+  );
+  ids.demoFixture.innerHTML = fixtures
+    .map(
+      (fixture) => `
+        <option value="${escapeHtml(fixture.id)}">${escapeHtml(fixture.label)}</option>
+      `,
+    )
+    .join('');
+  ids.demoFixture.value = state.demoFixtureDescriptions[selected] ? selected : fixtures[0]?.id || 'leafy_greens_trace';
+  updateDemoFixtureDescription();
+}
+
+async function loadDemoFixtures() {
+  const payload = await api('/api/demo-fixtures');
+  renderDemoFixtureOptions(payload.fixtures || []);
+}
+
+function updateDemoFixtureDescription() {
+  const fixtureId = ids.demoFixture.value || 'leafy_greens_trace';
+  ids.demoFixtureDescription.textContent = state.demoFixtureDescriptions[fixtureId] || 'Deterministic demo fixture.';
 }
 
 function renderExportPresetOptions(presets) {
@@ -574,6 +606,33 @@ async function retryFailedDeliveries() {
   }
 }
 
+async function loadSelectedDemoFixture() {
+  try {
+    const config = buildConfig();
+    const fixtureId = ids.demoFixture.value || 'leafy_greens_trace';
+    const result = await api(`/api/demo-fixtures/${encodeURIComponent(fixtureId)}/load`, {
+      method: 'POST',
+      body: JSON.stringify({
+        reset: true,
+        source: config.source,
+        delivery: config.delivery,
+      }),
+    });
+    ids.scenario.value = result.scenario;
+    ids.lineageResults.innerHTML = '';
+    if (result.status === 'delivery_failed') {
+      setStatus(`Loaded ${result.stored} fixture event(s), but delivery failed: ${result.error || 'delivery error'}`, 'error', 7000);
+    } else if (result.delivery_mode === 'none') {
+      setStatus(`Loaded ${result.stored} fixture event(s) without delivery.`, 'success', 3500);
+    } else {
+      setStatus(`Loaded fixture and posted ${result.posted} event(s).`, 'success', 3500);
+    }
+    await refresh();
+  } catch (error) {
+    setStatus(error.message, 'error', 5000);
+  }
+}
+
 async function replayCurrentLog() {
   try {
     const result = await api('/api/simulate/replay', { method: 'POST' });
@@ -660,15 +719,20 @@ document.getElementById('stepBtn').addEventListener('click', stepOnce);
 document.getElementById('replayBtn').addEventListener('click', replayCurrentLog);
 document.getElementById('importCsvBtn').addEventListener('click', importCsv);
 document.getElementById('retryFailedBtn').addEventListener('click', retryFailedDeliveries);
+document.getElementById('loadFixtureBtn').addEventListener('click', loadSelectedDemoFixture);
 document.getElementById('resetBtn').addEventListener('click', resetState);
 document.getElementById('refreshBtn').addEventListener('click', refresh);
 document.getElementById('lineageBtn').addEventListener('click', lookupLineage);
+ids.demoFixture.addEventListener('change', updateDemoFixtureDescription);
 ids.exportPreset.addEventListener('change', updateExportLink);
 ids.exportLot.addEventListener('input', updateExportLink);
 ids.exportStartDate.addEventListener('change', updateExportLink);
 ids.exportEndDate.addEventListener('change', updateExportLink);
 
 loadScenarios().catch((error) => {
+  setStatus(error.message, 'error', 5000);
+});
+loadDemoFixtures().catch((error) => {
   setStatus(error.message, 'error', 5000);
 });
 loadExportPresets().catch((error) => {

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -83,6 +83,24 @@
 
       <section class="panel">
         <div class="section-head">
+          <h2>Demo fixtures</h2>
+        </div>
+        <div class="grid two-up">
+          <label>
+            Fixture
+            <select id="demoFixture" name="demoFixture">
+              <option value="leafy_greens_trace" selected>Leafy greens trace</option>
+            </select>
+          </label>
+          <div class="field-action">
+            <button class="button secondary" id="loadFixtureBtn" type="button">Load fixture</button>
+          </div>
+        </div>
+        <p class="note" id="demoFixtureDescription">Harvest through cooling, packout, shipment, and DC receipt for one leafy greens lot.</p>
+      </section>
+
+      <section class="panel">
+        <div class="section-head">
           <h2>CSV bulk import</h2>
         </div>
         <div class="grid two-up">

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -118,6 +118,11 @@ label {
   font-size: 0.95rem;
 }
 
+.field-action {
+  display: flex;
+  align-items: flex-end;
+}
+
 input,
 select,
 button {

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -65,6 +65,123 @@ def test_scenario_catalog_endpoint_lists_supported_presets():
     assert all(scenario["label"] for scenario in scenarios)
 
 
+def test_demo_fixture_catalog_lists_supported_playbacks():
+    response = client.get("/api/demo-fixtures")
+
+    assert response.status_code == 200
+    fixtures = response.json()["fixtures"]
+    assert [fixture["id"] for fixture in fixtures] == [
+        "leafy_greens_trace",
+        "fresh_cut_transformation",
+        "retailer_handoff",
+    ]
+    assert fixtures[1]["scenario"] == "fresh_cut_processor"
+    assert fixtures[1]["event_count"] == 13
+    assert "TLC-DEMO-FC-OUT-001" in fixtures[1]["lot_codes"]
+
+
+def test_load_demo_fixture_resets_store_and_preserves_transformation_lineage(tmp_path):
+    custom_path = tmp_path / "demo-fixture-events.jsonl"
+    client.post(
+        "/api/simulate/reset",
+        json={
+            "batch_size": 1,
+            "seed": 204,
+            "persist_path": str(custom_path),
+        },
+    )
+    client.post("/api/simulate/step")
+
+    response = client.post(
+        "/api/demo-fixtures/fresh_cut_transformation/load",
+        json={
+            "reset": True,
+            "source": "fixture-suite",
+            "delivery": {"mode": "none"},
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "loaded"
+    assert body["fixture_id"] == "fresh_cut_transformation"
+    assert body["scenario"] == "fresh_cut_processor"
+    assert body["loaded"] == 13
+    assert body["stored"] == 13
+    assert body["posted"] == 0
+    assert body["failed"] == 0
+    assert body["source"] == "fixture-suite"
+    assert body["delivery_mode"] == "none"
+    assert body["lot_codes"] == [
+        "TLC-DEMO-FC-HARVEST-001",
+        "TLC-DEMO-FC-HARVEST-002",
+        "TLC-DEMO-FC-PACK-001",
+        "TLC-DEMO-FC-PACK-002",
+        "TLC-DEMO-FC-OUT-001",
+    ]
+
+    status = client.get("/api/simulate/status").json()
+    assert status["config"]["scenario"] == "fresh_cut_processor"
+    assert status["stats"]["total_records"] == 13
+    assert status["stats"]["by_delivery_status"] == {"generated": 13}
+
+    lineage = client.get("/api/lineage/TLC-DEMO-FC-OUT-001").json()
+    lineage_lot_codes = {record["event"]["traceability_lot_code"] for record in lineage["records"]}
+    assert {
+        "TLC-DEMO-FC-HARVEST-001",
+        "TLC-DEMO-FC-HARVEST-002",
+        "TLC-DEMO-FC-PACK-001",
+        "TLC-DEMO-FC-PACK-002",
+        "TLC-DEMO-FC-OUT-001",
+    } <= lineage_lot_codes
+    assert {
+        (edge["source_lot_code"], edge["target_lot_code"])
+        for edge in lineage["edges"]
+    } >= {
+        ("TLC-DEMO-FC-PACK-001", "TLC-DEMO-FC-OUT-001"),
+        ("TLC-DEMO-FC-PACK-002", "TLC-DEMO-FC-OUT-001"),
+    }
+
+    export_response = client.get(
+        "/api/mock/regengine/export/fda-request?preset=lot_trace&traceability_lot_code=TLC-DEMO-FC-OUT-001"
+    )
+    assert export_response.status_code == 200
+    assert "BATCH-DEMO-FC-001" in export_response.text
+
+
+def test_load_demo_fixture_posts_to_mock_when_requested(tmp_path):
+    custom_path = tmp_path / "demo-fixture-mock-events.jsonl"
+    client.post(
+        "/api/simulate/reset",
+        json={
+            "batch_size": 1,
+            "seed": 204,
+            "persist_path": str(custom_path),
+        },
+    )
+
+    response = client.post(
+        "/api/demo-fixtures/retailer_handoff/load",
+        json={
+            "delivery": {"mode": "mock"},
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "loaded"
+    assert body["loaded"] == 7
+    assert body["posted"] == 7
+    assert body["delivery_mode"] == "mock"
+    assert body["delivery_attempts"] == 1
+    assert body["response"]["total"] == 7
+
+    record = client.get("/api/events?limit=1").json()["events"][0]
+    assert record["delivery_status"] == "posted"
+    assert record["delivery_attempts"] == 1
+    assert record["delivery_response"]["sha256_hash"]
+
+
 def test_controller_revision_notifies_after_step():
     async def wait_for_step_update() -> dict:
         starting_revision = controller.revision


### PR DESCRIPTION
## Summary
- Add deterministic demo fixture definitions for leafy greens, fresh-cut transformation, and retailer handoff playbacks.
- Add API routes and controller support for listing and loading fixtures through mock/live/none delivery modes.
- Add dashboard controls and docs so operators can load repeatable demo flows with preserved lineage.

## Validation
- `pytest` passed: 37/37
- `node --check app/static/app.js`
- `git diff --check`
- Browser smoke covered fixture load, lineage lookup, FDA lot trace export, start/stop/reset

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Added demo fixtures allowing users to load pre-configured scenario demonstrations via UI selector
- New UI panel to browse available fixtures with descriptions and load button
- Demo fixtures automatically populate sample data for streamlined testing

**Documentation**
- Updated documentation with demo fixtures overview, available fixtures, and usage examples

**Tests**
- Added comprehensive tests for fixture discovery and loading functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->