### PR TITLE
Add dashboard tenant context and EPCIS controls

### DIFF
--- a/AUTOPILOT_TASKS.md
+++ b/AUTOPILOT_TASKS.md
@@ -33,7 +33,7 @@ This file is the standing backlog for unattended Codex runs.
 ## Priority 4
 
 - [x] Add release smoke regression harness and checklist.
-- [ ] Add tenant/auth status and EPCIS export controls to the dashboard.
+- [x] Add tenant/auth status and EPCIS export controls to the dashboard.
 - [ ] Add a design-partner demo script with expected talking points and reset steps.
 - [ ] Add deployment profile examples for local, shared demo, and live-ingest modes.
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ Then open:
 http://127.0.0.1:8000
 ```
 
-The dashboard lets you choose a scenario preset, save/load per-scenario demo states, load deterministic demo fixtures, start/stop/step/reset the simulator, replay the current persisted event log, import CSV seed lots or scheduled events, inspect recent events, trace lot lineage, and export mock FDA request CSV presets. API users can also derive scaffolded EPCIS 2.0 JSON-LD exports from the same stored records. It subscribes to live status/event snapshots with Server-Sent Events and falls back to refresh polling if the stream disconnects. Delivery mode defaults to **`mock`** so no credentials are required.
+The dashboard lets you choose a scenario preset, save/load per-scenario demo states, load deterministic demo fixtures, start/stop/step/reset the simulator, replay the current persisted event log, import CSV seed lots or scheduled events, inspect recent events, trace lot lineage, see the active tenant/auth/storage context, and export mock FDA request CSV presets plus scaffolded EPCIS 2.0 JSON-LD exports. It subscribes to live status/event snapshots with Server-Sent Events and falls back to refresh polling if the stream disconnects. Delivery mode defaults to **`mock`** so no credentials are required.
 
 Event records are stored as JSONL at `config.persist_path` (`data/events.jsonl` by default for local unauthenticated use). Existing records at that path are loaded when the app starts or when a start/reset request points at a different path; reset clears the currently configured event log. Tenant-scoped requests store records under `data/tenants/{tenant_id}/events.jsonl` and ignore untrusted persist-path overrides. Replay reads the JSONL log without appending, duplicating, or rewriting stored events.
 
@@ -149,6 +149,8 @@ export REGENGINE_BASIC_AUTH_PASSWORD=change-me
 When Basic Auth is enabled, requests without valid credentials receive `401` with a `WWW-Authenticate` challenge. If no tenant header is supplied, the authenticated username becomes the tenant id.
 
 Use `X-RegEngine-Tenant` to select an explicit tenant scope. Tenant ids must be 1-64 characters and can contain only letters, numbers, dots, underscores, or hyphens. Tenant-scoped controllers keep separate simulator state, event logs, mock ingest responses, scenario saves, lineage, and exports under `data/tenants/{tenant_id}/`.
+
+`GET /api/health` and the dashboard stats area expose the active tenant id, whether Basic Auth is enabled, and whether storage is local default or tenant-scoped. Passwords, API keys, and other credentials are never returned.
 
 ## Replay mode
 
@@ -246,7 +248,7 @@ The dashboard fixture loader resets the current event log before loading the sel
 - `preset`: one of `all_records`, `lot_trace`, `shipment_handoff`, `receiving_log`, or `transformation_batches`
 - `traceability_lot_code`: optional for most presets, required for `lot_trace`
 
-If a lot code is supplied, the export is scoped to that lot's transitive lineage before applying the preset filter. `GET /api/mock/regengine/export/presets` returns the preset catalog used by the dashboard.
+If a lot code is supplied, the export is scoped to that lot's transitive lineage before applying the preset filter. `GET /api/mock/regengine/export/presets` returns the preset catalog used by the dashboard. The dashboard export panel builds CSV and EPCIS download links from the same lot and date filters.
 
 ## EPCIS 2.0 export scaffolding
 
@@ -258,6 +260,8 @@ Supported query parameters:
 - `end_date`: optional inclusive `YYYY-MM-DD`
 - `traceability_lot_code`: optional lot code; when supplied, the export uses the same transitive lineage graph as `/api/lineage/{traceability_lot_code}`
 
+The dashboard exposes a `Download EPCIS` control beside the FDA CSV export. It uses the same optional lot code and date filters as the CSV export panel, but does not apply FDA-only preset filters.
+
 The export returns an `EPCISDocument` with `ObjectEvent` records for harvesting, cooling, packing, shipping, and receiving CTEs, plus `TransformationEvent` records for transformation CTEs. RegEngine-specific fields are preserved under the `regengine:` JSON-LD namespace so KDEs, parent lot codes, document references, product descriptions, and original CTE types remain visible while the current webhook contract stays unchanged.
 
 ## API reference
@@ -266,7 +270,7 @@ The export returns an `EPCISDocument` with `ObjectEvent` records for harvesting,
 
 | Method | Path | Purpose |
 |---|---|---|
-| `GET` | `/api/health` | Liveness probe + current config snapshot |
+| `GET` | `/api/health` | Liveness probe, tenant/auth context, and current config snapshot |
 | `GET` | `/api/scenarios` | List available scenario presets |
 | `GET` | `/api/scenario-saves` | List saved per-scenario demo states |
 | `POST` | `/api/scenario-saves/{scenario_id}` | Save the current or supplied config and event log for a scenario |

--- a/app/main.py
+++ b/app/main.py
@@ -126,10 +126,16 @@ async def root() -> FileResponse:
 @app.get("/api/health")
 async def health(request: Request) -> dict[str, Any]:
     active_controller = _active_controller(request)
+    context = _tenant_context(request)
     return {
         "ok": True,
         "utc_time": datetime.now(UTC).isoformat(),
-        "tenant": _tenant_context(request).tenant_id,
+        "tenant": context.tenant_id,
+        "auth": {
+            "enabled": context.auth_enabled,
+            "username": context.username,
+            "uses_default_storage": context.uses_default_storage,
+        },
         "status": active_controller.status(),
     }
 

--- a/app/static/app.js
+++ b/app/static/app.js
@@ -1,5 +1,6 @@
 const state = {
   status: null,
+  health: null,
   events: [],
   eventSource: null,
   fallbackTimer: null,
@@ -43,6 +44,7 @@ const ids = {
   exportStartDate: document.getElementById('exportStartDate'),
   exportEndDate: document.getElementById('exportEndDate'),
   exportDownloadLink: document.getElementById('exportDownloadLink'),
+  epcisDownloadLink: document.getElementById('epcisDownloadLink'),
   exportPresetDescription: document.getElementById('exportPresetDescription'),
   statusMessage: document.getElementById('statusMessage'),
   statsGrid: document.getElementById('statsGrid'),
@@ -221,30 +223,45 @@ async function loadExportPresets() {
 }
 
 function updateExportLink() {
-  const params = new URLSearchParams();
+  const csvParams = new URLSearchParams();
+  const epcisParams = new URLSearchParams();
   const preset = ids.exportPreset.value || 'all_records';
   const lotCode = ids.exportLot.value.trim();
   const startDate = ids.exportStartDate.value;
   const endDate = ids.exportEndDate.value;
-  params.set('preset', preset);
+  csvParams.set('preset', preset);
   if (lotCode) {
-    params.set('traceability_lot_code', lotCode);
+    csvParams.set('traceability_lot_code', lotCode);
+    epcisParams.set('traceability_lot_code', lotCode);
   }
   if (startDate) {
-    params.set('start_date', startDate);
+    csvParams.set('start_date', startDate);
+    epcisParams.set('start_date', startDate);
   }
   if (endDate) {
-    params.set('end_date', endDate);
+    csvParams.set('end_date', endDate);
+    epcisParams.set('end_date', endDate);
   }
-  ids.exportDownloadLink.href = `/api/mock/regengine/export/fda-request?${params.toString()}`;
-  ids.exportPresetDescription.textContent = state.exportPresetDescriptions[preset] || 'FDA-request CSV export.';
+  const epcisQuery = epcisParams.toString();
+  ids.exportDownloadLink.href = `/api/mock/regengine/export/fda-request?${csvParams.toString()}`;
+  ids.epcisDownloadLink.href = `/api/mock/regengine/export/epcis${epcisQuery ? `?${epcisQuery}` : ''}`;
+  const presetDescription = state.exportPresetDescriptions[preset] || 'FDA-request CSV export.';
+  ids.exportPresetDescription.textContent = `${presetDescription} EPCIS uses the same lot and date filters.`;
 }
 
 function renderStats(status) {
   const stats = status?.stats || {};
   const engine = stats.engine || {};
   const scenarioId = status?.config?.scenario || ids.scenario.value;
+  const health = state.health || {};
+  const auth = health.auth || {};
+  const tenant = health.tenant || 'local-demo';
+  const authState = auth.enabled ? 'Enabled' : 'Off';
+  const storageScope = auth.uses_default_storage === false ? 'Tenant' : 'Local';
   const cards = [
+    ['Tenant', tenant],
+    ['Auth', authState],
+    ['Storage scope', storageScope],
     ['Loop status', status?.running ? 'Running' : 'Stopped'],
     ['Scenario', scenarioLabel(scenarioId)],
     ['Total records', stats.total_records ?? 0],
@@ -259,8 +276,8 @@ function renderStats(status) {
     .map(
       ([label, value]) => `
         <article class="stat-card">
-          <span>${label}</span>
-          <strong>${value}</strong>
+          <span>${escapeHtml(label)}</span>
+          <strong>${escapeHtml(value)}</strong>
         </article>
       `,
     )
@@ -534,8 +551,9 @@ function renderImportResult(result) {
   `;
 }
 
-function renderSnapshot(status, events) {
+function renderSnapshot(status, events, health = state.health) {
   state.status = status;
+  state.health = health;
   state.events = events;
   renderStats(status);
   renderDeliverySummary(status);
@@ -546,8 +564,12 @@ function renderSnapshot(status, events) {
 }
 
 async function refresh() {
-  const [status, events] = await Promise.all([api('/api/simulate/status'), api('/api/events?limit=100')]);
-  renderSnapshot(status, events.events);
+  const [health, status, events] = await Promise.all([
+    api('/api/health'),
+    api('/api/simulate/status'),
+    api('/api/events?limit=100'),
+  ]);
+  renderSnapshot(status, events.events, health);
 }
 
 function stopFallbackPolling() {

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -143,8 +143,11 @@
 
       <section class="panel">
         <div class="section-head">
-          <h2>FDA export presets</h2>
-          <a class="button secondary" id="exportDownloadLink" href="/api/mock/regengine/export/fda-request" target="_blank" rel="noreferrer">Download CSV</a>
+          <h2>Exports</h2>
+          <div class="section-actions">
+            <a class="button secondary" id="exportDownloadLink" href="/api/mock/regengine/export/fda-request" target="_blank" rel="noreferrer">Download CSV</a>
+            <a class="button secondary" id="epcisDownloadLink" href="/api/mock/regengine/export/epcis" target="_blank" rel="noreferrer">Download EPCIS</a>
+          </div>
         </div>
         <div class="grid two-up">
           <label>
@@ -166,7 +169,7 @@
             <input id="exportEndDate" name="exportEndDate" type="date" />
           </label>
         </div>
-        <p class="note" id="exportPresetDescription">Full FDA-request export for the selected date range.</p>
+        <p class="note" id="exportPresetDescription">Full FDA-request export for the selected date range. EPCIS uses the same lot and date filters.</p>
       </section>
 
       <section class="grid stats-grid" id="statsGrid"></section>

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -66,7 +66,8 @@ h3 {
 .hero-actions,
 .actions,
 .inline-form,
-.section-head {
+.section-head,
+.section-actions {
   display: flex;
   gap: 12px;
   align-items: center;

--- a/scripts/smoke_regression.py
+++ b/scripts/smoke_regression.py
@@ -36,7 +36,14 @@ def run_smoke(client: TestClient) -> None:
     main_headers = request_headers(TENANTS[0])
     other_headers = request_headers(TENANTS[1])
 
-    assert_status(client.get("/api/health", headers=main_headers), 200)
+    health = assert_json(client.get("/api/health", headers=main_headers), 200)
+    assert_equal(health["tenant"], TENANTS[0], "health tenant")
+    assert_equal(
+        health["auth"]["enabled"],
+        bool(os.getenv("REGENGINE_BASIC_AUTH_USERNAME") and os.getenv("REGENGINE_BASIC_AUTH_PASSWORD")),
+        "health auth enabled",
+    )
+    assert_equal(health["auth"]["uses_default_storage"], False, "health tenant storage scope")
     reset_response = client.post(
         "/api/simulate/reset",
         headers=main_headers,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -72,7 +72,15 @@ def test_scenario_catalog_endpoint_lists_supported_presets():
 
 
 def test_basic_auth_is_optional_but_enforced_when_configured(monkeypatch):
-    assert client.get("/api/health").status_code == 200
+    health_response = client.get("/api/health")
+    assert health_response.status_code == 200
+    health = health_response.json()
+    assert health["tenant"] == "local-demo"
+    assert health["auth"] == {
+        "enabled": False,
+        "username": None,
+        "uses_default_storage": True,
+    }
 
     monkeypatch.setenv("REGENGINE_BASIC_AUTH_USERNAME", "demo-user")
     monkeypatch.setenv("REGENGINE_BASIC_AUTH_PASSWORD", "demo-pass")
@@ -86,7 +94,13 @@ def test_basic_auth_is_optional_but_enforced_when_configured(monkeypatch):
 
     authorized = client.get("/api/health", headers=basic_auth_header("demo-user", "demo-pass"))
     assert authorized.status_code == 200
-    assert authorized.json()["tenant"] == "demo-user"
+    authorized_body = authorized.json()
+    assert authorized_body["tenant"] == "demo-user"
+    assert authorized_body["auth"] == {
+        "enabled": True,
+        "username": "demo-user",
+        "uses_default_storage": False,
+    }
 
 
 def test_tenant_header_scopes_event_storage_and_rejects_invalid_ids(tmp_path):


### PR DESCRIPTION
## Summary
- expose safe tenant/auth/storage context through /api/health and dashboard stats
- add dashboard EPCIS download control that reuses lot/date filters without FDA preset params
- document the operator context/export controls and extend API/smoke coverage

## Verification
- pytest
- node --check app/static/app.js
- python3 -m compileall app scripts
- python3 scripts/smoke_regression.py
- git diff --check
- browser smoke on http://127.0.0.1:8005: reset, step, load fixture, lineage, EPCIS link, start/stop