### PR TITLE
[codex] Add scenario save load support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,6 @@ __pycache__/
 htmlcov/
 data/*.jsonl
 data/*.csv
+data/scenario_saves/
 uvicorn.out.log
 uvicorn.err.log

--- a/AUTOPILOT_TASKS.md
+++ b/AUTOPILOT_TASKS.md
@@ -27,7 +27,7 @@ This file is the standing backlog for unattended Codex runs.
 ## Priority 3
 
 - [x] Add EPCIS 2.0 export scaffolding without breaking the current webhook contract.
-- [ ] Add per-scenario save/load support.
+- [x] Add per-scenario save/load support.
 - [ ] Add basic auth and tenant-scoped storage boundaries.
 
 ## Progress notes

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ app/
   mock_service.py        # Built-in mock RegEngine ingest endpoint
   models.py              # Pydantic models for config, events, payloads
   regengine_client.py    # HTTP client for live RegEngine delivery
+  scenario_saves.py      # Per-scenario saved config and event-log snapshots
   scenarios.py           # Named scenario presets for product/location/flow mixes
   store.py               # Event persistence (JSONL)
   static/                # Dashboard (vanilla JS, HTML, CSS)
@@ -87,7 +88,7 @@ Then open:
 http://127.0.0.1:8000
 ```
 
-The dashboard lets you choose a scenario preset, load deterministic demo fixtures, start/stop/step/reset the simulator, replay the current persisted event log, import CSV seed lots or scheduled events, inspect recent events, trace lot lineage, and export mock FDA request CSV presets. API users can also derive scaffolded EPCIS 2.0 JSON-LD exports from the same stored records. It subscribes to live status/event snapshots with Server-Sent Events and falls back to refresh polling if the stream disconnects. Delivery mode defaults to **`mock`** so no credentials are required.
+The dashboard lets you choose a scenario preset, save/load per-scenario demo states, load deterministic demo fixtures, start/stop/step/reset the simulator, replay the current persisted event log, import CSV seed lots or scheduled events, inspect recent events, trace lot lineage, and export mock FDA request CSV presets. API users can also derive scaffolded EPCIS 2.0 JSON-LD exports from the same stored records. It subscribes to live status/event snapshots with Server-Sent Events and falls back to refresh polling if the stream disconnects. Delivery mode defaults to **`mock`** so no credentials are required.
 
 Event records are stored as JSONL at `config.persist_path` (`data/events.jsonl` by default). Existing records at that path are loaded when the app starts or when a start/reset request points at a different path; reset clears the currently configured event log. Replay reads the JSONL log without appending, duplicating, or rewriting stored events.
 
@@ -191,6 +192,8 @@ Use `config.scenario` to pick a deterministic product/location/flow mix without 
 
 Scenario selection is available in the dashboard, in `SimulationConfig`, and via `GET /api/scenarios`. The default is `leafy_greens_supplier`, and delivery still defaults to **`mock`**.
 
+Per-scenario save/load stores one saved slot per scenario under `data/scenario_saves/`. A saved scenario includes the sanitized simulator config and the current stored event records, so operators can restore repeatable demo states after switching scenarios. Live API keys are never saved; live delivery settings are restored as mock delivery to preserve mock-first safety.
+
 ## Demo fixtures
 
 Use `GET /api/demo-fixtures` to list deterministic demo playback fixtures. Each fixture contains fixed RegEngine-shaped events with stable timestamps, lot codes, reference documents, and parent-lot lineage. `POST /api/demo-fixtures/{fixture_id}/load` loads a fixture into the event store and optionally delivers it through `mock`, `live`, or `none` delivery.
@@ -234,6 +237,9 @@ The export returns an `EPCISDocument` with `ObjectEvent` records for harvesting,
 |---|---|---|
 | `GET` | `/api/health` | Liveness probe + current config snapshot |
 | `GET` | `/api/scenarios` | List available scenario presets |
+| `GET` | `/api/scenario-saves` | List saved per-scenario demo states |
+| `POST` | `/api/scenario-saves/{scenario_id}` | Save the current or supplied config and event log for a scenario |
+| `POST` | `/api/scenario-saves/{scenario_id}/load` | Restore a saved scenario config and event log |
 | `GET` | `/api/demo-fixtures` | List deterministic demo playback fixtures |
 | `POST` | `/api/demo-fixtures/{fixture_id}/load` | Load a deterministic fixture into the event store |
 | `GET` | `/api/simulate/status` | Running state, config, and aggregate stats |
@@ -317,6 +323,13 @@ curl -X POST http://127.0.0.1:8000/api/demo-fixtures/fresh_cut_transformation/lo
       "mode": "mock"
     }
   }'
+```
+
+### Example: save and reload a scenario state
+
+```bash
+curl -X POST http://127.0.0.1:8000/api/scenario-saves/fresh_cut_processor
+curl -X POST http://127.0.0.1:8000/api/scenario-saves/fresh_cut_processor/load
 ```
 
 ### Example: replay the current persisted log

--- a/app/controller.py
+++ b/app/controller.py
@@ -21,11 +21,19 @@ from .models import (
     IngestPayload,
     ReplayRequest,
     ReplayResponse,
+    ScenarioLoadResponse,
+    ScenarioSaveListResponse,
+    ScenarioSaveRequest,
+    ScenarioSaveResponse,
+    ScenarioSaveSnapshot,
+    ScenarioSaveSummary,
     SimulationConfig,
     StepResponse,
     StoredEventRecord,
 )
 from .regengine_client import LiveRegEngineClient
+from .scenario_saves import ScenarioSaveStore
+from .scenarios import ScenarioId, get_scenario
 from .store import EventStore
 
 
@@ -46,11 +54,13 @@ class SimulationController:
         self,
         engine: LegitFlowEngine,
         store: EventStore,
+        scenario_saves: ScenarioSaveStore,
         mock_service: MockRegEngineService,
         live_client: LiveRegEngineClient,
     ) -> None:
         self.engine = engine
         self.store = store
+        self.scenario_saves = scenario_saves
         self.mock_service = mock_service
         self.live_client = live_client
         self.config = SimulationConfig()
@@ -345,6 +355,57 @@ class SimulationController:
         await self._publish_update()
         return result
 
+    def list_scenario_saves(self) -> ScenarioSaveListResponse:
+        return ScenarioSaveListResponse(
+            saves=[
+                self._scenario_save_summary(snapshot)
+                for snapshot in self.scenario_saves.list()
+            ]
+        )
+
+    async def save_scenario(
+        self,
+        scenario_id: ScenarioId,
+        request: ScenarioSaveRequest | None = None,
+    ) -> ScenarioSaveResponse:
+        request = request or ScenarioSaveRequest()
+        async with self._lock:
+            config = request.config or self.config
+            config = config.model_copy(update={"scenario": scenario_id}, deep=True)
+            config = self._sanitize_saved_config(config)
+            records = self.store.all_between()
+            snapshot = self.scenario_saves.save_snapshot(
+                scenario=scenario_id,
+                config=config,
+                records=records,
+            )
+            result = ScenarioSaveResponse(
+                status="saved",
+                save=self._scenario_save_summary(snapshot),
+                config=snapshot.config,
+            )
+        return result
+
+    async def load_scenario_save(self, scenario_id: ScenarioId) -> ScenarioLoadResponse:
+        await self.stop()
+        snapshot = self.scenario_saves.get(scenario_id)
+        if snapshot is None:
+            raise KeyError(scenario_id.value)
+
+        async with self._lock:
+            self.config = snapshot.config
+            self.store.configure(self.config.persist_path)
+            loaded_records = self.store.replace_all(snapshot.records)
+            self.engine.reset(self.config.seed, scenario=self.config.scenario)
+            result = ScenarioLoadResponse(
+                status="loaded",
+                save=self._scenario_save_summary(snapshot),
+                config=self.config,
+                loaded_records=len(loaded_records),
+            )
+        await self._publish_update()
+        return result
+
     async def retry_failed_delivery(
         self,
         request: DeliveryRetryRequest | None = None,
@@ -537,3 +598,35 @@ class SimulationController:
                 "engine": self.engine.snapshot(),
             },
         }
+
+    def _sanitize_saved_config(self, config: SimulationConfig) -> SimulationConfig:
+        delivery = config.delivery.model_copy(update={"api_key": None}, deep=True)
+        if delivery.mode == DestinationMode.LIVE:
+            delivery = delivery.model_copy(
+                update={
+                    "mode": DestinationMode.MOCK,
+                    "endpoint": None,
+                    "tenant_id": None,
+                    "api_key": None,
+                },
+                deep=True,
+            )
+        return config.model_copy(update={"delivery": delivery}, deep=True)
+
+    def _scenario_save_summary(self, snapshot: ScenarioSaveSnapshot) -> ScenarioSaveSummary:
+        lot_codes = []
+        for record in sorted(snapshot.records, key=lambda item: item.sequence_no):
+            lot_code = record.event.traceability_lot_code
+            if lot_code not in lot_codes:
+                lot_codes.append(lot_code)
+        scenario = get_scenario(snapshot.scenario)
+        return ScenarioSaveSummary(
+            scenario=snapshot.scenario,
+            label=scenario.label,
+            saved_at=snapshot.saved_at,
+            record_count=len(snapshot.records),
+            lot_codes=lot_codes,
+            source=snapshot.config.source,
+            persist_path=snapshot.config.persist_path,
+            delivery_mode=snapshot.config.delivery.mode,
+        )

--- a/app/main.py
+++ b/app/main.py
@@ -44,7 +44,12 @@ from .models import (
     ReplayRequest,
     ReplayResponse,
     ResetResponse,
+    ScenarioLoadResponse,
     ScenarioListResponse,
+    ScenarioSaveListResponse,
+    ScenarioSaveRequest,
+    ScenarioSaveResponse,
+    ScenarioSaveSummary,
     ScenarioSummary,
     SimulationConfig,
     StartRequest,
@@ -52,16 +57,19 @@ from .models import (
     StepResponse,
 )
 from .regengine_client import LiveRegEngineClient
-from .scenarios import list_scenario_summaries
+from .scenario_saves import ScenarioSaveStore
+from .scenarios import ScenarioId, list_scenario_summaries
 from .store import EventStore
 
 
 engine = LegitFlowEngine(seed=204)
 store = EventStore(persist_path="data/events.jsonl")
+scenario_saves = ScenarioSaveStore()
 mock_service = MockRegEngineService()
 controller = SimulationController(
     engine=engine,
     store=store,
+    scenario_saves=scenario_saves,
     mock_service=mock_service,
     live_client=LiveRegEngineClient(),
 )
@@ -116,6 +124,32 @@ async def list_scenarios() -> ScenarioListResponse:
     return ScenarioListResponse(
         scenarios=[ScenarioSummary.model_validate(summary) for summary in list_scenario_summaries()]
     )
+
+
+@app.get("/api/scenario-saves", response_model=ScenarioSaveListResponse)
+async def list_saved_scenarios() -> ScenarioSaveListResponse:
+    return ScenarioSaveListResponse(
+        saves=[
+            ScenarioSaveSummary.model_validate(summary)
+            for summary in controller.list_scenario_saves().saves
+        ]
+    )
+
+
+@app.post("/api/scenario-saves/{scenario_id}", response_model=ScenarioSaveResponse)
+async def save_scenario(
+    scenario_id: ScenarioId,
+    request: ScenarioSaveRequest | None = None,
+) -> ScenarioSaveResponse:
+    return await controller.save_scenario(scenario_id, request)
+
+
+@app.post("/api/scenario-saves/{scenario_id}/load", response_model=ScenarioLoadResponse)
+async def load_saved_scenario(scenario_id: ScenarioId) -> ScenarioLoadResponse:
+    try:
+        return await controller.load_scenario_save(scenario_id)
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail="No saved scenario found") from exc
 
 
 @app.get("/api/demo-fixtures", response_model=DemoFixtureListResponse)

--- a/app/models.py
+++ b/app/models.py
@@ -144,6 +144,45 @@ class ScenarioListResponse(BaseModel):
     scenarios: list[ScenarioSummary]
 
 
+class ScenarioSaveSnapshot(BaseModel):
+    scenario: ScenarioId
+    config: SimulationConfig
+    records: list[StoredEventRecord] = Field(default_factory=list)
+    saved_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+
+
+class ScenarioSaveSummary(BaseModel):
+    scenario: ScenarioId
+    label: str
+    saved_at: datetime
+    record_count: int
+    lot_codes: list[str]
+    source: str
+    persist_path: str
+    delivery_mode: DestinationMode
+
+
+class ScenarioSaveListResponse(BaseModel):
+    saves: list[ScenarioSaveSummary]
+
+
+class ScenarioSaveRequest(BaseModel):
+    config: SimulationConfig | None = None
+
+
+class ScenarioSaveResponse(BaseModel):
+    status: Literal["saved"]
+    save: ScenarioSaveSummary
+    config: SimulationConfig
+
+
+class ScenarioLoadResponse(BaseModel):
+    status: Literal["loaded"]
+    save: ScenarioSaveSummary
+    config: SimulationConfig
+    loaded_records: int
+
+
 class FDAExportPresetSummary(BaseModel):
     id: FDAExportPreset
     label: str

--- a/app/scenario_saves.py
+++ b/app/scenario_saves.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from threading import RLock
+from typing import Iterable
+
+from .models import ScenarioSaveSnapshot, SimulationConfig, StoredEventRecord
+from .scenarios import ScenarioId
+
+
+class ScenarioSaveStore:
+    def __init__(self, save_dir: str = "data/scenario_saves") -> None:
+        self.save_dir = Path(save_dir)
+        self._lock = RLock()
+        self.save_dir.mkdir(parents=True, exist_ok=True)
+
+    def configure(self, save_dir: str) -> None:
+        with self._lock:
+            self.save_dir = Path(save_dir)
+            self.save_dir.mkdir(parents=True, exist_ok=True)
+
+    def list(self) -> list[ScenarioSaveSnapshot]:
+        with self._lock:
+            saves = []
+            for scenario in ScenarioId:
+                snapshot = self.get(scenario)
+                if snapshot is not None:
+                    saves.append(snapshot)
+            return saves
+
+    def get(self, scenario: ScenarioId | str) -> ScenarioSaveSnapshot | None:
+        path = self._path_for(scenario)
+        with self._lock:
+            if not path.exists():
+                return None
+            return ScenarioSaveSnapshot.model_validate_json(path.read_text(encoding="utf-8"))
+
+    def save(
+        self,
+        snapshot: ScenarioSaveSnapshot,
+    ) -> ScenarioSaveSnapshot:
+        with self._lock:
+            self.save_dir.mkdir(parents=True, exist_ok=True)
+            path = self._path_for(snapshot.scenario)
+            tmp_path = path.with_suffix(f"{path.suffix}.tmp")
+            tmp_path.write_text(
+                json.dumps(snapshot.model_dump(mode="json"), indent=2) + "\n",
+                encoding="utf-8",
+            )
+            tmp_path.replace(path)
+        return snapshot
+
+    def save_snapshot(
+        self,
+        scenario: ScenarioId,
+        config: SimulationConfig,
+        records: Iterable[StoredEventRecord],
+    ) -> ScenarioSaveSnapshot:
+        return self.save(
+            ScenarioSaveSnapshot(
+                scenario=scenario,
+                config=config,
+                records=list(records),
+            )
+        )
+
+    def _path_for(self, scenario: ScenarioId | str) -> Path:
+        normalized = ScenarioId(scenario)
+        return self.save_dir / f"{normalized.value}.json"

--- a/app/static/app.js
+++ b/app/static/app.js
@@ -12,6 +12,7 @@ const state = {
   demoFixtureDescriptions: {
     leafy_greens_trace: 'Harvest through cooling, packout, shipment, and DC receipt for one leafy greens lot.',
   },
+  scenarioSaves: [],
   exportPresetDescriptions: {
     all_records: 'Full FDA-request export for the selected date range.',
   },
@@ -30,6 +31,10 @@ const ids = {
   csvImportType: document.getElementById('csvImportType'),
   csvFile: document.getElementById('csvFile'),
   importResults: document.getElementById('importResults'),
+  scenarioSave: document.getElementById('scenarioSave'),
+  scenarioSaveDescription: document.getElementById('scenarioSaveDescription'),
+  saveScenarioBtn: document.getElementById('saveScenarioBtn'),
+  loadScenarioBtn: document.getElementById('loadScenarioBtn'),
   demoFixture: document.getElementById('demoFixture'),
   demoFixtureDescription: document.getElementById('demoFixtureDescription'),
   loadFixtureBtn: document.getElementById('loadFixtureBtn'),
@@ -111,6 +116,61 @@ function renderScenarioOptions(scenarios) {
 async function loadScenarios() {
   const payload = await api('/api/scenarios');
   renderScenarioOptions(payload.scenarios || []);
+}
+
+function applyConfigToForm(config) {
+  if (!config) {
+    return;
+  }
+  ids.source.value = config.source || 'codex-simulator';
+  ids.scenario.value = config.scenario || 'leafy_greens_supplier';
+  ids.interval.value = config.interval_seconds ?? 1.5;
+  ids.batchSize.value = config.batch_size ?? 3;
+  ids.seed.value = config.seed ?? '';
+  ids.deliveryMode.value = config.delivery?.mode || 'mock';
+  ids.endpoint.value = config.delivery?.endpoint || '';
+  ids.apiKey.value = '';
+  ids.tenantId.value = config.delivery?.tenant_id || '';
+}
+
+function renderScenarioSaveOptions(saves) {
+  const selected = ids.scenarioSave.value;
+  state.scenarioSaves = saves || [];
+  if (!state.scenarioSaves.length) {
+    ids.scenarioSave.innerHTML = '<option value="">No saved scenarios</option>';
+    ids.scenarioSave.value = '';
+    ids.loadScenarioBtn.disabled = true;
+    updateScenarioSaveDescription();
+    return;
+  }
+  ids.scenarioSave.innerHTML = state.scenarioSaves
+    .map(
+      (save) => `
+        <option value="${escapeHtml(save.scenario)}">${escapeHtml(save.label)}</option>
+      `,
+    )
+    .join('');
+  ids.scenarioSave.value = state.scenarioSaves.some((save) => save.scenario === selected)
+    ? selected
+    : state.scenarioSaves[0].scenario;
+  ids.loadScenarioBtn.disabled = false;
+  updateScenarioSaveDescription();
+}
+
+async function loadScenarioSaves() {
+  const payload = await api('/api/scenario-saves');
+  renderScenarioSaveOptions(payload.saves || []);
+}
+
+function updateScenarioSaveDescription() {
+  const selected = ids.scenarioSave.value;
+  const save = state.scenarioSaves.find((item) => item.scenario === selected);
+  if (!save) {
+    ids.scenarioSaveDescription.textContent = 'Save the current scenario controls and event log for later demos.';
+    return;
+  }
+  const savedAt = new Date(save.saved_at).toLocaleString();
+  ids.scenarioSaveDescription.textContent = `${save.label}: ${save.record_count} event(s), ${save.lot_codes.length} lot(s), saved ${savedAt}.`;
 }
 
 function renderDemoFixtureOptions(fixtures) {
@@ -606,6 +666,45 @@ async function retryFailedDeliveries() {
   }
 }
 
+async function saveCurrentScenario() {
+  try {
+    const config = buildConfig();
+    const result = await api(`/api/scenario-saves/${encodeURIComponent(config.scenario)}`, {
+      method: 'POST',
+      body: JSON.stringify({ config }),
+    });
+    await loadScenarioSaves();
+    ids.scenarioSave.value = result.save.scenario;
+    updateScenarioSaveDescription();
+    setStatus(`Saved ${result.save.label} with ${result.save.record_count} event(s).`, 'success', 3500);
+  } catch (error) {
+    setStatus(error.message, 'error', 5000);
+  }
+}
+
+async function loadSavedScenario() {
+  const scenarioId = ids.scenarioSave.value;
+  if (!scenarioId) {
+    setStatus('Save a scenario first.', 'error', 5000);
+    return;
+  }
+  try {
+    const result = await api(`/api/scenario-saves/${encodeURIComponent(scenarioId)}/load`, {
+      method: 'POST',
+    });
+    applyConfigToForm(result.config);
+    ids.lineageResults.innerHTML = '';
+    ids.importResults.innerHTML = '';
+    await refresh();
+    await loadScenarioSaves();
+    ids.scenarioSave.value = result.save.scenario;
+    updateScenarioSaveDescription();
+    setStatus(`Loaded ${result.save.label} with ${result.loaded_records} saved event(s).`, 'success', 3500);
+  } catch (error) {
+    setStatus(error.message, 'error', 5000);
+  }
+}
+
 async function loadSelectedDemoFixture() {
   try {
     const config = buildConfig();
@@ -719,10 +818,13 @@ document.getElementById('stepBtn').addEventListener('click', stepOnce);
 document.getElementById('replayBtn').addEventListener('click', replayCurrentLog);
 document.getElementById('importCsvBtn').addEventListener('click', importCsv);
 document.getElementById('retryFailedBtn').addEventListener('click', retryFailedDeliveries);
+document.getElementById('saveScenarioBtn').addEventListener('click', saveCurrentScenario);
+document.getElementById('loadScenarioBtn').addEventListener('click', loadSavedScenario);
 document.getElementById('loadFixtureBtn').addEventListener('click', loadSelectedDemoFixture);
 document.getElementById('resetBtn').addEventListener('click', resetState);
 document.getElementById('refreshBtn').addEventListener('click', refresh);
 document.getElementById('lineageBtn').addEventListener('click', lookupLineage);
+ids.scenarioSave.addEventListener('change', updateScenarioSaveDescription);
 ids.demoFixture.addEventListener('change', updateDemoFixtureDescription);
 ids.exportPreset.addEventListener('change', updateExportLink);
 ids.exportLot.addEventListener('input', updateExportLink);
@@ -730,6 +832,9 @@ ids.exportStartDate.addEventListener('change', updateExportLink);
 ids.exportEndDate.addEventListener('change', updateExportLink);
 
 loadScenarios().catch((error) => {
+  setStatus(error.message, 'error', 5000);
+});
+loadScenarioSaves().catch((error) => {
   setStatus(error.message, 'error', 5000);
 });
 loadDemoFixtures().catch((error) => {

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -83,6 +83,25 @@
 
       <section class="panel">
         <div class="section-head">
+          <h2>Scenario saves</h2>
+        </div>
+        <div class="grid two-up">
+          <label>
+            Saved scenario
+            <select id="scenarioSave" name="scenarioSave">
+              <option value="">No saved scenarios</option>
+            </select>
+          </label>
+          <div class="field-action">
+            <button class="button secondary" id="saveScenarioBtn" type="button">Save scenario</button>
+            <button class="button secondary" id="loadScenarioBtn" type="button">Load saved</button>
+          </div>
+        </div>
+        <p class="note" id="scenarioSaveDescription">Save the current scenario controls and event log for later demos.</p>
+      </section>
+
+      <section class="panel">
+        <div class="section-head">
           <h2>Demo fixtures</h2>
         </div>
         <div class="grid two-up">

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -121,6 +121,8 @@ label {
 .field-action {
   display: flex;
   align-items: flex-end;
+  gap: 10px;
+  flex-wrap: wrap;
 }
 
 input,

--- a/app/store.py
+++ b/app/store.py
@@ -97,6 +97,19 @@ class EventStore:
 
         return [record for record in updated_records if record.record_id in replacements]
 
+    def replace_all(self, records: Iterable[StoredEventRecord]) -> list[StoredEventRecord]:
+        persisted_records = sorted(list(records), key=lambda record: record.sequence_no)
+        with self._lock:
+            self.persist_path.parent.mkdir(parents=True, exist_ok=True)
+            tmp_path = self.persist_path.with_suffix(f"{self.persist_path.suffix}.tmp")
+            with tmp_path.open("w", encoding="utf-8") as handle:
+                for record in persisted_records:
+                    handle.write(json.dumps(record.model_dump(mode="json")) + "\n")
+            tmp_path.replace(self.persist_path)
+            self._records = deque(reversed(persisted_records), maxlen=self.max_records)
+            self._counter = max((record.sequence_no for record in persisted_records), default=0)
+        return persisted_records
+
     def recent(self, limit: int = 100) -> list[StoredEventRecord]:
         with self._lock:
             return list(self._records)[:limit]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -5,7 +5,7 @@ import json
 
 from fastapi.testclient import TestClient
 
-from app.main import app, controller
+from app.main import app, controller, scenario_saves
 from app.models import SimulationConfig
 from app.scenarios import ScenarioId, get_scenario
 
@@ -63,6 +63,103 @@ def test_scenario_catalog_endpoint_lists_supported_presets():
         "retailer_readiness_demo",
     ]
     assert all(scenario["label"] for scenario in scenarios)
+
+
+def test_scenario_save_load_restores_config_and_event_log(tmp_path):
+    scenario_saves.configure(str(tmp_path / "scenario-saves"))
+    fresh_path = tmp_path / "fresh-cut-events.jsonl"
+    retailer_path = tmp_path / "retailer-events.jsonl"
+    client.post(
+        "/api/simulate/reset",
+        json={
+            "scenario": "fresh_cut_processor",
+            "batch_size": 1,
+            "seed": 204,
+            "persist_path": str(fresh_path),
+            "delivery": {"mode": "none"},
+        },
+    )
+    client.post(
+        "/api/demo-fixtures/fresh_cut_transformation/load",
+        json={
+            "source": "scenario-save-suite",
+            "delivery": {"mode": "none"},
+        },
+    )
+
+    save_response = client.post("/api/scenario-saves/fresh_cut_processor")
+    assert save_response.status_code == 200
+    save_body = save_response.json()
+    assert save_body["status"] == "saved"
+    assert save_body["save"]["scenario"] == "fresh_cut_processor"
+    assert save_body["save"]["record_count"] == 13
+    assert save_body["config"]["source"] == "scenario-save-suite"
+    assert save_body["config"]["delivery"]["mode"] == "none"
+
+    list_response = client.get("/api/scenario-saves")
+    assert list_response.status_code == 200
+    assert [save["scenario"] for save in list_response.json()["saves"]] == ["fresh_cut_processor"]
+
+    client.post(
+        "/api/simulate/reset",
+        json={
+            "scenario": "retailer_readiness_demo",
+            "batch_size": 1,
+            "seed": 204,
+            "persist_path": str(retailer_path),
+            "delivery": {"mode": "none"},
+        },
+    )
+    client.post("/api/simulate/step")
+    assert client.get("/api/simulate/status").json()["stats"]["total_records"] == 1
+
+    load_response = client.post("/api/scenario-saves/fresh_cut_processor/load")
+    assert load_response.status_code == 200
+    load_body = load_response.json()
+    assert load_body["status"] == "loaded"
+    assert load_body["loaded_records"] == 13
+    assert load_body["config"]["scenario"] == "fresh_cut_processor"
+    assert load_body["config"]["persist_path"] == str(fresh_path)
+
+    status = client.get("/api/simulate/status").json()
+    assert status["config"]["scenario"] == "fresh_cut_processor"
+    assert status["stats"]["total_records"] == 13
+    assert status["stats"]["engine"]["scenario"] == "fresh_cut_processor"
+    lineage = client.get("/api/lineage/TLC-DEMO-FC-OUT-001").json()
+    assert len(lineage["records"]) == 13
+
+
+def test_scenario_save_sanitizes_live_credentials_and_missing_load_returns_404(tmp_path):
+    scenario_saves.configure(str(tmp_path / "scenario-saves"))
+    response = client.post(
+        "/api/scenario-saves/retailer_readiness_demo",
+        json={
+            "config": {
+                "source": "live-suite",
+                "scenario": "retailer_readiness_demo",
+                "interval_seconds": 2,
+                "batch_size": 2,
+                "seed": 204,
+                "persist_path": str(tmp_path / "live-events.jsonl"),
+                "delivery": {
+                    "mode": "live",
+                    "endpoint": "https://www.regengine.co/api/v1/webhooks/ingest",
+                    "api_key": "secret-key",
+                    "tenant_id": "tenant-123",
+                },
+            }
+        },
+    )
+
+    assert response.status_code == 200
+    delivery = response.json()["config"]["delivery"]
+    assert delivery["mode"] == "mock"
+    assert delivery["endpoint"] is None
+    assert delivery["api_key"] is None
+    assert delivery["tenant_id"] is None
+
+    missing_response = client.post("/api/scenario-saves/leafy_greens_supplier/load")
+    assert missing_response.status_code == 404
 
 
 def test_demo_fixture_catalog_lists_supported_playbacks():


### PR DESCRIPTION
## Summary
- Add per-scenario saved demo states that capture sanitized simulator config plus current stored event records.
- Add API routes for listing, saving, and loading scenario saves.
- Add dashboard controls for saving/loading scenario states and update docs/backlog.

## Safety and UX
- Live API keys are never persisted in saved scenario configs.
- Live delivery saves are restored as mock delivery to preserve mock-first behavior.
- Loading a scenario restores the saved event log so lineage and exports remain derivable from stored records.

## Validation
- `pytest` passed: 41/41
- `node --check app/static/app.js`
- `python3 -m compileall app`
- `git diff --check`
- Browser smoke covered fixture load, scenario save, reset, step, saved load, lineage lookup, start/stop, and reset