### PR TITLE
Add Railway shared demo deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+.git
+.github
+.venv
+__pycache__
+.pytest_cache
+*.py[cod]
+*.egg-info
+.coverage
+htmlcov
+data
+uvicorn.out.log
+uvicorn.err.log
+tests/__pycache__
+app/__pycache__
+scripts/__pycache__

--- a/AUTOPILOT_TASKS.md
+++ b/AUTOPILOT_TASKS.md
@@ -41,6 +41,10 @@ This file is the standing backlog for unattended Codex runs.
 
 - [x] Restrict credentialed CORS to configured browser origins for shared demo and live-ingest profiles.
 
+## Priority 6
+
+- [x] Add container/Railway deployment artifacts with persistent data-directory support.
+
 ## Progress notes
 
 - Start with the smallest safe change that materially improves demo readiness.

--- a/DEPLOYMENT_PROFILES.md
+++ b/DEPLOYMENT_PROFILES.md
@@ -23,6 +23,7 @@ python3 scripts/smoke_regression.py
 Before exposing any profile to another person, verify:
 
 ```bash
+curl http://127.0.0.1:8000/api/healthz
 curl http://127.0.0.1:8000/api/health
 ```
 
@@ -68,6 +69,7 @@ export REGENGINE_BASIC_AUTH_USERNAME=demo
 export REGENGINE_BASIC_AUTH_PASSWORD='replace-with-a-strong-password'
 export REGENGINE_DEFAULT_TENANT=demo-default
 export REGENGINE_CORS_ORIGINS=https://demo.example.com
+export REGENGINE_DATA_DIR=/data
 uvicorn app.main:app --host 0.0.0.0 --port 8000
 ```
 
@@ -109,6 +111,7 @@ Shared-demo operating notes:
 - Use a distinct tenant value per partner or workshop.
 - Rotate `REGENGINE_BASIC_AUTH_PASSWORD` between external demos.
 - Keep `REGENGINE_CORS_ORIGINS` limited to the HTTPS origins that should run the browser dashboard.
+- Mount persistent storage at `REGENGINE_DATA_DIR` so event logs and scenario saves survive restarts.
 - Back up or delete `data/tenants/{tenant_id}/` according to the partner's data-retention expectation.
 
 ## Live Ingest Trial Profile
@@ -122,6 +125,7 @@ export REGENGINE_BASIC_AUTH_USERNAME=demo
 export REGENGINE_BASIC_AUTH_PASSWORD='replace-with-a-strong-password'
 export REGENGINE_DEFAULT_TENANT=live-trial
 export REGENGINE_CORS_ORIGINS=https://live-trial.example.com
+export REGENGINE_DATA_DIR=/data
 uvicorn app.main:app --host 127.0.0.1 --port 8000
 ```
 
@@ -192,10 +196,26 @@ For a persistent local or shared demo service, use the macOS LaunchAgent, Linux 
 - Shared demo: bind to the private interface or proxy target, Basic Auth set, CORS origins explicit.
 - Live trial: prefer private network access, Basic Auth set, CORS origins explicit, and live delivery enabled only per operator action.
 
+## Railway Shared Demo
+
+The repo includes `Dockerfile` and `railway.json` for Railway. Recommended Railway variables:
+
+```bash
+REGENGINE_BASIC_AUTH_USERNAME=demo
+REGENGINE_BASIC_AUTH_PASSWORD=<strong generated password>
+REGENGINE_DEFAULT_TENANT=demo-default
+REGENGINE_CORS_ORIGINS=https://<railway-domain>
+REGENGINE_DATA_DIR=/data
+```
+
+Attach a Railway volume at `/data` before using the service for partner demos. After a Railway domain is generated, update `REGENGINE_CORS_ORIGINS` to that exact HTTPS origin.
+
 ## Profile Verification Checklist
 
 - `GET /api/health` returns the expected tenant and auth context.
+- `GET /api/healthz` returns `{"ok": true, ...}` without credentials for platform healthchecks.
 - Browser requests from the intended HTTPS origin receive the `access-control-allow-origin` response header; untrusted origins do not.
+- `REGENGINE_DATA_DIR` points at mounted persistent storage in shared-demo and live-trial deployments.
 - Dashboard stats match the chosen tenant/auth/storage profile.
 - `POST /api/demo-fixtures/fresh_cut_transformation/load` succeeds in `mock` mode.
 - Lineage for `TLC-DEMO-FC-OUT-001` includes upstream harvest and packed lots.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+FROM python:3.12-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    REGENGINE_DATA_DIR=/data
+
+WORKDIR /app
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends gosu \
+    && rm -rf /var/lib/apt/lists/* \
+    && adduser --disabled-password --gecos "" appuser \
+    && mkdir -p /data \
+    && chown -R appuser:appuser /data /app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY app ./app
+COPY scripts ./scripts
+COPY pyproject.toml README.md ./
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
+EXPOSE 8000
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
+  CMD python -c "import json, os, urllib.request; port=os.getenv('PORT', '8000'); json.load(urllib.request.urlopen(f'http://127.0.0.1:{port}/api/healthz', timeout=3))"
+
+ENTRYPOINT ["docker-entrypoint.sh"]
+CMD ["sh", "-c", "uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8000}"]

--- a/README.md
+++ b/README.md
@@ -68,13 +68,17 @@ app/
 scripts/
   smoke_regression.py    # End-to-end API smoke for demo-ready release checks
 tests/
+.dockerignore
 AGENTS.md                # Repository instructions for Codex-style agents
 AUTOPILOT_TASKS.md       # Standing backlog for unattended runs
 DEPLOYMENT_PROFILES.md   # Local, shared-demo, and live-ingest run profiles
 DESIGN_PARTNER_DEMO_SCRIPT.md  # Design-partner walkthrough and reset script
+Dockerfile               # Container image for shared demo deployments
+docker-entrypoint.sh     # Chowns mounted data dir, then drops to app user
 PROMPT_FOR_CODEX.md      # Paste-ready Codex task prompt
 RELEASE_CHECKLIST.md     # Demo-ready release gate
 pyproject.toml
+railway.json             # Railway Docker build and healthcheck config
 requirements.txt
 ```
 
@@ -100,7 +104,7 @@ http://127.0.0.1:8000
 
 The dashboard lets you choose a scenario preset, save/load per-scenario demo states, load deterministic demo fixtures, start/stop/step/reset the simulator, replay the current persisted event log, import CSV seed lots or scheduled events, inspect recent events, trace lot lineage, see the active tenant/auth/storage context, and export mock FDA request CSV presets plus scaffolded EPCIS 2.0 JSON-LD exports. It subscribes to live status/event snapshots with Server-Sent Events and falls back to refresh polling if the stream disconnects. Delivery mode defaults to **`mock`** so no credentials are required.
 
-Event records are stored as JSONL at `config.persist_path` (`data/events.jsonl` by default for local unauthenticated use). Existing records at that path are loaded when the app starts or when a start/reset request points at a different path; reset clears the currently configured event log. Tenant-scoped requests store records under `data/tenants/{tenant_id}/events.jsonl` and ignore untrusted persist-path overrides. Replay reads the JSONL log without appending, duplicating, or rewriting stored events.
+Event records are stored as JSONL at `config.persist_path` (`data/events.jsonl` by default for local unauthenticated use). Set `REGENGINE_DATA_DIR` to move the default event log, tenant logs, and scenario saves under another directory such as `/data` for a mounted deployment volume. Existing records at that path are loaded when the app starts or when a start/reset request points at a different path; reset clears the currently configured event log. Tenant-scoped requests store records under `{REGENGINE_DATA_DIR}/tenants/{tenant_id}/events.jsonl` and ignore untrusted persist-path overrides. Replay reads the JSONL log without appending, duplicating, or rewriting stored events.
 
 ## Running tests
 
@@ -296,7 +300,8 @@ The service wrapper examples below can be used with any profile; keep the profil
 
 | Method | Path | Purpose |
 |---|---|---|
-| `GET` | `/api/health` | Liveness probe, tenant/auth context, and current config snapshot |
+| `GET` | `/api/health` | Authenticated liveness probe, tenant/auth context, and current config snapshot |
+| `GET` | `/api/healthz` | Unauthenticated platform/container healthcheck |
 | `GET` | `/api/scenarios` | List available scenario presets |
 | `GET` | `/api/scenario-saves` | List saved per-scenario demo states |
 | `POST` | `/api/scenario-saves/{scenario_id}` | Save the current or supplied config and event log for a scenario |
@@ -576,24 +581,20 @@ journalctl -u regengine -f    # live logs
 
 ### Docker (optional)
 
-A minimal image is straightforward:
-
-```dockerfile
-FROM python:3.12-slim
-WORKDIR /app
-COPY requirements.txt ./
-RUN pip install --no-cache-dir -r requirements.txt
-COPY . .
-EXPOSE 8000
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]
-```
-
-Build and run:
+The repository ships with a production-oriented `Dockerfile`. The entrypoint prepares the mounted data directory, drops to a non-root app user for Uvicorn, stores default simulator data under `/data`, and includes a healthcheck for `/api/healthz`.
 
 ```bash
 docker build -t regengine-inflow-lab .
-docker run --rm -p 8000:8000 regengine-inflow-lab
+docker run --rm \
+  -p 8000:8000 \
+  -v "$PWD/data:/data" \
+  -e REGENGINE_BASIC_AUTH_USERNAME=demo \
+  -e REGENGINE_BASIC_AUTH_PASSWORD=change-me \
+  -e REGENGINE_CORS_ORIGINS=http://127.0.0.1:8000 \
+  regengine-inflow-lab
 ```
+
+`railway.json` uses the same Dockerfile and healthcheck for Railway deployments. Mount persistent storage at `/data` and keep `REGENGINE_DATA_DIR=/data`.
 
 ## Logs and troubleshooting
 

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -21,8 +21,10 @@ Use this checklist before tagging a demo-ready build or handing the simulator to
 ## Operator Flow Checks
 
 - [ ] Dashboard loads without credentials when Basic Auth env vars are unset.
+- [ ] `/api/healthz` remains available without credentials for container/platform healthchecks.
 - [ ] Basic Auth returns `401` without valid credentials when env vars are set.
 - [ ] Shared-demo or live-trial deployments set explicit `REGENGINE_CORS_ORIGINS` values instead of wildcard CORS.
+- [ ] Shared-demo or live-trial deployments set `REGENGINE_DATA_DIR` to mounted persistent storage.
 - [ ] Demo fixture loading resets to a known event log.
 - [ ] Start, stop, single-step, and reset work from the dashboard.
 - [ ] Scenario save/load restores both config and event records.

--- a/app/controller.py
+++ b/app/controller.py
@@ -63,7 +63,7 @@ class SimulationController:
         self.scenario_saves = scenario_saves
         self.mock_service = mock_service
         self.live_client = live_client
-        self.config = SimulationConfig()
+        self.config = SimulationConfig(persist_path=str(store.persist_path))
         self._task: asyncio.Task[None] | None = None
         self._stop_event = asyncio.Event()
         self._lock = asyncio.Lock()

--- a/app/main.py
+++ b/app/main.py
@@ -66,12 +66,13 @@ from .scenarios import ScenarioId, list_scenario_summaries
 from .store import EventStore
 
 
-TENANT_DATA_ROOT = Path("data/tenants")
+DATA_ROOT = Path(os.getenv("REGENGINE_DATA_DIR", "data"))
+TENANT_DATA_ROOT = DATA_ROOT / "tenants"
 DEFAULT_CORS_ORIGINS = ("http://127.0.0.1:8000", "http://localhost:8000")
 
 engine = LegitFlowEngine(seed=204)
-store = EventStore(persist_path="data/events.jsonl")
-scenario_saves = ScenarioSaveStore()
+store = EventStore(persist_path=str(DATA_ROOT / "events.jsonl"))
+scenario_saves = ScenarioSaveStore(save_dir=str(DATA_ROOT / "scenario_saves"))
 mock_service = MockRegEngineService()
 controller = SimulationController(
     engine=engine,
@@ -144,7 +145,7 @@ app.add_middleware(
 
 @app.middleware("http")
 async def auth_and_tenant_middleware(request: Request, call_next):
-    if request.method == "OPTIONS":
+    if request.method == "OPTIONS" or request.url.path == "/api/healthz":
         return await call_next(request)
 
     context = tenant_context_from_request(request)
@@ -176,6 +177,14 @@ async def health(request: Request) -> dict[str, Any]:
             "uses_default_storage": context.uses_default_storage,
         },
         "status": active_controller.status(),
+    }
+
+
+@app.get("/api/healthz")
+async def healthz() -> dict[str, Any]:
+    return {
+        "ok": True,
+        "utc_time": datetime.now(UTC).isoformat(),
     }
 
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+data_dir="${REGENGINE_DATA_DIR:-/data}"
+mkdir -p "$data_dir"
+chown -R appuser:appuser "$data_dir" 2>/dev/null || true
+
+exec gosu appuser "$@"

--- a/railway.json
+++ b/railway.json
@@ -1,0 +1,12 @@
+{
+  "build": {
+    "builder": "DOCKERFILE",
+    "dockerfilePath": "Dockerfile"
+  },
+  "deploy": {
+    "healthcheckPath": "/api/healthz",
+    "healthcheckTimeout": 300,
+    "restartPolicyType": "ON_FAILURE",
+    "restartPolicyMaxRetries": 10
+  }
+}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -113,6 +113,10 @@ def test_basic_auth_is_optional_but_enforced_when_configured(monkeypatch):
     monkeypatch.setenv("REGENGINE_BASIC_AUTH_USERNAME", "demo-user")
     monkeypatch.setenv("REGENGINE_BASIC_AUTH_PASSWORD", "demo-pass")
 
+    healthz = client.get("/api/healthz")
+    assert healthz.status_code == 200
+    assert healthz.json()["ok"] is True
+
     unauthorized = client.get("/api/health")
     assert unauthorized.status_code == 401
     assert unauthorized.headers["www-authenticate"] == 'Basic realm="RegEngine Inflow Lab"'
@@ -171,6 +175,16 @@ def test_tenant_header_scopes_event_storage_and_rejects_invalid_ids(tmp_path):
 
     invalid_response = client.get("/api/health", headers={"X-RegEngine-Tenant": "../tenant"})
     assert invalid_response.status_code == 400
+
+
+def test_default_data_root_is_used_for_local_and_tenant_paths():
+    health = client.get("/api/health").json()
+    assert health["status"]["config"]["persist_path"] == "data/events.jsonl"
+
+    tenant_health = client.get("/api/health", headers={"X-RegEngine-Tenant": "tenant-path-check"}).json()
+    assert tenant_health["status"]["config"]["persist_path"] == (
+        "data/tenants/tenant-path-check/events.jsonl"
+    )
 
 
 def test_scenario_save_load_restores_config_and_event_log(tmp_path):


### PR DESCRIPTION
## Summary
- add Docker/Railway deployment artifacts for the FastAPI simulator
- support REGENGINE_DATA_DIR so Railway volume storage can persist event logs and scenario saves under /data
- add unauthenticated /api/healthz for platform healthchecks while keeping /api/health protected by Basic Auth
- document Railway/shared-demo runtime variables and mounted storage expectations

## Deployed demo
- Railway project: regengine-inflow-lab-demo
- Service: regengine-inflow-lab
- URL: https://regengine-inflow-lab-production.up.railway.app
- Volume: /data
- Basic Auth username: demo
- Password stored locally at /tmp/regengine_inflow_lab_demo_basic_auth_password and in Railway variables

## Verification
- pytest
- python3 scripts/smoke_regression.py
- REGENGINE_DATA_DIR=/tmp/regengine-data-root-check import/health path check
- node --check app/static/app.js
- python3 -m compileall app scripts
- git diff --check
- Railway deployment status SUCCESS
- Remote smoke: /api/healthz, Basic Auth 401 on /api/health, allowed/blocked CORS, fresh-cut fixture load, transformed-lot lineage, FDA export, EPCIS export