### PR TITLE
[codex] Add EPCIS export scaffolding

### DIFF
--- a/AUTOPILOT_TASKS.md
+++ b/AUTOPILOT_TASKS.md
@@ -26,7 +26,7 @@ This file is the standing backlog for unattended Codex runs.
 
 ## Priority 3
 
-- [ ] Add EPCIS 2.0 export scaffolding without breaking the current webhook contract.
+- [x] Add EPCIS 2.0 export scaffolding without breaking the current webhook contract.
 - [ ] Add per-scenario save/load support.
 - [ ] Add basic auth and tenant-scoped storage boundaries.
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A mock-first FSMA 204 traceability simulator that emits **RegEngine-compatible i
 - [Scenario presets](#scenario-presets)
 - [Demo fixtures](#demo-fixtures)
 - [FDA export presets](#fda-export-presets)
+- [EPCIS 2.0 export scaffolding](#epcis-20-export-scaffolding)
 - [API reference](#api-reference)
 - [RegEngine payload contract](#regengine-payload-contract)
 - [Deployment](#deployment)
@@ -44,6 +45,7 @@ app/
   controller.py          # Simulator lifecycle (start/stop/step/reset)
   demo_fixtures.py       # Deterministic demo playback fixtures
   engine.py              # CTE generation and lot lineage logic
+  epcis_export.py        # EPCIS 2.0 JSON-LD export scaffolding
   fda_export.py          # FDA-request CSV export presets and rendering
   main.py                # FastAPI app and route wiring
   mock_service.py        # Built-in mock RegEngine ingest endpoint
@@ -85,7 +87,7 @@ Then open:
 http://127.0.0.1:8000
 ```
 
-The dashboard lets you choose a scenario preset, load deterministic demo fixtures, start/stop/step/reset the simulator, replay the current persisted event log, import CSV seed lots or scheduled events, inspect recent events, trace lot lineage, and export mock FDA request CSV presets. It subscribes to live status/event snapshots with Server-Sent Events and falls back to refresh polling if the stream disconnects. Delivery mode defaults to **`mock`** so no credentials are required.
+The dashboard lets you choose a scenario preset, load deterministic demo fixtures, start/stop/step/reset the simulator, replay the current persisted event log, import CSV seed lots or scheduled events, inspect recent events, trace lot lineage, and export mock FDA request CSV presets. API users can also derive scaffolded EPCIS 2.0 JSON-LD exports from the same stored records. It subscribes to live status/event snapshots with Server-Sent Events and falls back to refresh polling if the stream disconnects. Delivery mode defaults to **`mock`** so no credentials are required.
 
 Event records are stored as JSONL at `config.persist_path` (`data/events.jsonl` by default). Existing records at that path are loaded when the app starts or when a start/reset request points at a different path; reset clears the currently configured event log. Replay reads the JSONL log without appending, duplicating, or rewriting stored events.
 
@@ -212,6 +214,18 @@ The dashboard fixture loader resets the current event log before loading the sel
 
 If a lot code is supplied, the export is scoped to that lot's transitive lineage before applying the preset filter. `GET /api/mock/regengine/export/presets` returns the preset catalog used by the dashboard.
 
+## EPCIS 2.0 export scaffolding
+
+`GET /api/mock/regengine/export/epcis` derives a scaffolded EPCIS 2.0 JSON-LD document from stored simulator records. This is intentionally additive: it does not change live RegEngine ingest payloads, the mock ingest route, or the FDA CSV export shape.
+
+Supported query parameters:
+
+- `start_date`: optional inclusive `YYYY-MM-DD`
+- `end_date`: optional inclusive `YYYY-MM-DD`
+- `traceability_lot_code`: optional lot code; when supplied, the export uses the same transitive lineage graph as `/api/lineage/{traceability_lot_code}`
+
+The export returns an `EPCISDocument` with `ObjectEvent` records for harvesting, cooling, packing, shipping, and receiving CTEs, plus `TransformationEvent` records for transformation CTEs. RegEngine-specific fields are preserved under the `regengine:` JSON-LD namespace so KDEs, parent lot codes, document references, product descriptions, and original CTE types remain visible while the current webhook contract stays unchanged.
+
 ## API reference
 
 ### Simulator control
@@ -246,6 +260,7 @@ If a lot code is supplied, the export is scoped to that lot's transitive lineage
 | `POST` | `/api/mock/regengine/ingest` | Accepts RegEngine-shaped payloads |
 | `GET` | `/api/mock/regengine/export/presets` | List FDA request export presets |
 | `GET` | `/api/mock/regengine/export/fda-request` | Mock 11-column FDA request CSV |
+| `GET` | `/api/mock/regengine/export/epcis` | Scaffolded EPCIS 2.0 JSON-LD export |
 
 ### Example: start the simulator in live mode
 
@@ -358,6 +373,12 @@ The lineage response keeps the original `records[]` event timeline and adds `nod
 curl "http://127.0.0.1:8000/api/mock/regengine/export/fda-request?preset=lot_trace&traceability_lot_code=TLC-20260421-000003"
 ```
 
+### Example: export a lot-trace EPCIS scaffold
+
+```bash
+curl "http://127.0.0.1:8000/api/mock/regengine/export/epcis?traceability_lot_code=TLC-20260421-000003"
+```
+
 ## RegEngine payload contract
 
 The live delivery client targets the current RegEngine webhook shape:
@@ -388,7 +409,7 @@ The live delivery client targets the current RegEngine webhook shape:
 }
 ```
 
-The mock FDA export mirrors RegEngine's documented 11-column request export shape.
+The mock FDA export mirrors RegEngine's documented 11-column request export shape. The EPCIS 2.0 export is a separate derived JSON-LD scaffold and does not change this webhook contract.
 
 ## Deployment
 

--- a/app/epcis_export.py
+++ b/app/epcis_export.py
@@ -1,0 +1,253 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any, Callable, Iterable
+from urllib.parse import quote
+
+from .models import CTEType, StoredEventRecord
+
+
+EPCIS_CONTEXT = "https://ref.gs1.org/standards/epcis/2.0.0/epcis-context.jsonld"
+REGENGINE_EPCIS_CONTEXT = {"regengine": "https://www.regengine.co/ns/epcis#"}
+
+_BIZ_STEPS = {
+    CTEType.HARVESTING: "urn:epcglobal:cbv:bizstep:commissioning",
+    CTEType.COOLING: "urn:epcglobal:cbv:bizstep:storing",
+    CTEType.INITIAL_PACKING: "urn:epcglobal:cbv:bizstep:packing",
+    CTEType.SHIPPING: "urn:epcglobal:cbv:bizstep:shipping",
+    CTEType.RECEIVING: "urn:epcglobal:cbv:bizstep:receiving",
+    CTEType.TRANSFORMATION: "urn:epcglobal:cbv:bizstep:transforming",
+}
+
+_DISPOSITIONS = {
+    CTEType.HARVESTING: "urn:epcglobal:cbv:disp:active",
+    CTEType.COOLING: "urn:epcglobal:cbv:disp:active",
+    CTEType.INITIAL_PACKING: "urn:epcglobal:cbv:disp:active",
+    CTEType.SHIPPING: "urn:epcglobal:cbv:disp:in_transit",
+    CTEType.RECEIVING: "urn:epcglobal:cbv:disp:active",
+    CTEType.TRANSFORMATION: "urn:epcglobal:cbv:disp:active",
+}
+
+_OBJECT_ACTIONS = {
+    CTEType.HARVESTING: "ADD",
+    CTEType.COOLING: "OBSERVE",
+    CTEType.INITIAL_PACKING: "ADD",
+    CTEType.SHIPPING: "OBSERVE",
+    CTEType.RECEIVING: "OBSERVE",
+}
+
+
+def render_epcis_document(
+    records: Iterable[StoredEventRecord],
+    source: str,
+    location_gln: Callable[[str], str],
+    creation_date: datetime | None = None,
+) -> dict[str, Any]:
+    ordered_records = sorted(records, key=lambda record: (record.event.timestamp, record.sequence_no))
+    return {
+        "@context": [EPCIS_CONTEXT, REGENGINE_EPCIS_CONTEXT],
+        "type": "EPCISDocument",
+        "schemaVersion": "2.0",
+        "creationDate": _format_datetime(creation_date or datetime.now(UTC)),
+        "sender": source,
+        "epcisBody": {
+            "eventList": [
+                _render_event(record, location_gln=location_gln)
+                for record in ordered_records
+            ]
+        },
+    }
+
+
+def epcis_filename() -> str:
+    return "epcis_events.jsonld"
+
+
+def _render_event(
+    record: StoredEventRecord,
+    location_gln: Callable[[str], str],
+) -> dict[str, Any]:
+    if record.event.cte_type == CTEType.TRANSFORMATION:
+        event = _render_transformation_event(record, location_gln)
+    else:
+        event = _render_object_event(record, location_gln)
+
+    event["eventID"] = f"urn:uuid:{record.record_id}"
+    event["eventTime"] = _format_datetime(record.event.timestamp)
+    event["eventTimeZoneOffset"] = _timezone_offset(record.event.timestamp)
+    event["bizStep"] = _BIZ_STEPS[record.event.cte_type]
+    event["disposition"] = _DISPOSITIONS[record.event.cte_type]
+    event["readPoint"] = _location_reference(record.event.location_name, location_gln)
+    event["bizLocation"] = _location_reference(record.event.location_name, location_gln)
+    event["regengine:sequenceNo"] = record.sequence_no
+    event["regengine:cteType"] = record.event.cte_type.value
+    event["regengine:traceabilityLotCode"] = record.event.traceability_lot_code
+    event["regengine:productDescription"] = record.event.product_description
+    event["regengine:parentLotCodes"] = _input_lot_codes(record)
+    event["regengine:kdes"] = record.event.kdes
+
+    transactions = _biz_transactions(record)
+    if transactions:
+        event["bizTransactionList"] = transactions
+
+    return event
+
+
+def _render_object_event(
+    record: StoredEventRecord,
+    location_gln: Callable[[str], str],
+) -> dict[str, Any]:
+    event = record.event
+    return {
+        "type": "ObjectEvent",
+        "action": _OBJECT_ACTIONS[event.cte_type],
+        "quantityList": [
+            _quantity_element(
+                lot_code=event.traceability_lot_code,
+                quantity=event.quantity,
+                unit_of_measure=event.unit_of_measure,
+                product_description=event.product_description,
+            )
+        ],
+        "regengine:location": _location_reference(event.location_name, location_gln),
+    }
+
+
+def _render_transformation_event(
+    record: StoredEventRecord,
+    location_gln: Callable[[str], str],
+) -> dict[str, Any]:
+    event = record.event
+    batch_number = _transformation_batch_number(record)
+    transformation_id = (
+        f"urn:regengine:batch:{quote(batch_number, safe='')}"
+        if batch_number
+        else f"urn:regengine:transformation:{record.record_id}"
+    )
+    return {
+        "type": "TransformationEvent",
+        "transformationID": transformation_id,
+        "inputQuantityList": [
+            _quantity_element(lot_code=lot_code)
+            for lot_code in _input_lot_codes(record)
+        ],
+        "outputQuantityList": [
+            _quantity_element(
+                lot_code=event.traceability_lot_code,
+                quantity=event.quantity,
+                unit_of_measure=event.unit_of_measure,
+                product_description=event.product_description,
+            )
+        ],
+        "regengine:location": _location_reference(event.location_name, location_gln),
+    }
+
+
+def _transformation_batch_number(record: StoredEventRecord) -> str | None:
+    batch_number = record.event.kdes.get("batch_number")
+    if isinstance(batch_number, str) and batch_number:
+        return batch_number
+
+    reference_type = record.event.kdes.get("reference_document_type")
+    reference_number = record.event.kdes.get("reference_document_number")
+    if (
+        isinstance(reference_type, str)
+        and "batch" in reference_type.lower()
+        and isinstance(reference_number, str)
+        and reference_number
+    ):
+        return reference_number
+    return None
+
+
+def _quantity_element(
+    lot_code: str,
+    quantity: float | None = None,
+    unit_of_measure: str | None = None,
+    product_description: str | None = None,
+) -> dict[str, Any]:
+    element: dict[str, Any] = {
+        "epcClass": _lot_identifier(lot_code),
+        "regengine:traceabilityLotCode": lot_code,
+    }
+    if quantity is not None:
+        element["quantity"] = quantity
+    if unit_of_measure:
+        element["uom"] = unit_of_measure
+    if product_description:
+        element["regengine:productDescription"] = product_description
+    return element
+
+
+def _input_lot_codes(record: StoredEventRecord) -> list[str]:
+    lot_codes: list[str] = []
+    for lot_code in record.parent_lot_codes:
+        if lot_code not in lot_codes:
+            lot_codes.append(lot_code)
+
+    source_lot_code = record.event.kdes.get("source_traceability_lot_code")
+    if isinstance(source_lot_code, str) and source_lot_code not in lot_codes:
+        lot_codes.append(source_lot_code)
+
+    input_lot_codes = record.event.kdes.get("input_traceability_lot_codes", [])
+    if isinstance(input_lot_codes, list):
+        for lot_code in input_lot_codes:
+            if isinstance(lot_code, str) and lot_code not in lot_codes:
+                lot_codes.append(lot_code)
+
+    return lot_codes
+
+
+def _biz_transactions(record: StoredEventRecord) -> list[dict[str, str]]:
+    reference_type = record.event.kdes.get("reference_document_type")
+    reference_number = record.event.kdes.get("reference_document_number")
+    if not isinstance(reference_type, str) or not isinstance(reference_number, str):
+        return []
+    if not reference_type or not reference_number:
+        return []
+
+    return [
+        {
+            "type": _reference_type_identifier(reference_type),
+            "bizTransaction": f"urn:regengine:document:{quote(reference_number, safe='')}",
+            "regengine:documentType": reference_type,
+            "regengine:documentNumber": reference_number,
+        }
+    ]
+
+
+def _lot_identifier(lot_code: str) -> str:
+    return f"urn:regengine:lot:{quote(lot_code, safe='')}"
+
+
+def _location_reference(location_name: str, location_gln: Callable[[str], str]) -> dict[str, str]:
+    gln = location_gln(location_name)
+    reference = {
+        "id": f"urn:regengine:location:{quote(location_name, safe='')}",
+        "regengine:locationName": location_name,
+    }
+    if gln:
+        reference["regengine:gln"] = gln
+    return reference
+
+
+def _reference_type_identifier(reference_type: str) -> str:
+    normalized = reference_type.strip().lower().replace(" ", "_")
+    return f"urn:regengine:document_type:{quote(normalized, safe='')}"
+
+
+def _format_datetime(value: datetime) -> str:
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=UTC)
+    return value.isoformat()
+
+
+def _timezone_offset(value: datetime) -> str:
+    offset = value.utcoffset() if value.tzinfo else None
+    if offset is None:
+        return "+00:00"
+    total_minutes = int(offset.total_seconds() // 60)
+    sign = "+" if total_minutes >= 0 else "-"
+    total_minutes = abs(total_minutes)
+    hours, minutes = divmod(total_minutes, 60)
+    return f"{sign}{hours:02d}:{minutes:02d}"

--- a/app/main.py
+++ b/app/main.py
@@ -15,6 +15,7 @@ from fastapi.staticfiles import StaticFiles
 from .controller import SimulationController
 from .demo_fixtures import list_demo_fixture_summaries
 from .engine import LegitFlowEngine
+from .epcis_export import epcis_filename, render_epcis_document
 from .fda_export import (
     FDA_EXPORT_PRESETS,
     apply_fda_export_preset,
@@ -271,6 +272,32 @@ async def mock_fda_request_export(
         content=csv_text,
         media_type="text/csv",
         headers={"Content-Disposition": f"attachment; filename={export_filename(preset)}"},
+    )
+
+
+@app.get("/api/mock/regengine/export/epcis")
+async def mock_epcis_export(
+    start_date: str | None = Query(default=None, description="Inclusive YYYY-MM-DD"),
+    end_date: str | None = Query(default=None, description="Inclusive YYYY-MM-DD"),
+    traceability_lot_code: str | None = Query(default=None),
+) -> JSONResponse:
+    if traceability_lot_code:
+        records = store.lineage(traceability_lot_code)
+        if not records:
+            raise HTTPException(status_code=404, detail="No records found for that lot code")
+        records = _filter_records_between(records, start_date=start_date, end_date=end_date)
+    else:
+        records = store.all_between(start_date=start_date, end_date=end_date)
+
+    document = render_epcis_document(
+        records,
+        source=controller.config.source,
+        location_gln=engine.location_gln,
+    )
+    return JSONResponse(
+        content=document,
+        media_type="application/ld+json",
+        headers={"Content-Disposition": f"attachment; filename={epcis_filename()}"},
     )
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -337,6 +337,110 @@ transformation,TLC-FDA-OUT,Fresh Cut Salad Mix,95,cases,ReadyFresh Processing Pl
     assert missing_lot_response.status_code == 400
 
 
+def test_epcis_export_scaffold_maps_lineage_to_jsonld_without_changing_ingest_contract(tmp_path):
+    custom_path = tmp_path / "epcis-events.jsonl"
+    client.post(
+        "/api/simulate/reset",
+        json={
+            "batch_size": 1,
+            "seed": 204,
+            "persist_path": str(custom_path),
+            "delivery": {"mode": "none"},
+        },
+    )
+    load_response = client.post(
+        "/api/demo-fixtures/fresh_cut_transformation/load",
+        json={
+            "source": "epcis-suite",
+            "delivery": {"mode": "none"},
+        },
+    )
+    assert load_response.status_code == 200
+
+    response = client.get(
+        "/api/mock/regengine/export/epcis?traceability_lot_code=TLC-DEMO-FC-OUT-001"
+    )
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("application/ld+json")
+    assert response.headers["content-disposition"] == "attachment; filename=epcis_events.jsonld"
+    document = response.json()
+    assert document["type"] == "EPCISDocument"
+    assert document["schemaVersion"] == "2.0"
+    assert document["sender"] == "epcis-suite"
+
+    events = document["epcisBody"]["eventList"]
+    assert len(events) == 13
+    assert {event["type"] for event in events} == {"ObjectEvent", "TransformationEvent"}
+    assert events[0]["regengine:cteType"] == "harvesting"
+    assert events[0]["quantityList"][0]["epcClass"] == "urn:regengine:lot:TLC-DEMO-FC-HARVEST-001"
+
+    shipping_event = next(event for event in events if event["regengine:cteType"] == "shipping")
+    assert shipping_event["bizStep"] == "urn:epcglobal:cbv:bizstep:shipping"
+    assert shipping_event["disposition"] == "urn:epcglobal:cbv:disp:in_transit"
+    assert shipping_event["bizTransactionList"][0]["regengine:documentNumber"]
+
+    transformation_event = next(event for event in events if event["type"] == "TransformationEvent")
+    assert transformation_event["transformationID"] == "urn:regengine:batch:BATCH-DEMO-FC-001"
+    assert {
+        quantity["regengine:traceabilityLotCode"]
+        for quantity in transformation_event["inputQuantityList"]
+    } == {"TLC-DEMO-FC-PACK-001", "TLC-DEMO-FC-PACK-002"}
+    assert transformation_event["outputQuantityList"][0]["regengine:traceabilityLotCode"] == (
+        "TLC-DEMO-FC-OUT-001"
+    )
+    assert transformation_event["regengine:kdes"]["reference_document_number"] == "BATCH-DEMO-FC-001"
+
+    ingest_response = client.post(
+        "/api/mock/regengine/ingest",
+        json={
+            "source": "contract-check",
+            "events": [
+                {
+                    "cte_type": "receiving",
+                    "traceability_lot_code": "TLC-EP-CHECK",
+                    "product_description": "Romaine Lettuce",
+                    "quantity": 12,
+                    "unit_of_measure": "cases",
+                    "location_name": "Distribution Center #4",
+                    "timestamp": "2026-02-05T08:30:00Z",
+                    "kdes": {},
+                }
+            ],
+        },
+    )
+    assert ingest_response.status_code == 200
+    assert ingest_response.json()["events"][0]["status"] == "accepted"
+
+
+def test_epcis_export_supports_date_filters_and_missing_lot_errors(tmp_path):
+    custom_path = tmp_path / "epcis-date-events.jsonl"
+    client.post(
+        "/api/simulate/reset",
+        json={
+            "batch_size": 1,
+            "seed": 204,
+            "persist_path": str(custom_path),
+            "delivery": {"mode": "none"},
+        },
+    )
+    client.post(
+        "/api/demo-fixtures/fresh_cut_transformation/load",
+        json={"delivery": {"mode": "none"}},
+    )
+
+    filtered_response = client.get(
+        "/api/mock/regengine/export/epcis?start_date=2026-02-07&end_date=2026-02-07"
+    )
+    assert filtered_response.status_code == 200
+    filtered_events = filtered_response.json()["epcisBody"]["eventList"]
+    assert [event["regengine:cteType"] for event in filtered_events] == ["receiving"]
+    assert filtered_events[0]["regengine:traceabilityLotCode"] == "TLC-DEMO-FC-OUT-001"
+
+    missing_response = client.get("/api/mock/regengine/export/epcis?traceability_lot_code=NOPE")
+    assert missing_response.status_code == 404
+
+
 def test_start_applies_configured_persist_path_and_keeps_mock_default(tmp_path):
     custom_path = tmp_path / "start-events.jsonl"
     response = client.post(


### PR DESCRIPTION
## Summary
- Add an additive EPCIS 2.0 JSON-LD export scaffold derived from stored simulator records.
- Map current FSMA 204 CTE records into ObjectEvent and TransformationEvent payloads while preserving RegEngine-specific KDEs and lineage metadata.
- Document the new export route and mark the Priority 3 EPCIS task complete.

## Contract safety
- The live/mock RegEngine ingest payload remains unchanged: top-level `source` plus `events[]` with the documented per-event fields.
- EPCIS is exposed only as a derived export at `GET /api/mock/regengine/export/epcis`.

## Validation
- `pytest` passed: 39/39
- `python3 -m compileall app`
- `git diff --check`