### PR TITLE
[codex] Add basic auth tenant storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,6 @@ htmlcov/
 data/*.jsonl
 data/*.csv
 data/scenario_saves/
+data/tenants/
 uvicorn.out.log
 uvicorn.err.log

--- a/AUTOPILOT_TASKS.md
+++ b/AUTOPILOT_TASKS.md
@@ -28,7 +28,7 @@ This file is the standing backlog for unattended Codex runs.
 
 - [x] Add EPCIS 2.0 export scaffolding without breaking the current webhook contract.
 - [x] Add per-scenario save/load support.
-- [ ] Add basic auth and tenant-scoped storage boundaries.
+- [x] Add basic auth and tenant-scoped storage boundaries.
 
 ## Progress notes
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A mock-first FSMA 204 traceability simulator that emits **RegEngine-compatible i
 - [Quick start (local dev)](#quick-start-local-dev)
 - [Running tests](#running-tests)
 - [Delivery modes](#delivery-modes)
+- [Basic auth and tenant storage](#basic-auth-and-tenant-storage)
 - [Replay mode](#replay-mode)
 - [CSV import](#csv-import)
 - [Scenario presets](#scenario-presets)
@@ -42,6 +43,7 @@ Each event is persisted with `event_id`, `sha256_hash`, and `chain_hash` so the 
 
 ```text
 app/
+  auth.py                # Optional Basic Auth and tenant context resolution
   controller.py          # Simulator lifecycle (start/stop/step/reset)
   demo_fixtures.py       # Deterministic demo playback fixtures
   engine.py              # CTE generation and lot lineage logic
@@ -90,7 +92,7 @@ http://127.0.0.1:8000
 
 The dashboard lets you choose a scenario preset, save/load per-scenario demo states, load deterministic demo fixtures, start/stop/step/reset the simulator, replay the current persisted event log, import CSV seed lots or scheduled events, inspect recent events, trace lot lineage, and export mock FDA request CSV presets. API users can also derive scaffolded EPCIS 2.0 JSON-LD exports from the same stored records. It subscribes to live status/event snapshots with Server-Sent Events and falls back to refresh polling if the stream disconnects. Delivery mode defaults to **`mock`** so no credentials are required.
 
-Event records are stored as JSONL at `config.persist_path` (`data/events.jsonl` by default). Existing records at that path are loaded when the app starts or when a start/reset request points at a different path; reset clears the currently configured event log. Replay reads the JSONL log without appending, duplicating, or rewriting stored events.
+Event records are stored as JSONL at `config.persist_path` (`data/events.jsonl` by default for local unauthenticated use). Existing records at that path are loaded when the app starts or when a start/reset request points at a different path; reset clears the currently configured event log. Tenant-scoped requests store records under `data/tenants/{tenant_id}/events.jsonl` and ignore untrusted persist-path overrides. Replay reads the JSONL log without appending, duplicating, or rewriting stored events.
 
 ## Running tests
 
@@ -118,6 +120,19 @@ Sends real traffic to a RegEngine workspace. Configure from the dashboard or via
 Generates and persists events locally without delivering them anywhere. Useful for seeding fixtures.
 
 Every stored record tracks `delivery_status`, `destination_mode`, `delivery_attempts`, and last delivery timestamps. The dashboard delivery monitor summarizes posted, failed, generated-only, and retryable records. Failed records can be retried through the dashboard or `POST /api/delivery/retry` after switching to a working `mock` or `live` delivery configuration.
+
+## Basic auth and tenant storage
+
+Basic Auth is opt-in so local mock demos remain frictionless. Set both environment variables to require credentials for the dashboard and API:
+
+```bash
+export REGENGINE_BASIC_AUTH_USERNAME=demo
+export REGENGINE_BASIC_AUTH_PASSWORD=change-me
+```
+
+When Basic Auth is enabled, requests without valid credentials receive `401` with a `WWW-Authenticate` challenge. If no tenant header is supplied, the authenticated username becomes the tenant id.
+
+Use `X-RegEngine-Tenant` to select an explicit tenant scope. Tenant ids must be 1-64 characters and can contain only letters, numbers, dots, underscores, or hyphens. Tenant-scoped controllers keep separate simulator state, event logs, mock ingest responses, scenario saves, lineage, and exports under `data/tenants/{tenant_id}/`.
 
 ## Replay mode
 
@@ -251,6 +266,8 @@ The export returns an `EPCISDocument` with `ObjectEvent` records for harvesting,
 | `GET` | `/api/simulate/stream` | Server-Sent Events snapshots for live dashboard updates |
 | `POST` | `/api/import/csv` | Bulk import scheduled events or seed lots from CSV text |
 | `POST` | `/api/delivery/retry` | Retry failed stored deliveries with the current or supplied delivery config |
+
+All routes accept optional `X-RegEngine-Tenant` for tenant-scoped storage. If Basic Auth is enabled, include standard HTTP Basic credentials.
 
 ### Inspection
 
@@ -539,6 +556,8 @@ docker run --rm -p 8000:8000 regengine-inflow-lab
 | `uvicorn.out.log` | Server stdout (request logs, lifecycle messages) |
 | `uvicorn.err.log` | Server stderr (Python tracebacks, startup errors) |
 | `data/events.jsonl` | Persisted simulator events |
+| `data/tenants/{tenant_id}/events.jsonl` | Tenant-scoped simulator events |
+| `data/tenants/{tenant_id}/scenario_saves/` | Tenant-scoped saved scenario states |
 
 Common checks:
 

--- a/app/auth.py
+++ b/app/auth.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import base64
+import os
+import re
+import secrets
+from dataclasses import dataclass
+
+from fastapi import Request
+from fastapi.responses import JSONResponse
+
+
+DEFAULT_TENANT_ID = "local-demo"
+TENANT_HEADER = "X-RegEngine-Tenant"
+_TENANT_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]{0,63}$")
+
+
+@dataclass(frozen=True, slots=True)
+class BasicAuthConfig:
+    username: str | None
+    password: str | None
+    default_tenant: str = DEFAULT_TENANT_ID
+
+    @property
+    def enabled(self) -> bool:
+        return bool(self.username and self.password)
+
+
+@dataclass(frozen=True, slots=True)
+class TenantContext:
+    tenant_id: str
+    auth_enabled: bool = False
+    username: str | None = None
+
+    @property
+    def uses_default_storage(self) -> bool:
+        return self.tenant_id == DEFAULT_TENANT_ID and not self.auth_enabled
+
+
+def basic_auth_config_from_env() -> BasicAuthConfig:
+    return BasicAuthConfig(
+        username=os.getenv("REGENGINE_BASIC_AUTH_USERNAME"),
+        password=os.getenv("REGENGINE_BASIC_AUTH_PASSWORD"),
+        default_tenant=normalize_tenant_id(
+            os.getenv("REGENGINE_DEFAULT_TENANT", DEFAULT_TENANT_ID)
+        ),
+    )
+
+
+def tenant_context_from_request(request: Request) -> TenantContext | JSONResponse:
+    config = basic_auth_config_from_env()
+    username = None
+    if config.enabled:
+        credentials = _parse_basic_authorization(request.headers.get("authorization"))
+        if credentials is None:
+            return _unauthorized_response()
+
+        supplied_username, supplied_password = credentials
+        if not (
+            secrets.compare_digest(supplied_username, config.username or "")
+            and secrets.compare_digest(supplied_password, config.password or "")
+        ):
+            return _unauthorized_response()
+        username = supplied_username
+
+    requested_tenant = request.headers.get(TENANT_HEADER) or username or config.default_tenant
+    try:
+        tenant_id = normalize_tenant_id(requested_tenant)
+    except ValueError as exc:
+        return JSONResponse(status_code=400, content={"detail": str(exc)})
+
+    return TenantContext(
+        tenant_id=tenant_id,
+        auth_enabled=config.enabled,
+        username=username,
+    )
+
+
+def normalize_tenant_id(value: str) -> str:
+    tenant_id = value.strip()
+    if not _TENANT_PATTERN.fullmatch(tenant_id):
+        raise ValueError(
+            "Tenant id must be 1-64 characters and contain only letters, numbers, dots, underscores, or hyphens"
+        )
+    return tenant_id
+
+
+def _parse_basic_authorization(header: str | None) -> tuple[str, str] | None:
+    if not header:
+        return None
+    scheme, _, encoded = header.partition(" ")
+    if scheme.lower() != "basic" or not encoded:
+        return None
+    try:
+        decoded = base64.b64decode(encoded, validate=True).decode("utf-8")
+    except (ValueError, UnicodeDecodeError):
+        return None
+    username, separator, password = decoded.partition(":")
+    if not separator:
+        return None
+    return username, password
+
+
+def _unauthorized_response() -> JSONResponse:
+    return JSONResponse(
+        status_code=401,
+        content={"detail": "Authentication required"},
+        headers={"WWW-Authenticate": 'Basic realm="RegEngine Inflow Lab"'},
+    )

--- a/app/main.py
+++ b/app/main.py
@@ -5,6 +5,7 @@ import json
 from contextlib import asynccontextmanager
 from datetime import UTC, datetime
 from pathlib import Path
+from threading import RLock
 from typing import Any
 
 from fastapi import FastAPI, HTTPException, Query, Request
@@ -12,6 +13,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, JSONResponse, PlainTextResponse, StreamingResponse
 from fastapi.staticfiles import StaticFiles
 
+from .auth import DEFAULT_TENANT_ID, TenantContext, tenant_context_from_request
 from .controller import SimulationController
 from .demo_fixtures import list_demo_fixture_summaries
 from .engine import LegitFlowEngine
@@ -62,6 +64,8 @@ from .scenarios import ScenarioId, list_scenario_summaries
 from .store import EventStore
 
 
+TENANT_DATA_ROOT = Path("data/tenants")
+
 engine = LegitFlowEngine(seed=204)
 store = EventStore(persist_path="data/events.jsonl")
 scenario_saves = ScenarioSaveStore()
@@ -73,12 +77,15 @@ controller = SimulationController(
     mock_service=mock_service,
     live_client=LiveRegEngineClient(),
 )
+_tenant_controllers: dict[str, SimulationController] = {DEFAULT_TENANT_ID: controller}
+_tenant_lock = RLock()
 
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     yield
-    await controller.shutdown()
+    for tenant_controller in set(_tenant_controllers.values()):
+        await tenant_controller.shutdown()
 
 
 app = FastAPI(
@@ -95,6 +102,18 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+
+@app.middleware("http")
+async def auth_and_tenant_middleware(request: Request, call_next):
+    if request.method == "OPTIONS":
+        return await call_next(request)
+
+    context = tenant_context_from_request(request)
+    if isinstance(context, JSONResponse):
+        return context
+    request.state.tenant_context = context
+    return await call_next(request)
+
 static_dir = Path(__file__).parent / "static"
 app.mount("/static", StaticFiles(directory=static_dir), name="static")
 
@@ -105,17 +124,19 @@ async def root() -> FileResponse:
 
 
 @app.get("/api/health")
-async def health() -> dict[str, Any]:
+async def health(request: Request) -> dict[str, Any]:
+    active_controller = _active_controller(request)
     return {
         "ok": True,
         "utc_time": datetime.now(UTC).isoformat(),
-        "status": controller.status(),
+        "tenant": _tenant_context(request).tenant_id,
+        "status": active_controller.status(),
     }
 
 
 @app.get("/api/simulate/status", response_model=StatusResponse)
-async def simulate_status() -> StatusResponse:
-    status = controller.status()
+async def simulate_status(request: Request) -> StatusResponse:
+    status = _active_controller(request).status()
     return StatusResponse.model_validate(status)
 
 
@@ -127,27 +148,31 @@ async def list_scenarios() -> ScenarioListResponse:
 
 
 @app.get("/api/scenario-saves", response_model=ScenarioSaveListResponse)
-async def list_saved_scenarios() -> ScenarioSaveListResponse:
+async def list_saved_scenarios(request: Request) -> ScenarioSaveListResponse:
+    active_controller = _active_controller(request)
     return ScenarioSaveListResponse(
         saves=[
             ScenarioSaveSummary.model_validate(summary)
-            for summary in controller.list_scenario_saves().saves
+            for summary in active_controller.list_scenario_saves().saves
         ]
     )
 
 
 @app.post("/api/scenario-saves/{scenario_id}", response_model=ScenarioSaveResponse)
 async def save_scenario(
+    http_request: Request,
     scenario_id: ScenarioId,
     request: ScenarioSaveRequest | None = None,
 ) -> ScenarioSaveResponse:
-    return await controller.save_scenario(scenario_id, request)
+    active_controller = _active_controller(http_request)
+    scoped_request = _scope_scenario_save_request(http_request, request)
+    return await active_controller.save_scenario(scenario_id, scoped_request)
 
 
 @app.post("/api/scenario-saves/{scenario_id}/load", response_model=ScenarioLoadResponse)
-async def load_saved_scenario(scenario_id: ScenarioId) -> ScenarioLoadResponse:
+async def load_saved_scenario(http_request: Request, scenario_id: ScenarioId) -> ScenarioLoadResponse:
     try:
-        return await controller.load_scenario_save(scenario_id)
+        return await _active_controller(http_request).load_scenario_save(scenario_id)
     except KeyError as exc:
         raise HTTPException(status_code=404, detail="No saved scenario found") from exc
 
@@ -164,10 +189,11 @@ async def list_demo_fixtures() -> DemoFixtureListResponse:
 
 @app.post("/api/demo-fixtures/{fixture_id}/load", response_model=DemoFixtureLoadResponse)
 async def load_demo_fixture(
+    http_request: Request,
     fixture_id: DemoFixtureId,
     request: DemoFixtureLoadRequest | None = None,
 ) -> DemoFixtureLoadResponse:
-    return await controller.load_demo_fixture(fixture_id, request)
+    return await _active_controller(http_request).load_demo_fixture(fixture_id, request)
 
 
 def sse_message(event_name: str, payload: dict[str, Any]) -> str:
@@ -181,8 +207,10 @@ async def simulate_stream(
     limit: int = Query(default=100, ge=1, le=500),
     once: bool = Query(default=False),
 ) -> StreamingResponse:
+    active_controller = _active_controller(request)
+
     async def event_generator():
-        snapshot = controller.snapshot(event_limit=limit)
+        snapshot = active_controller.snapshot(event_limit=limit)
         last_revision = snapshot["revision"]
         yield sse_message("snapshot", snapshot)
         if once:
@@ -192,12 +220,12 @@ async def simulate_stream(
             if await request.is_disconnected():
                 break
             try:
-                last_revision = await controller.wait_for_revision(last_revision)
+                last_revision = await active_controller.wait_for_revision(last_revision)
             except asyncio.TimeoutError:
                 yield ": keep-alive\n\n"
                 continue
 
-            snapshot = controller.snapshot(event_limit=limit)
+            snapshot = active_controller.snapshot(event_limit=limit)
             last_revision = snapshot["revision"]
             yield sse_message("snapshot", snapshot)
 
@@ -212,64 +240,76 @@ async def simulate_stream(
 
 
 @app.post("/api/simulate/start", response_model=StatusResponse)
-async def simulate_start(request: StartRequest) -> StatusResponse:
-    await controller.start(request.config)
-    return StatusResponse.model_validate(controller.status())
+async def simulate_start(http_request: Request, request: StartRequest) -> StatusResponse:
+    active_controller = _active_controller(http_request)
+    await active_controller.start(_scope_config(http_request, request.config))
+    return StatusResponse.model_validate(active_controller.status())
 
 
 @app.post("/api/simulate/stop", response_model=StatusResponse)
-async def simulate_stop() -> StatusResponse:
-    await controller.stop()
-    return StatusResponse.model_validate(controller.status())
+async def simulate_stop(request: Request) -> StatusResponse:
+    active_controller = _active_controller(request)
+    await active_controller.stop()
+    return StatusResponse.model_validate(active_controller.status())
 
 
 @app.post("/api/simulate/reset", response_model=ResetResponse)
-async def simulate_reset(config: SimulationConfig | None = None) -> ResetResponse:
-    await controller.reset(config)
+async def simulate_reset(request: Request, config: SimulationConfig | None = None) -> ResetResponse:
+    await _active_controller(request).reset(_scope_config(request, config) if config else None)
     return ResetResponse(status="reset")
 
 
 @app.post("/api/simulate/step", response_model=StepResponse)
-async def simulate_step(batch_size: int | None = Query(default=None, ge=1, le=100)) -> StepResponse:
-    return await controller.step(batch_size=batch_size)
+async def simulate_step(
+    request: Request,
+    batch_size: int | None = Query(default=None, ge=1, le=100),
+) -> StepResponse:
+    return await _active_controller(request).step(batch_size=batch_size)
 
 
 @app.post("/api/simulate/replay", response_model=ReplayResponse)
-async def simulate_replay(request: ReplayRequest | None = None) -> ReplayResponse:
-    return await controller.replay(request)
+async def simulate_replay(http_request: Request, request: ReplayRequest | None = None) -> ReplayResponse:
+    return await _active_controller(http_request).replay(_scope_replay_request(http_request, request))
 
 
 @app.post("/api/import/csv", response_model=CSVImportResponse)
-async def import_csv(request: CSVImportRequest) -> CSVImportResponse:
-    return await controller.import_csv(request)
+async def import_csv(http_request: Request, request: CSVImportRequest) -> CSVImportResponse:
+    return await _active_controller(http_request).import_csv(request)
 
 
 @app.post("/api/delivery/retry", response_model=DeliveryRetryResponse)
-async def retry_failed_delivery(request: DeliveryRetryRequest | None = None) -> DeliveryRetryResponse:
-    return await controller.retry_failed_delivery(request)
+async def retry_failed_delivery(
+    http_request: Request,
+    request: DeliveryRetryRequest | None = None,
+) -> DeliveryRetryResponse:
+    return await _active_controller(http_request).retry_failed_delivery(request)
 
 
 @app.get("/api/events", response_model=EventListResponse)
-async def list_events(limit: int = Query(default=100, ge=1, le=500)) -> EventListResponse:
-    return EventListResponse(events=store.recent(limit=limit))
+async def list_events(
+    request: Request,
+    limit: int = Query(default=100, ge=1, le=500),
+) -> EventListResponse:
+    return EventListResponse(events=_active_controller(request).store.recent(limit=limit))
 
 
 @app.get("/api/lineage/{traceability_lot_code}", response_model=LineageResponse)
-async def get_lineage(traceability_lot_code: str) -> LineageResponse:
-    records = store.lineage(traceability_lot_code)
+async def get_lineage(request: Request, traceability_lot_code: str) -> LineageResponse:
+    active_controller = _active_controller(request)
+    records = active_controller.store.lineage(traceability_lot_code)
     if not records:
         raise HTTPException(status_code=404, detail="No records found for that lot code")
     return LineageResponse(
         traceability_lot_code=traceability_lot_code,
         records=records,
-        nodes=store.lineage_nodes(records),
-        edges=store.lineage_edges(records),
+        nodes=active_controller.store.lineage_nodes(records),
+        edges=active_controller.store.lineage_edges(records),
     )
 
 
 @app.post("/api/mock/regengine/ingest", response_model=MockIngestResponse)
-async def mock_regengine_ingest(payload: IngestPayload) -> MockIngestResponse:
-    return mock_service.ingest(payload)
+async def mock_regengine_ingest(request: Request, payload: IngestPayload) -> MockIngestResponse:
+    return _active_controller(request).mock_service.ingest(payload)
 
 
 @app.get("/api/mock/regengine/export/presets", response_model=FDAExportPresetListResponse)
@@ -284,24 +324,26 @@ async def mock_fda_request_export_presets() -> FDAExportPresetListResponse:
 
 @app.get("/api/mock/regengine/export/fda-request")
 async def mock_fda_request_export(
+    request: Request,
     start_date: str | None = Query(default=None, description="Inclusive YYYY-MM-DD"),
     end_date: str | None = Query(default=None, description="Inclusive YYYY-MM-DD"),
     preset: FDAExportPreset = Query(default=FDAExportPreset.ALL_RECORDS),
     traceability_lot_code: str | None = Query(default=None),
 ) -> PlainTextResponse:
+    active_controller = _active_controller(request)
     definition = FDA_EXPORT_PRESETS[preset]
     if definition.requires_lot_code and not traceability_lot_code:
         raise HTTPException(status_code=400, detail="traceability_lot_code is required for this export preset")
 
     if traceability_lot_code:
-        records = store.lineage(traceability_lot_code)
+        records = active_controller.store.lineage(traceability_lot_code)
         if not records:
             raise HTTPException(status_code=404, detail="No records found for that lot code")
         records = _filter_records_between(records, start_date=start_date, end_date=end_date)
     else:
-        records = store.all_between(start_date=start_date, end_date=end_date)
+        records = active_controller.store.all_between(start_date=start_date, end_date=end_date)
     records = apply_fda_export_preset(records, preset)
-    csv_text = render_fda_request_csv(records, location_gln=engine.location_gln)
+    csv_text = render_fda_request_csv(records, location_gln=active_controller.engine.location_gln)
     return PlainTextResponse(
         content=csv_text,
         media_type="text/csv",
@@ -311,22 +353,24 @@ async def mock_fda_request_export(
 
 @app.get("/api/mock/regengine/export/epcis")
 async def mock_epcis_export(
+    request: Request,
     start_date: str | None = Query(default=None, description="Inclusive YYYY-MM-DD"),
     end_date: str | None = Query(default=None, description="Inclusive YYYY-MM-DD"),
     traceability_lot_code: str | None = Query(default=None),
 ) -> JSONResponse:
+    active_controller = _active_controller(request)
     if traceability_lot_code:
-        records = store.lineage(traceability_lot_code)
+        records = active_controller.store.lineage(traceability_lot_code)
         if not records:
             raise HTTPException(status_code=404, detail="No records found for that lot code")
         records = _filter_records_between(records, start_date=start_date, end_date=end_date)
     else:
-        records = store.all_between(start_date=start_date, end_date=end_date)
+        records = active_controller.store.all_between(start_date=start_date, end_date=end_date)
 
     document = render_epcis_document(
         records,
-        source=controller.config.source,
-        location_gln=engine.location_gln,
+        source=active_controller.config.source,
+        location_gln=active_controller.engine.location_gln,
     )
     return JSONResponse(
         content=document,
@@ -349,6 +393,84 @@ def _filter_records_between(
             continue
         filtered.append(record)
     return sorted(filtered, key=lambda record: record.event.timestamp)
+
+
+def _tenant_context(request: Request) -> TenantContext:
+    return getattr(request.state, "tenant_context", TenantContext(tenant_id=DEFAULT_TENANT_ID))
+
+
+def _active_controller(request: Request) -> SimulationController:
+    context = _tenant_context(request)
+    if context.uses_default_storage:
+        return controller
+
+    with _tenant_lock:
+        existing_controller = _tenant_controllers.get(context.tenant_id)
+        if existing_controller is not None:
+            return existing_controller
+
+        tenant_controller = _create_tenant_controller(context.tenant_id)
+        _tenant_controllers[context.tenant_id] = tenant_controller
+        return tenant_controller
+
+
+def _create_tenant_controller(tenant_id: str) -> SimulationController:
+    persist_path = _tenant_events_path(tenant_id)
+    tenant_engine = LegitFlowEngine(seed=204)
+    tenant_store = EventStore(persist_path=str(persist_path))
+    tenant_saves = ScenarioSaveStore(save_dir=str(_tenant_saves_path(tenant_id)))
+    return SimulationController(
+        engine=tenant_engine,
+        store=tenant_store,
+        scenario_saves=tenant_saves,
+        mock_service=MockRegEngineService(),
+        live_client=LiveRegEngineClient(),
+    )
+
+
+def _scope_config(request: Request, config: SimulationConfig) -> SimulationConfig:
+    context = _tenant_context(request)
+    if context.uses_default_storage:
+        return config
+    return config.model_copy(
+        update={"persist_path": str(_tenant_events_path(context.tenant_id))},
+        deep=True,
+    )
+
+
+def _scope_replay_request(request: Request, replay_request: ReplayRequest | None) -> ReplayRequest | None:
+    context = _tenant_context(request)
+    if context.uses_default_storage:
+        return replay_request
+    request_body = replay_request or ReplayRequest()
+    return request_body.model_copy(
+        update={"persist_path": str(_tenant_events_path(context.tenant_id))},
+        deep=True,
+    )
+
+
+def _scope_scenario_save_request(
+    request: Request,
+    save_request: ScenarioSaveRequest | None,
+) -> ScenarioSaveRequest | None:
+    if save_request is None or save_request.config is None:
+        return save_request
+    return save_request.model_copy(
+        update={"config": _scope_config(request, save_request.config)},
+        deep=True,
+    )
+
+
+def _tenant_dir(tenant_id: str) -> Path:
+    return TENANT_DATA_ROOT / tenant_id
+
+
+def _tenant_events_path(tenant_id: str) -> Path:
+    return _tenant_dir(tenant_id) / "events.jsonl"
+
+
+def _tenant_saves_path(tenant_id: str) -> Path:
+    return _tenant_dir(tenant_id) / "scenario_saves"
 
 
 @app.exception_handler(ValueError)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,4 +1,5 @@
 import asyncio
+import base64
 import csv
 import io
 import json
@@ -11,6 +12,11 @@ from app.scenarios import ScenarioId, get_scenario
 
 
 client = TestClient(app)
+
+
+def basic_auth_header(username: str, password: str) -> dict[str, str]:
+    token = base64.b64encode(f"{username}:{password}".encode("utf-8")).decode("ascii")
+    return {"Authorization": f"Basic {token}"}
 
 
 def setup_function() -> None:
@@ -63,6 +69,66 @@ def test_scenario_catalog_endpoint_lists_supported_presets():
         "retailer_readiness_demo",
     ]
     assert all(scenario["label"] for scenario in scenarios)
+
+
+def test_basic_auth_is_optional_but_enforced_when_configured(monkeypatch):
+    assert client.get("/api/health").status_code == 200
+
+    monkeypatch.setenv("REGENGINE_BASIC_AUTH_USERNAME", "demo-user")
+    monkeypatch.setenv("REGENGINE_BASIC_AUTH_PASSWORD", "demo-pass")
+
+    unauthorized = client.get("/api/health")
+    assert unauthorized.status_code == 401
+    assert unauthorized.headers["www-authenticate"] == 'Basic realm="RegEngine Inflow Lab"'
+
+    bad_password = client.get("/api/health", headers=basic_auth_header("demo-user", "wrong"))
+    assert bad_password.status_code == 401
+
+    authorized = client.get("/api/health", headers=basic_auth_header("demo-user", "demo-pass"))
+    assert authorized.status_code == 200
+    assert authorized.json()["tenant"] == "demo-user"
+
+
+def test_tenant_header_scopes_event_storage_and_rejects_invalid_ids(tmp_path):
+    alpha_headers = {"X-RegEngine-Tenant": "tenant-alpha"}
+    beta_headers = {"X-RegEngine-Tenant": "tenant-beta"}
+    alpha_path = tmp_path / "alpha-escape-attempt.jsonl"
+
+    reset_response = client.post(
+        "/api/simulate/reset",
+        headers=alpha_headers,
+        json={
+            "batch_size": 1,
+            "seed": 204,
+            "persist_path": str(alpha_path),
+            "delivery": {"mode": "none"},
+        },
+    )
+    assert reset_response.status_code == 200
+    assert client.post(
+        "/api/simulate/reset",
+        headers=beta_headers,
+        json={"batch_size": 1, "seed": 204, "delivery": {"mode": "none"}},
+    ).status_code == 200
+
+    step_response = client.post("/api/simulate/step", headers=alpha_headers)
+    assert step_response.status_code == 200
+
+    alpha_status = client.get("/api/simulate/status", headers=alpha_headers).json()
+    beta_status = client.get("/api/simulate/status", headers=beta_headers).json()
+    assert alpha_status["stats"]["total_records"] == 1
+    assert beta_status["stats"]["total_records"] == 0
+    assert alpha_status["config"]["persist_path"] == "data/tenants/tenant-alpha/events.jsonl"
+    assert beta_status["config"]["persist_path"] == "data/tenants/tenant-beta/events.jsonl"
+    assert not alpha_path.exists()
+
+    alpha_events = client.get("/api/events", headers=alpha_headers).json()["events"]
+    beta_events = client.get("/api/events", headers=beta_headers).json()["events"]
+    assert len(alpha_events) == 1
+    assert beta_events == []
+
+    invalid_response = client.get("/api/health", headers={"X-RegEngine-Tenant": "../tenant"})
+    assert invalid_response.status_code == 400
 
 
 def test_scenario_save_load_restores_config_and_event_log(tmp_path):


### PR DESCRIPTION
## Summary
- Add optional Basic Auth middleware, enabled only when `REGENGINE_BASIC_AUTH_USERNAME` and `REGENGINE_BASIC_AUTH_PASSWORD` are set.
- Add tenant context resolution with `X-RegEngine-Tenant` and per-tenant controllers/stores under `data/tenants/{tenant_id}/`.
- Keep unauthenticated local mock mode on the existing default storage path while tenant-scoped requests isolate state, events, scenario saves, lineage, and exports.
- Document auth/tenant behavior and mark the final Priority 3 backlog item complete.

## Contract safety
- RegEngine ingest payload shape remains unchanged.
- Live delivery remains opt-in and mock mode remains the default.
- Tenant-scoped requests ignore untrusted persist-path overrides and use tenant-owned JSONL storage.

## Validation
- `pytest` passed: 43/43
- `python3 -m compileall app`
- `node --check app/static/app.js`
- `git diff --check`
- Browser smoke covered fixture load, lineage lookup, start/stop, and reset through the dashboard