### PR TITLE
[codex] Add release regression harness

### DIFF
--- a/AUTOPILOT_TASKS.md
+++ b/AUTOPILOT_TASKS.md
@@ -30,6 +30,13 @@ This file is the standing backlog for unattended Codex runs.
 - [x] Add per-scenario save/load support.
 - [x] Add basic auth and tenant-scoped storage boundaries.
 
+## Priority 4
+
+- [x] Add release smoke regression harness and checklist.
+- [ ] Add tenant/auth status and EPCIS export controls to the dashboard.
+- [ ] Add a design-partner demo script with expected talking points and reset steps.
+- [ ] Add deployment profile examples for local, shared demo, and live-ingest modes.
+
 ## Progress notes
 
 - Start with the smallest safe change that materially improves demo readiness.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A mock-first FSMA 204 traceability simulator that emits **RegEngine-compatible i
 - [Project layout](#project-layout)
 - [Quick start (local dev)](#quick-start-local-dev)
 - [Running tests](#running-tests)
+- [Release smoke regression](#release-smoke-regression)
 - [Delivery modes](#delivery-modes)
 - [Basic auth and tenant storage](#basic-auth-and-tenant-storage)
 - [Replay mode](#replay-mode)
@@ -62,10 +63,13 @@ app/
   codex/prompts/autobuild.md
   workflows/ci.yml
   workflows/codex-autopilot.yml
+scripts/
+  smoke_regression.py    # End-to-end API smoke for demo-ready release checks
 tests/
 AGENTS.md                # Repository instructions for Codex-style agents
 AUTOPILOT_TASKS.md       # Standing backlog for unattended runs
 PROMPT_FOR_CODEX.md      # Paste-ready Codex task prompt
+RELEASE_CHECKLIST.md     # Demo-ready release gate
 pyproject.toml
 requirements.txt
 ```
@@ -101,6 +105,18 @@ pytest
 ```
 
 The suite covers payload shape, engine determinism, and the HTTP API contract.
+
+## Release smoke regression
+
+Run the release smoke harness before tagging or handing the simulator to a design partner:
+
+```bash
+python3 scripts/smoke_regression.py
+```
+
+The smoke harness uses FastAPI's in-process `TestClient` to exercise the operator-critical path: tenant-scoped fixture load, lineage lookup, FDA export, EPCIS export, scenario save/load, replay, and tenant isolation. If Basic Auth env vars are set, it sends matching Basic credentials automatically. Temporary smoke tenants are cleaned up after the run.
+
+Use `RELEASE_CHECKLIST.md` as the full demo-ready gate.
 
 ## Delivery modes
 

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -1,0 +1,38 @@
+# Release Checklist
+
+Use this checklist before tagging a demo-ready build or handing the simulator to a design partner.
+
+## Required Verification
+
+- [ ] `pytest`
+- [ ] `python3 scripts/smoke_regression.py`
+- [ ] `node --check app/static/app.js`
+- [ ] `python3 -m compileall app`
+- [ ] `git diff --check`
+
+## Contract Checks
+
+- [ ] Mock and live ingest payloads still use top-level `source` plus `events[]`.
+- [ ] Each event still includes `cte_type`, `traceability_lot_code`, `product_description`, `quantity`, `unit_of_measure`, `location_name`, `timestamp`, and `kdes`.
+- [ ] Mock mode remains the default delivery mode.
+- [ ] Live delivery still requires `api_key` and `tenant_id`.
+- [ ] New export or dashboard behavior is derived from stored records and does not mutate the ingest contract.
+
+## Operator Flow Checks
+
+- [ ] Dashboard loads without credentials when Basic Auth env vars are unset.
+- [ ] Basic Auth returns `401` without valid credentials when env vars are set.
+- [ ] Demo fixture loading resets to a known event log.
+- [ ] Start, stop, single-step, and reset work from the dashboard.
+- [ ] Scenario save/load restores both config and event records.
+- [ ] Lot lineage for `TLC-DEMO-FC-OUT-001` includes upstream harvested and packed lots.
+- [ ] FDA lot-trace export includes `BATCH-DEMO-FC-001`.
+- [ ] EPCIS export includes a `TransformationEvent`.
+- [ ] Tenant-scoped requests keep separate event logs and scenario saves.
+
+## Handoff Notes
+
+- [ ] README has the current API surface and setup instructions.
+- [ ] `AUTOPILOT_TASKS.md` reflects the current backlog state.
+- [ ] No generated data files are staged.
+- [ ] Any live endpoint or credential values are excluded from docs, logs, fixtures, saved scenarios, and commits.

--- a/scripts/smoke_regression.py
+++ b/scripts/smoke_regression.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+import base64
+import os
+import shutil
+import sys
+from pathlib import Path
+from typing import Any
+
+from fastapi.testclient import TestClient
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+from app.main import app
+
+
+TENANTS = ["release-smoke-main", "release-smoke-other"]
+
+
+class SmokeFailure(AssertionError):
+    pass
+
+
+def main() -> int:
+    client = TestClient(app)
+    try:
+        run_smoke(client)
+    finally:
+        cleanup_smoke_tenants()
+    print("Release smoke regression passed.")
+    return 0
+
+
+def run_smoke(client: TestClient) -> None:
+    main_headers = request_headers(TENANTS[0])
+    other_headers = request_headers(TENANTS[1])
+
+    assert_status(client.get("/api/health", headers=main_headers), 200)
+    reset_response = client.post(
+        "/api/simulate/reset",
+        headers=main_headers,
+        json={
+            "scenario": "fresh_cut_processor",
+            "batch_size": 1,
+            "seed": 204,
+            "delivery": {"mode": "none"},
+        },
+    )
+    assert_status(reset_response, 200)
+
+    fixture_response = client.post(
+        "/api/demo-fixtures/fresh_cut_transformation/load",
+        headers=main_headers,
+        json={
+            "source": "release-smoke",
+            "delivery": {"mode": "none"},
+        },
+    )
+    fixture = assert_json(fixture_response, 200)
+    assert_equal(fixture["stored"], 13, "fixture stored events")
+    assert_equal(fixture["delivery_mode"], "none", "fixture delivery mode")
+
+    status = assert_json(client.get("/api/simulate/status", headers=main_headers), 200)
+    assert_equal(status["stats"]["total_records"], 13, "fixture status total")
+    assert_equal(
+        status["config"]["persist_path"],
+        "data/tenants/release-smoke-main/events.jsonl",
+        "tenant persist path",
+    )
+
+    lineage = assert_json(
+        client.get("/api/lineage/TLC-DEMO-FC-OUT-001", headers=main_headers),
+        200,
+    )
+    lineage_lots = {record["event"]["traceability_lot_code"] for record in lineage["records"]}
+    assert_in("TLC-DEMO-FC-HARVEST-001", lineage_lots, "lineage upstream harvest lot")
+    assert_in("TLC-DEMO-FC-PACK-001", lineage_lots, "lineage input packed lot")
+
+    fda_response = client.get(
+        "/api/mock/regengine/export/fda-request?preset=lot_trace&traceability_lot_code=TLC-DEMO-FC-OUT-001",
+        headers=main_headers,
+    )
+    assert_status(fda_response, 200)
+    assert_in("BATCH-DEMO-FC-001", fda_response.text, "FDA lot trace batch reference")
+
+    epcis = assert_json(
+        client.get(
+            "/api/mock/regengine/export/epcis?traceability_lot_code=TLC-DEMO-FC-OUT-001",
+            headers=main_headers,
+        ),
+        200,
+    )
+    epcis_event_types = {event["type"] for event in epcis["epcisBody"]["eventList"]}
+    assert_in("TransformationEvent", epcis_event_types, "EPCIS transformation event")
+
+    save_response = assert_json(
+        client.post("/api/scenario-saves/fresh_cut_processor", headers=main_headers),
+        200,
+    )
+    assert_equal(save_response["save"]["record_count"], 13, "saved scenario record count")
+
+    assert_status(
+        client.post(
+            "/api/simulate/reset",
+            headers=main_headers,
+            json={
+                "scenario": "retailer_readiness_demo",
+                "batch_size": 1,
+                "seed": 204,
+                "delivery": {"mode": "none"},
+            },
+        ),
+        200,
+    )
+    step = assert_json(client.post("/api/simulate/step", headers=main_headers), 200)
+    assert_equal(step["generated"], 1, "single step generated count")
+
+    load_response = assert_json(
+        client.post("/api/scenario-saves/fresh_cut_processor/load", headers=main_headers),
+        200,
+    )
+    assert_equal(load_response["loaded_records"], 13, "loaded scenario record count")
+
+    replay = assert_json(
+        client.post("/api/simulate/replay", headers=main_headers, json={"delivery": {"mode": "none"}}),
+        200,
+    )
+    assert_equal(replay["status"], "rebuilt", "replay status")
+    assert_equal(replay["replayed"], 13, "replay event count")
+
+    assert_status(
+        client.post(
+            "/api/simulate/reset",
+            headers=other_headers,
+            json={
+                "scenario": "leafy_greens_supplier",
+                "batch_size": 1,
+                "seed": 204,
+                "delivery": {"mode": "none"},
+            },
+        ),
+        200,
+    )
+    other_status = assert_json(client.get("/api/simulate/status", headers=other_headers), 200)
+    main_status = assert_json(client.get("/api/simulate/status", headers=main_headers), 200)
+    assert_equal(other_status["stats"]["total_records"], 0, "other tenant empty event log")
+    assert_equal(main_status["stats"]["total_records"], 13, "main tenant preserved event log")
+
+    assert_status(client.post("/api/simulate/stop", headers=main_headers), 200)
+    assert_status(client.post("/api/simulate/stop", headers=other_headers), 200)
+
+
+def request_headers(tenant_id: str) -> dict[str, str]:
+    headers = {"X-RegEngine-Tenant": tenant_id}
+    username = os.getenv("REGENGINE_BASIC_AUTH_USERNAME")
+    password = os.getenv("REGENGINE_BASIC_AUTH_PASSWORD")
+    if username and password:
+        token = base64.b64encode(f"{username}:{password}".encode("utf-8")).decode("ascii")
+        headers["Authorization"] = f"Basic {token}"
+    return headers
+
+
+def cleanup_smoke_tenants() -> None:
+    for tenant_id in TENANTS:
+        shutil.rmtree(Path("data") / "tenants" / tenant_id, ignore_errors=True)
+
+
+def assert_json(response, expected_status: int) -> dict[str, Any]:
+    assert_status(response, expected_status)
+    return response.json()
+
+
+def assert_status(response, expected_status: int) -> None:
+    if response.status_code != expected_status:
+        raise SmokeFailure(
+            f"Expected status {expected_status}, got {response.status_code}: {response.text}"
+        )
+
+
+def assert_equal(actual: Any, expected: Any, label: str) -> None:
+    if actual != expected:
+        raise SmokeFailure(f"{label}: expected {expected!r}, got {actual!r}")
+
+
+def assert_in(member: Any, container: Any, label: str) -> None:
+    if member not in container:
+        raise SmokeFailure(f"{label}: expected {member!r} to be present")
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except SmokeFailure as exc:
+        print(f"Release smoke regression failed: {exc}", file=sys.stderr)
+        raise SystemExit(1)


### PR DESCRIPTION
## Summary
- Add a release smoke regression command for the critical operator/API path.
- Add a demo-ready release checklist covering tests, contract checks, operator flows, tenant isolation, and handoff notes.
- Document the smoke command in README and start a Priority 4 release-hardening backlog.

## Validation
- `python3 scripts/smoke_regression.py`
- `pytest` passed: 43/43
- `node --check app/static/app.js`
- `python3 -m compileall app scripts`
- `git diff --check`

## Contract safety
- The harness verifies current stored-record exports and lineage without changing the RegEngine ingest contract.
- Mock mode remains the default and live delivery stays opt-in.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added comprehensive release validation checklist with verification steps, contract requirements, operator workflows, and handoff procedures
  * Enhanced project documentation with release testing workflow and API coverage guidance
  * Updated task backlog with new priority items for dashboard controls and demo resources

* **New Features**
  * Implemented automated smoke regression testing to validate critical API paths and tenant isolation during releases

<!-- end of auto-generated comment: release notes by coderabbit.ai -->