### PR TITLE
Add design-partner demo and deployment runbooks

### DIFF
--- a/AUTOPILOT_TASKS.md
+++ b/AUTOPILOT_TASKS.md
@@ -34,8 +34,8 @@ This file is the standing backlog for unattended Codex runs.
 
 - [x] Add release smoke regression harness and checklist.
 - [x] Add tenant/auth status and EPCIS export controls to the dashboard.
-- [ ] Add a design-partner demo script with expected talking points and reset steps.
-- [ ] Add deployment profile examples for local, shared demo, and live-ingest modes.
+- [x] Add a design-partner demo script with expected talking points and reset steps.
+- [x] Add deployment profile examples for local, shared demo, and live-ingest modes.
 
 ## Progress notes
 

--- a/DEPLOYMENT_PROFILES.md
+++ b/DEPLOYMENT_PROFILES.md
@@ -1,0 +1,198 @@
+# Deployment Profiles
+
+This guide gives concrete run profiles for local development, shared design-partner demos, and live-ingest trials. All profiles preserve mock mode as the default unless live delivery is explicitly configured per request.
+
+## Profile Matrix
+
+| Profile | Bind address | Auth | Storage | Delivery default | Best for |
+|---|---|---|---|---|---|
+| Local demo | `127.0.0.1` | Off | `data/events.jsonl` | `mock` | Solo development and screen-share demos |
+| Shared demo | `0.0.0.0` behind TLS/proxy | Basic Auth on | `data/tenants/{tenant_id}/` | `mock` | Design partners, multiple tenants, non-live workshops |
+| Live ingest trial | Prefer private host or VPN | Basic Auth on | Tenant-scoped | `mock`; switch request to `live` | Controlled RegEngine workspace validation |
+
+## Common Prerequisites
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+pytest
+python3 scripts/smoke_regression.py
+```
+
+Before exposing any profile to another person, verify:
+
+```bash
+curl http://127.0.0.1:8000/api/health
+```
+
+## Local Demo Profile
+
+Use this profile for development and screen-share demos on one machine.
+
+```bash
+unset REGENGINE_BASIC_AUTH_USERNAME
+unset REGENGINE_BASIC_AUTH_PASSWORD
+unset REGENGINE_DEFAULT_TENANT
+uvicorn app.main:app --host 127.0.0.1 --port 8000 --reload
+```
+
+Expected health context:
+
+- `tenant`: `local-demo`
+- `auth.enabled`: `false`
+- `auth.uses_default_storage`: `true`
+- `status.config.delivery.mode`: `mock`
+
+Quick setup for a repeatable fixture demo:
+
+```bash
+curl -X POST http://127.0.0.1:8000/api/demo-fixtures/fresh_cut_transformation/load \
+  -H 'Content-Type: application/json' \
+  -d '{"reset":true,"delivery":{"mode":"mock"}}'
+```
+
+Reset to blank local state:
+
+```bash
+curl -X POST http://127.0.0.1:8000/api/simulate/stop
+curl -X POST http://127.0.0.1:8000/api/simulate/reset
+```
+
+## Shared Demo Profile
+
+Use this profile when more than one person or partner may access the service. Put it behind HTTPS with a reverse proxy or trusted tunnel; do not expose raw HTTP on the public internet.
+
+```bash
+export REGENGINE_BASIC_AUTH_USERNAME=demo
+export REGENGINE_BASIC_AUTH_PASSWORD='replace-with-a-strong-password'
+export REGENGINE_DEFAULT_TENANT=demo-default
+uvicorn app.main:app --host 0.0.0.0 --port 8000
+```
+
+Tenant-scoped smoke check:
+
+```bash
+curl -u "$REGENGINE_BASIC_AUTH_USERNAME:$REGENGINE_BASIC_AUTH_PASSWORD" \
+  -H 'X-RegEngine-Tenant: partner-acme' \
+  http://127.0.0.1:8000/api/health
+```
+
+Expected health context:
+
+- `tenant`: `partner-acme`
+- `auth.enabled`: `true`
+- `auth.username`: configured username
+- `auth.uses_default_storage`: `false`
+- `status.config.persist_path`: `data/tenants/partner-acme/events.jsonl`
+
+Tenant selection notes:
+
+- API clients can send `X-RegEngine-Tenant` directly.
+- Browser dashboard requests use the authenticated username as the tenant unless a trusted proxy injects `X-RegEngine-Tenant`.
+- If several partners need isolated dashboard sessions at the same time, use separate reverse-proxy routes that inject different tenant headers, or run separate service instances with different `REGENGINE_BASIC_AUTH_USERNAME` values.
+
+Prepare a tenant-specific fixture:
+
+```bash
+curl -u "$REGENGINE_BASIC_AUTH_USERNAME:$REGENGINE_BASIC_AUTH_PASSWORD" \
+  -H 'X-RegEngine-Tenant: partner-acme' \
+  -H 'Content-Type: application/json' \
+  -X POST http://127.0.0.1:8000/api/demo-fixtures/fresh_cut_transformation/load \
+  -d '{"reset":true,"delivery":{"mode":"mock"}}'
+```
+
+Shared-demo operating notes:
+
+- Keep delivery mode set to `mock` unless there is an explicit live-ingest trial.
+- Use a distinct tenant value per partner or workshop.
+- Rotate `REGENGINE_BASIC_AUTH_PASSWORD` between external demos.
+- Back up or delete `data/tenants/{tenant_id}/` according to the partner's data-retention expectation.
+
+## Live Ingest Trial Profile
+
+Use this only when a RegEngine workspace, API key, tenant id, and endpoint target are approved for the trial. The application still starts in mock mode; live delivery is enabled in the request or dashboard controls.
+
+Start the server with shared-demo protections:
+
+```bash
+export REGENGINE_BASIC_AUTH_USERNAME=demo
+export REGENGINE_BASIC_AUTH_PASSWORD='replace-with-a-strong-password'
+export REGENGINE_DEFAULT_TENANT=live-trial
+uvicorn app.main:app --host 127.0.0.1 --port 8000
+```
+
+Dry-run the exact scenario without live traffic:
+
+```bash
+curl -u "$REGENGINE_BASIC_AUTH_USERNAME:$REGENGINE_BASIC_AUTH_PASSWORD" \
+  -H 'X-RegEngine-Tenant: live-trial' \
+  -H 'Content-Type: application/json' \
+  -X POST http://127.0.0.1:8000/api/simulate/reset \
+  -d '{"scenario":"fresh_cut_processor","batch_size":1,"seed":204,"delivery":{"mode":"mock"}}'
+
+curl -u "$REGENGINE_BASIC_AUTH_USERNAME:$REGENGINE_BASIC_AUTH_PASSWORD" \
+  -H 'X-RegEngine-Tenant: live-trial' \
+  -X POST http://127.0.0.1:8000/api/simulate/step
+```
+
+Set the live delivery config only after the dry run looks correct:
+
+```bash
+export REGENGINE_LIVE_API_KEY='replace-with-live-key'
+export REGENGINE_LIVE_TENANT_ID='replace-with-live-tenant-id'
+
+curl -u "$REGENGINE_BASIC_AUTH_USERNAME:$REGENGINE_BASIC_AUTH_PASSWORD" \
+  -H 'X-RegEngine-Tenant: live-trial' \
+  -H 'Content-Type: application/json' \
+  -X POST http://127.0.0.1:8000/api/simulate/reset \
+  --data-binary @- <<JSON
+{
+  "source": "codex-simulator",
+  "scenario": "fresh_cut_processor",
+  "batch_size": 1,
+  "seed": 204,
+  "delivery": {
+    "mode": "live",
+    "endpoint": "https://www.regengine.co/api/v1/webhooks/ingest",
+    "api_key": "${REGENGINE_LIVE_API_KEY}",
+    "tenant_id": "${REGENGINE_LIVE_TENANT_ID}"
+  }
+}
+JSON
+```
+
+Then send exactly one live event batch:
+
+```bash
+curl -u "$REGENGINE_BASIC_AUTH_USERNAME:$REGENGINE_BASIC_AUTH_PASSWORD" \
+  -H 'X-RegEngine-Tenant: live-trial' \
+  -X POST 'http://127.0.0.1:8000/api/simulate/step?batch_size=1'
+```
+
+If using the dashboard instead of curl, set delivery mode to `Live RegEngine`, enter the API key and tenant id, leave the endpoint blank to use the documented default, and click `Single batch` first. Direct browser sessions use the Basic Auth username as the storage tenant unless a proxy injects `X-RegEngine-Tenant`. Avoid starting the loop until one live batch is accepted.
+
+Live-trial safeguards:
+
+- Keep `batch_size` at `1` for the first live request.
+- Confirm the dashboard delivery monitor shows `posted` before increasing volume.
+- If delivery fails, do not keep retrying with the same credentials blindly; inspect the displayed error and confirm endpoint, API key, and tenant id.
+- Use `POST /api/delivery/retry` only after correcting the delivery config.
+- Do not commit API keys, tenant ids, partner names, downloaded exports, or event logs from live trials.
+
+## Service Wrappers
+
+For a persistent local or shared demo service, use the macOS LaunchAgent, Linux systemd unit, or Docker examples in `README.md`. Keep these profile choices the same inside the service wrapper:
+
+- Local demo: bind `127.0.0.1`, Basic Auth unset.
+- Shared demo: bind to the private interface or proxy target, Basic Auth set.
+- Live trial: prefer private network access, Basic Auth set, and live delivery enabled only per operator action.
+
+## Profile Verification Checklist
+
+- `GET /api/health` returns the expected tenant and auth context.
+- Dashboard stats match the chosen tenant/auth/storage profile.
+- `POST /api/demo-fixtures/fresh_cut_transformation/load` succeeds in `mock` mode.
+- Lineage for `TLC-DEMO-FC-OUT-001` includes upstream harvest and packed lots.
+- FDA CSV and EPCIS exports are derivable from stored records.
+- No generated `data/` files or secrets are staged before committing.

--- a/DESIGN_PARTNER_DEMO_SCRIPT.md
+++ b/DESIGN_PARTNER_DEMO_SCRIPT.md
@@ -1,0 +1,127 @@
+# Design-Partner Demo Script
+
+Use this script for a 15-25 minute RegEngine Inflow Lab walkthrough with a design partner. It is written for mock-first demos where no live workspace traffic is sent unless everyone explicitly agrees to switch modes.
+
+## Demo Goal
+
+Show that the simulator can produce realistic FSMA 204 CTE flow data, preserve lot lineage through transformation, and derive FDA-request and EPCIS exports from stored records while keeping the RegEngine ingest contract stable.
+
+## Pre-Demo Setup
+
+Run these checks before the call:
+
+```bash
+pytest
+python3 scripts/smoke_regression.py
+node --check app/static/app.js
+python3 -m compileall app scripts
+git diff --check
+```
+
+Start the local server:
+
+```bash
+uvicorn app.main:app --reload
+```
+
+Open `http://127.0.0.1:8000` and keep a terminal ready for quick API checks.
+
+## Opening Talk Track
+
+- "This is a mock-first FSMA 204 inflow simulator for RegEngine-compatible webhooks."
+- "The live ingest contract stays intentionally small: top-level `source`, top-level `events[]`, and the documented per-event CTE fields."
+- "By default everything posts to the built-in mock endpoint, so a demo cannot accidentally send live traffic."
+- "The event log is the source of truth for lineage, FDA CSV exports, and EPCIS JSON-LD scaffolding."
+
+## Happy-Path Walkthrough
+
+1. Confirm operator context.
+   - Dashboard action: point to the stats cards for `Tenant`, `Auth`, `Storage scope`, `Loop status`, and `Persist path`.
+   - Expected result: local demos show tenant `local-demo`, auth `Off`, storage `Local`, loop `Stopped`.
+   - Talking point: "A shared demo can use Basic Auth and tenant headers, but local mock mode stays frictionless."
+
+2. Load the fresh-cut fixture.
+   - Dashboard action: set delivery mode to `Mock RegEngine`, choose fixture `Fresh-cut transformation`, click `Load fixture`.
+   - Expected result: scenario changes to `Fresh-cut processor`, total records becomes `13`, delivery monitor shows posted records, recent events include harvesting, cooling, packing, shipping, receiving, and transformation.
+   - Talking point: "The fixture is deterministic so every partner sees the same batch, documents, and lot codes."
+
+3. Inspect transformation lineage.
+   - Dashboard action: paste `TLC-DEMO-FC-OUT-001` in lot lineage lookup and click `Trace lot`.
+   - Expected result: lineage includes `TLC-DEMO-FC-HARVEST-001`, `TLC-DEMO-FC-HARVEST-002`, `TLC-DEMO-FC-PACK-001`, `TLC-DEMO-FC-PACK-002`, and `TLC-DEMO-FC-OUT-001`.
+   - Talking point: "Transformation consumes packed ingredient lots and emits a new output lot. The trace can move backward to harvest and forward to shipment and receipt."
+
+4. Show FDA-request export.
+   - Dashboard action: set export preset to `Lot trace`, set Traceability Lot Code to `TLC-DEMO-FC-OUT-001`, click `Download CSV`.
+   - Expected result: downloaded CSV includes `BATCH-DEMO-FC-001` and the transitive lot history.
+   - API check:
+
+```bash
+curl "http://127.0.0.1:8000/api/mock/regengine/export/fda-request?preset=lot_trace&traceability_lot_code=TLC-DEMO-FC-OUT-001" | head
+```
+
+5. Show EPCIS export.
+   - Dashboard action: with the same lot filter, click `Download EPCIS`.
+   - Expected result: JSON-LD export includes an `EPCISDocument` with `ObjectEvent` and `TransformationEvent` entries.
+   - API check:
+
+```bash
+curl "http://127.0.0.1:8000/api/mock/regengine/export/epcis?traceability_lot_code=TLC-DEMO-FC-OUT-001" | python3 -m json.tool | head -40
+```
+
+6. Demonstrate operator controls.
+   - Dashboard action: click `Save scenario`, switch the scenario preset, click `Reset state`, then `Load saved`.
+   - Expected result: the fresh-cut scenario and all 13 records return.
+   - Talking point: "Design partners can rehearse the same story without rebuilding data by hand."
+
+7. Optional live-ingest explanation.
+   - Do not switch to live during a first demo unless a real workspace, API key, tenant id, and consent are ready.
+   - Talking point: "Live mode targets `https://www.regengine.co/api/v1/webhooks/ingest`, requires API key and tenant id, and uses the same payload shape we just inspected."
+
+## Reset Steps
+
+Use this before each design-partner call:
+
+```bash
+curl -X POST http://127.0.0.1:8000/api/simulate/stop
+curl -X POST http://127.0.0.1:8000/api/simulate/reset \
+  -H 'Content-Type: application/json' \
+  -d '{"scenario":"fresh_cut_processor","batch_size":3,"seed":204,"delivery":{"mode":"mock"}}'
+curl -X POST http://127.0.0.1:8000/api/demo-fixtures/fresh_cut_transformation/load \
+  -H 'Content-Type: application/json' \
+  -d '{"reset":true,"delivery":{"mode":"mock"}}'
+```
+
+Use this after a call if you want a blank local state:
+
+```bash
+curl -X POST http://127.0.0.1:8000/api/simulate/stop
+curl -X POST http://127.0.0.1:8000/api/simulate/reset
+```
+
+For a shared demo tenant, add the tenant header to every reset command:
+
+```bash
+-H 'X-RegEngine-Tenant: partner-acme'
+```
+
+If Basic Auth is enabled, also add:
+
+```bash
+-u "$REGENGINE_BASIC_AUTH_USERNAME:$REGENGINE_BASIC_AUTH_PASSWORD"
+```
+
+## Recovery Notes
+
+- If the dashboard looks stale, click `Refresh` or reload the browser tab.
+- If the loop is still running, click `Stop` before loading fixtures or resetting.
+- If live delivery fails, switch delivery mode to `Mock RegEngine` and use `Retry failed deliveries` to prove recovery behavior.
+- If lineage for `TLC-DEMO-FC-OUT-001` is empty, reload the `Fresh-cut transformation` fixture.
+- If downloaded exports are empty, confirm the event count is nonzero and the lot filter has no extra spaces.
+
+## Questions To Capture
+
+- Which CTEs or KDEs are missing from the partner's real workflow?
+- Which identifiers matter most for their operators: lot code, GLN, reference document, PO, BOL, batch, or shipment id?
+- Do they need tenant isolation by business unit, facility, customer, or demo workspace?
+- Would they prefer FDA CSV, EPCIS JSON-LD, or both as the first export handoff?
+- What dashboard status would make a failed live ingest easiest to understand?

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ A mock-first FSMA 204 traceability simulator that emits **RegEngine-compatible i
 - [Demo fixtures](#demo-fixtures)
 - [FDA export presets](#fda-export-presets)
 - [EPCIS 2.0 export scaffolding](#epcis-20-export-scaffolding)
+- [Design-partner demo script](#design-partner-demo-script)
+- [Deployment profiles](#deployment-profiles)
 - [API reference](#api-reference)
 - [RegEngine payload contract](#regengine-payload-contract)
 - [Deployment](#deployment)
@@ -68,6 +70,8 @@ scripts/
 tests/
 AGENTS.md                # Repository instructions for Codex-style agents
 AUTOPILOT_TASKS.md       # Standing backlog for unattended runs
+DEPLOYMENT_PROFILES.md   # Local, shared-demo, and live-ingest run profiles
+DESIGN_PARTNER_DEMO_SCRIPT.md  # Design-partner walkthrough and reset script
 PROMPT_FOR_CODEX.md      # Paste-ready Codex task prompt
 RELEASE_CHECKLIST.md     # Demo-ready release gate
 pyproject.toml
@@ -116,7 +120,7 @@ python3 scripts/smoke_regression.py
 
 The smoke harness uses FastAPI's in-process `TestClient` to exercise the operator-critical path: tenant-scoped fixture load, lineage lookup, FDA export, EPCIS export, scenario save/load, replay, and tenant isolation. If Basic Auth env vars are set, it sends matching Basic credentials automatically. Temporary smoke tenants are cleaned up after the run.
 
-Use `RELEASE_CHECKLIST.md` as the full demo-ready gate.
+Use `RELEASE_CHECKLIST.md` as the full demo-ready gate. Use `DESIGN_PARTNER_DEMO_SCRIPT.md` for the call flow, expected talking points, fixture reset commands, and recovery steps.
 
 ## Delivery modes
 
@@ -263,6 +267,20 @@ Supported query parameters:
 The dashboard exposes a `Download EPCIS` control beside the FDA CSV export. It uses the same optional lot code and date filters as the CSV export panel, but does not apply FDA-only preset filters.
 
 The export returns an `EPCISDocument` with `ObjectEvent` records for harvesting, cooling, packing, shipping, and receiving CTEs, plus `TransformationEvent` records for transformation CTEs. RegEngine-specific fields are preserved under the `regengine:` JSON-LD namespace so KDEs, parent lot codes, document references, product descriptions, and original CTE types remain visible while the current webhook contract stays unchanged.
+
+## Design-partner demo script
+
+`DESIGN_PARTNER_DEMO_SCRIPT.md` contains a repeatable design-partner walkthrough with pre-demo verification, talking points, expected dashboard states, lot codes to inspect, FDA/EPCIS export checks, reset commands, and recovery notes. The default path uses the deterministic `fresh_cut_transformation` fixture and keeps delivery in mock mode.
+
+## Deployment profiles
+
+`DEPLOYMENT_PROFILES.md` defines three operator profiles:
+
+- Local demo: bind to `127.0.0.1`, no Basic Auth, default local storage, mock delivery.
+- Shared demo: Basic Auth enabled, tenant-scoped storage, mock delivery, and HTTPS/proxy guidance.
+- Live ingest trial: shared-demo protections plus an explicit one-batch live delivery workflow using the documented RegEngine endpoint.
+
+The service wrapper examples below can be used with any profile; keep the profile's bind address, auth, tenant, and delivery safeguards intact.
 
 ## API reference
 

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -33,6 +33,8 @@ Use this checklist before tagging a demo-ready build or handing the simulator to
 ## Handoff Notes
 
 - [ ] README has the current API surface and setup instructions.
+- [ ] `DESIGN_PARTNER_DEMO_SCRIPT.md` matches the current fixture names, lot codes, expected exports, and reset flow.
+- [ ] `DEPLOYMENT_PROFILES.md` matches the intended local, shared-demo, and live-ingest operating modes.
 - [ ] `AUTOPILOT_TASKS.md` reflects the current backlog state.
 - [ ] No generated data files are staged.
 - [ ] Any live endpoint or credential values are excluded from docs, logs, fixtures, saved scenarios, and commits.


### PR DESCRIPTION
## Summary
- add a design-partner demo script with talking points, expected states, fixture flow, reset commands, and recovery notes
- add deployment profiles for local demo, shared demo, and live-ingest trial modes
- link the runbooks from README and release checklist, and close out the remaining Priority 4 backlog items

## Verification
- pytest
- python3 scripts/smoke_regression.py
- node --check app/static/app.js
- python3 -m compileall app scripts
- git diff --check