### PR TITLE
Restrict credentialed CORS origins

### DIFF
--- a/AUTOPILOT_TASKS.md
+++ b/AUTOPILOT_TASKS.md
@@ -37,6 +37,10 @@ This file is the standing backlog for unattended Codex runs.
 - [x] Add a design-partner demo script with expected talking points and reset steps.
 - [x] Add deployment profile examples for local, shared demo, and live-ingest modes.
 
+## Priority 5
+
+- [x] Restrict credentialed CORS to configured browser origins for shared demo and live-ingest profiles.
+
 ## Progress notes
 
 - Start with the smallest safe change that materially improves demo readiness.

--- a/DEPLOYMENT_PROFILES.md
+++ b/DEPLOYMENT_PROFILES.md
@@ -67,6 +67,7 @@ Use this profile when more than one person or partner may access the service. Pu
 export REGENGINE_BASIC_AUTH_USERNAME=demo
 export REGENGINE_BASIC_AUTH_PASSWORD='replace-with-a-strong-password'
 export REGENGINE_DEFAULT_TENANT=demo-default
+export REGENGINE_CORS_ORIGINS=https://demo.example.com
 uvicorn app.main:app --host 0.0.0.0 --port 8000
 ```
 
@@ -107,6 +108,7 @@ Shared-demo operating notes:
 - Keep delivery mode set to `mock` unless there is an explicit live-ingest trial.
 - Use a distinct tenant value per partner or workshop.
 - Rotate `REGENGINE_BASIC_AUTH_PASSWORD` between external demos.
+- Keep `REGENGINE_CORS_ORIGINS` limited to the HTTPS origins that should run the browser dashboard.
 - Back up or delete `data/tenants/{tenant_id}/` according to the partner's data-retention expectation.
 
 ## Live Ingest Trial Profile
@@ -119,6 +121,7 @@ Start the server with shared-demo protections:
 export REGENGINE_BASIC_AUTH_USERNAME=demo
 export REGENGINE_BASIC_AUTH_PASSWORD='replace-with-a-strong-password'
 export REGENGINE_DEFAULT_TENANT=live-trial
+export REGENGINE_CORS_ORIGINS=https://live-trial.example.com
 uvicorn app.main:app --host 127.0.0.1 --port 8000
 ```
 
@@ -178,6 +181,7 @@ Live-trial safeguards:
 - Confirm the dashboard delivery monitor shows `posted` before increasing volume.
 - If delivery fails, do not keep retrying with the same credentials blindly; inspect the displayed error and confirm endpoint, API key, and tenant id.
 - Use `POST /api/delivery/retry` only after correcting the delivery config.
+- Keep the live-trial dashboard origin explicit in `REGENGINE_CORS_ORIGINS`; do not use wildcard CORS with Basic Auth.
 - Do not commit API keys, tenant ids, partner names, downloaded exports, or event logs from live trials.
 
 ## Service Wrappers
@@ -185,12 +189,13 @@ Live-trial safeguards:
 For a persistent local or shared demo service, use the macOS LaunchAgent, Linux systemd unit, or Docker examples in `README.md`. Keep these profile choices the same inside the service wrapper:
 
 - Local demo: bind `127.0.0.1`, Basic Auth unset.
-- Shared demo: bind to the private interface or proxy target, Basic Auth set.
-- Live trial: prefer private network access, Basic Auth set, and live delivery enabled only per operator action.
+- Shared demo: bind to the private interface or proxy target, Basic Auth set, CORS origins explicit.
+- Live trial: prefer private network access, Basic Auth set, CORS origins explicit, and live delivery enabled only per operator action.
 
 ## Profile Verification Checklist
 
 - `GET /api/health` returns the expected tenant and auth context.
+- Browser requests from the intended HTTPS origin receive the `access-control-allow-origin` response header; untrusted origins do not.
 - Dashboard stats match the chosen tenant/auth/storage profile.
 - `POST /api/demo-fixtures/fresh_cut_transformation/load` succeeds in `mock` mode.
 - Lineage for `TLC-DEMO-FC-OUT-001` includes upstream harvest and packed lots.

--- a/README.md
+++ b/README.md
@@ -156,6 +156,14 @@ Use `X-RegEngine-Tenant` to select an explicit tenant scope. Tenant ids must be 
 
 `GET /api/health` and the dashboard stats area expose the active tenant id, whether Basic Auth is enabled, and whether storage is local default or tenant-scoped. Passwords, API keys, and other credentials are never returned.
 
+Credentialed browser requests are limited to explicit CORS origins. By default the app allows the local dashboard origins `http://127.0.0.1:8000` and `http://localhost:8000`. For shared demos, set comma-separated HTTPS origins:
+
+```bash
+export REGENGINE_CORS_ORIGINS=https://demo.example.com,https://partner-demo.example.com
+```
+
+Wildcard CORS origins are rejected because Basic Auth and tenant-scoped requests may carry credentials.
+
 ## Replay mode
 
 Replay mode reads previously persisted `StoredEventRecord` JSONL lines, rebuilds the RegEngine ingest payload as:

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -22,6 +22,7 @@ Use this checklist before tagging a demo-ready build or handing the simulator to
 
 - [ ] Dashboard loads without credentials when Basic Auth env vars are unset.
 - [ ] Basic Auth returns `401` without valid credentials when env vars are set.
+- [ ] Shared-demo or live-trial deployments set explicit `REGENGINE_CORS_ORIGINS` values instead of wildcard CORS.
 - [ ] Demo fixture loading resets to a known event log.
 - [ ] Start, stop, single-step, and reset work from the dashboard.
 - [ ] Scenario save/load restores both config and event records.

--- a/app/main.py
+++ b/app/main.py
@@ -2,11 +2,13 @@ from __future__ import annotations
 
 import asyncio
 import json
+import os
 from contextlib import asynccontextmanager
 from datetime import UTC, datetime
 from pathlib import Path
 from threading import RLock
 from typing import Any
+from urllib.parse import urlparse
 
 from fastapi import FastAPI, HTTPException, Query, Request
 from fastapi.middleware.cors import CORSMiddleware
@@ -65,6 +67,7 @@ from .store import EventStore
 
 
 TENANT_DATA_ROOT = Path("data/tenants")
+DEFAULT_CORS_ORIGINS = ("http://127.0.0.1:8000", "http://localhost:8000")
 
 engine = LegitFlowEngine(seed=204)
 store = EventStore(persist_path="data/events.jsonl")
@@ -88,6 +91,42 @@ async def lifespan(app: FastAPI):
         await tenant_controller.shutdown()
 
 
+def cors_origins_from_env() -> list[str]:
+    raw_origins = os.getenv("REGENGINE_CORS_ORIGINS")
+    if not raw_origins or not raw_origins.strip():
+        return list(DEFAULT_CORS_ORIGINS)
+
+    origins: list[str] = []
+    for raw_origin in raw_origins.split(","):
+        origin = _normalize_cors_origin(raw_origin)
+        if origin and origin not in origins:
+            origins.append(origin)
+    return origins or list(DEFAULT_CORS_ORIGINS)
+
+
+def _normalize_cors_origin(raw_origin: str) -> str | None:
+    origin = raw_origin.strip().rstrip("/")
+    if not origin:
+        return None
+    if origin == "*":
+        raise ValueError("REGENGINE_CORS_ORIGINS cannot contain '*' while credentialed requests are enabled")
+
+    parsed = urlparse(origin)
+    if (
+        parsed.scheme not in {"http", "https"}
+        or not parsed.netloc
+        or parsed.params
+        or parsed.query
+        or parsed.fragment
+        or parsed.path not in {"", "/"}
+    ):
+        raise ValueError(
+            "REGENGINE_CORS_ORIGINS entries must be comma-separated HTTP(S) origins such as "
+            "https://demo.example.com"
+        )
+    return f"{parsed.scheme}://{parsed.netloc}"
+
+
 app = FastAPI(
     title="RegEngine Inflow Lab",
     description="Mock-first FSMA 204 CTE data-flow simulator for RegEngine-compatible payloads.",
@@ -96,7 +135,7 @@ app = FastAPI(
 )
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=cors_origins_from_env(),
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -4,9 +4,10 @@ import csv
 import io
 import json
 
+import pytest
 from fastapi.testclient import TestClient
 
-from app.main import app, controller, scenario_saves
+from app.main import app, controller, cors_origins_from_env, scenario_saves
 from app.models import SimulationConfig
 from app.scenarios import ScenarioId, get_scenario
 
@@ -69,6 +70,33 @@ def test_scenario_catalog_endpoint_lists_supported_presets():
         "retailer_readiness_demo",
     ]
     assert all(scenario["label"] for scenario in scenarios)
+
+
+def test_cors_defaults_allow_local_origins_and_block_unknown_origins():
+    allowed = client.get("/api/health", headers={"Origin": "http://127.0.0.1:8000"})
+    assert allowed.status_code == 200
+    assert allowed.headers["access-control-allow-origin"] == "http://127.0.0.1:8000"
+    assert allowed.headers["access-control-allow-credentials"] == "true"
+
+    blocked = client.get("/api/health", headers={"Origin": "https://untrusted.example"})
+    assert blocked.status_code == 200
+    assert "access-control-allow-origin" not in blocked.headers
+
+
+def test_cors_origins_can_be_configured_without_wildcard_credentials(monkeypatch):
+    monkeypatch.setenv(
+        "REGENGINE_CORS_ORIGINS",
+        " https://demo.example.com/, http://localhost:3000, https://demo.example.com ",
+    )
+    assert cors_origins_from_env() == ["https://demo.example.com", "http://localhost:3000"]
+
+    monkeypatch.setenv("REGENGINE_CORS_ORIGINS", "*")
+    with pytest.raises(ValueError, match="cannot contain"):
+        cors_origins_from_env()
+
+    monkeypatch.setenv("REGENGINE_CORS_ORIGINS", "https://demo.example.com/path")
+    with pytest.raises(ValueError, match="HTTP\\(S\\) origins"):
+        cors_origins_from_env()
 
 
 def test_basic_auth_is_optional_but_enforced_when_configured(monkeypatch):


### PR DESCRIPTION
## Summary
- replace wildcard credentialed CORS with explicit local default origins
- add REGENGINE_CORS_ORIGINS parsing and validation for shared demo/live-ingest deployments
- document CORS profile settings and add release/backlog checklist coverage

## Verification
- pytest
- python3 scripts/smoke_regression.py
- node --check app/static/app.js
- python3 -m compileall app scripts
- git diff --check