### PR TITLE
Add remote smoke CLI

### DIFF
--- a/DEPLOYMENT_PROFILES.md
+++ b/DEPLOYMENT_PROFILES.md
@@ -210,6 +210,18 @@ REGENGINE_DATA_DIR=/data
 
 Attach a Railway volume at `/data` before using the service for partner demos. After a Railway domain is generated, update `REGENGINE_CORS_ORIGINS` to that exact HTTPS origin.
 
+Validate the deployed Railway demo with the remote smoke harness:
+
+```bash
+export REGENGINE_REMOTE_BASE_URL=https://regengine-inflow-lab-production.up.railway.app
+export REGENGINE_REMOTE_USERNAME=demo
+export REGENGINE_REMOTE_PASSWORD='<shared-demo-password>'
+export REGENGINE_REMOTE_TENANT=remote-smoke
+python3 scripts/remote_smoke.py
+```
+
+The harness keeps delivery in `mock` mode, uses the dedicated smoke tenant by default, and verifies health, Basic Auth, CORS, fixture load, lineage, FDA CSV, and EPCIS JSON-LD without printing the password.
+
 ## Profile Verification Checklist
 
 - `GET /api/health` returns the expected tenant and auth context.
@@ -218,6 +230,7 @@ Attach a Railway volume at `/data` before using the service for partner demos. A
 - `REGENGINE_DATA_DIR` points at mounted persistent storage in shared-demo and live-trial deployments.
 - Dashboard stats match the chosen tenant/auth/storage profile.
 - `POST /api/demo-fixtures/fresh_cut_transformation/load` succeeds in `mock` mode.
+- `python3 scripts/remote_smoke.py` passes for the deployed shared-demo URL.
 - Lineage for `TLC-DEMO-FC-OUT-001` includes upstream harvest and packed lots.
 - FDA CSV and EPCIS exports are derivable from stored records.
 - No generated `data/` files or secrets are staged before committing.

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ app/
   workflows/codex-autopilot.yml
 scripts/
   smoke_regression.py    # End-to-end API smoke for demo-ready release checks
+  remote_smoke.py        # HTTP smoke harness for deployed shared-demo instances
 tests/
 .dockerignore
 AGENTS.md                # Repository instructions for Codex-style agents
@@ -123,6 +124,18 @@ python3 scripts/smoke_regression.py
 ```
 
 The smoke harness uses FastAPI's in-process `TestClient` to exercise the operator-critical path: tenant-scoped fixture load, lineage lookup, FDA export, EPCIS export, scenario save/load, replay, and tenant isolation. If Basic Auth env vars are set, it sends matching Basic credentials automatically. Temporary smoke tenants are cleaned up after the run.
+
+For a deployed shared-demo instance, run the remote smoke harness against the public HTTPS URL:
+
+```bash
+export REGENGINE_REMOTE_BASE_URL=https://regengine-inflow-lab-production.up.railway.app
+export REGENGINE_REMOTE_USERNAME=demo
+export REGENGINE_REMOTE_PASSWORD='replace-with-shared-demo-password'
+export REGENGINE_REMOTE_TENANT=remote-smoke
+python3 scripts/remote_smoke.py
+```
+
+`scripts/remote_smoke.py` uses `httpx` with normal TLS verification to check `/api/healthz`, Basic Auth enforcement, credentialed CORS allow/block behavior, mock fixture loading, transformed-lot lineage, FDA CSV export, and EPCIS JSON-LD export. The tenant defaults to `remote-smoke`, fixture delivery stays in `mock` mode, and failure messages redact configured passwords and credential-like environment values.
 
 Use `RELEASE_CHECKLIST.md` as the full demo-ready gate. Use `DESIGN_PARTNER_DEMO_SCRIPT.md` for the call flow, expected talking points, fixture reset commands, and recovery steps.
 

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -7,7 +7,7 @@ Use this checklist before tagging a demo-ready build or handing the simulator to
 - [ ] `pytest`
 - [ ] `python3 scripts/smoke_regression.py`
 - [ ] `node --check app/static/app.js`
-- [ ] `python3 -m compileall app`
+- [ ] `python3 -m compileall app scripts`
 - [ ] `git diff --check`
 
 ## Contract Checks
@@ -32,6 +32,7 @@ Use this checklist before tagging a demo-ready build or handing the simulator to
 - [ ] FDA lot-trace export includes `BATCH-DEMO-FC-001`.
 - [ ] EPCIS export includes a `TransformationEvent`.
 - [ ] Tenant-scoped requests keep separate event logs and scenario saves.
+- [ ] For shared-demo releases, `python3 scripts/remote_smoke.py` passes against the deployed HTTPS URL.
 
 ## Handoff Notes
 

--- a/scripts/remote_smoke.py
+++ b/scripts/remote_smoke.py
@@ -1,0 +1,383 @@
+from __future__ import annotations
+
+import os
+import sys
+from dataclasses import dataclass, field
+from typing import Any
+from urllib.parse import urlparse
+
+import httpx
+
+
+DEFAULT_TENANT = "remote-smoke"
+DEFAULT_UNTRUSTED_ORIGIN = "https://untrusted.example"
+FRESH_CUT_OUTPUT_LOT = "TLC-DEMO-FC-OUT-001"
+
+
+class RemoteSmokeFailure(AssertionError):
+    pass
+
+
+@dataclass(frozen=True)
+class RemoteSmokeConfig:
+    base_url: str
+    username: str
+    password: str = field(repr=False)
+    tenant: str = DEFAULT_TENANT
+    cors_origin: str | None = None
+    untrusted_origin: str = DEFAULT_UNTRUSTED_ORIGIN
+    timeout_seconds: float = 30.0
+
+    @property
+    def allowed_origin(self) -> str:
+        return self.cors_origin or origin_from_url(self.base_url)
+
+    def redact(self, value: str) -> str:
+        redacted = value
+        for secret in secret_values(self.password):
+            redacted = redacted.replace(secret, "[redacted]")
+        return redacted
+
+
+def main() -> int:
+    try:
+        config = config_from_env()
+        summary = run_remote_smoke(config)
+    except RemoteSmokeFailure as exc:
+        print(f"Remote smoke failed: {exc}", file=sys.stderr)
+        return 1
+    except httpx.HTTPError as exc:
+        print(f"Remote smoke failed: HTTP client error: {exc}", file=sys.stderr)
+        return 1
+
+    print(
+        "Remote smoke passed: "
+        f"base_url={config.base_url}, "
+        f"tenant={summary['tenant']}, "
+        f"fixture_stored={summary['fixture_stored']}, "
+        f"fixture_posted={summary['fixture_posted']}, "
+        f"lineage_records={summary['lineage_records']}, "
+        f"epcis_events={summary['epcis_events']}"
+    )
+    return 0
+
+
+def config_from_env(environ: dict[str, str] | None = None) -> RemoteSmokeConfig:
+    environ = environ or os.environ
+    missing = [
+        name
+        for name in (
+            "REGENGINE_REMOTE_BASE_URL",
+            "REGENGINE_REMOTE_USERNAME",
+            "REGENGINE_REMOTE_PASSWORD",
+        )
+        if not environ.get(name)
+    ]
+    if missing:
+        raise RemoteSmokeFailure(
+            "Missing required environment variables: " + ", ".join(missing)
+        )
+
+    base_url = normalize_base_url(environ["REGENGINE_REMOTE_BASE_URL"])
+    return RemoteSmokeConfig(
+        base_url=base_url,
+        username=environ["REGENGINE_REMOTE_USERNAME"],
+        password=environ["REGENGINE_REMOTE_PASSWORD"],
+        tenant=environ.get("REGENGINE_REMOTE_TENANT") or DEFAULT_TENANT,
+        cors_origin=normalize_optional_origin(environ.get("REGENGINE_REMOTE_CORS_ORIGIN")),
+        untrusted_origin=normalize_optional_origin(
+            environ.get("REGENGINE_REMOTE_UNTRUSTED_ORIGIN")
+        )
+        or DEFAULT_UNTRUSTED_ORIGIN,
+    )
+
+
+def run_remote_smoke(
+    config: RemoteSmokeConfig,
+    client: httpx.Client | None = None,
+) -> dict[str, Any]:
+    owns_client = client is None
+    if client is None:
+        client = httpx.Client(
+            base_url=config.base_url,
+            follow_redirects=True,
+            timeout=config.timeout_seconds,
+            verify=True,
+        )
+
+    try:
+        healthz = request_json(client, config, "GET", "/api/healthz", authenticated=False)
+        assert_equal(healthz.get("ok"), True, "healthz ok")
+
+        unauthenticated_health = client.get("/api/health")
+        assert_status(config, unauthenticated_health, 401, "Basic Auth enforcement")
+
+        health = request_json(
+            client,
+            config,
+            "GET",
+            "/api/health",
+            headers={"Origin": config.allowed_origin},
+        )
+        assert_equal(health.get("tenant"), config.tenant, "health tenant")
+        auth = health.get("auth") or {}
+        assert_equal(auth.get("enabled"), True, "health auth enabled")
+        assert_equal(auth.get("uses_default_storage"), False, "health tenant storage")
+        assert_header(
+            config,
+            health_response_header(client, config, config.allowed_origin),
+            "access-control-allow-origin",
+            config.allowed_origin,
+            "allowed CORS origin",
+        )
+
+        blocked_cors = request(
+            client,
+            config,
+            "GET",
+            "/api/health",
+            headers={"Origin": config.untrusted_origin},
+        )
+        assert_status(config, blocked_cors, 200, "blocked CORS health probe")
+        blocked_origin = blocked_cors.headers.get("access-control-allow-origin")
+        if blocked_origin == config.untrusted_origin:
+            raise RemoteSmokeFailure(
+                "blocked CORS origin: untrusted origin was allowed"
+            )
+
+        request_json(
+            client,
+            config,
+            "POST",
+            "/api/simulate/reset",
+            json={
+                "scenario": "fresh_cut_processor",
+                "batch_size": 1,
+                "seed": 204,
+                "delivery": {"mode": "mock"},
+            },
+        )
+
+        fixture = request_json(
+            client,
+            config,
+            "POST",
+            "/api/demo-fixtures/fresh_cut_transformation/load",
+            json={
+                "reset": True,
+                "source": "remote-smoke",
+                "delivery": {"mode": "mock"},
+            },
+        )
+        assert_equal(fixture.get("status"), "loaded", "fixture load status")
+        assert_equal(fixture.get("stored"), 13, "fixture stored events")
+        assert_equal(fixture.get("posted"), 13, "fixture posted events")
+        assert_equal(fixture.get("failed"), 0, "fixture failed events")
+        assert_equal(fixture.get("delivery_mode"), "mock", "fixture delivery mode")
+
+        lineage = request_json(
+            client,
+            config,
+            "GET",
+            f"/api/lineage/{FRESH_CUT_OUTPUT_LOT}",
+        )
+        records = lineage.get("records") or []
+        lot_codes = {
+            record.get("event", {}).get("traceability_lot_code") for record in records
+        }
+        assert_in("TLC-DEMO-FC-HARVEST-001", lot_codes, "lineage harvest lot")
+        assert_in("TLC-DEMO-FC-PACK-001", lot_codes, "lineage packed input lot")
+        assert_in(FRESH_CUT_OUTPUT_LOT, lot_codes, "lineage output lot")
+
+        fda_response = request(
+            client,
+            config,
+            "GET",
+            "/api/mock/regengine/export/fda-request",
+            params={
+                "preset": "lot_trace",
+                "traceability_lot_code": FRESH_CUT_OUTPUT_LOT,
+            },
+        )
+        assert_status(config, fda_response, 200, "FDA lot-trace export")
+        assert_in(
+            "BATCH-DEMO-FC-001",
+            fda_response.text,
+            "FDA lot-trace batch reference",
+        )
+
+        epcis = request_json(
+            client,
+            config,
+            "GET",
+            "/api/mock/regengine/export/epcis",
+            params={"traceability_lot_code": FRESH_CUT_OUTPUT_LOT},
+        )
+        epcis_events = epcis.get("epcisBody", {}).get("eventList") or []
+        event_types = {event.get("type") for event in epcis_events}
+        assert_in("TransformationEvent", event_types, "EPCIS transformation event")
+
+        return {
+            "tenant": config.tenant,
+            "fixture_stored": fixture["stored"],
+            "fixture_posted": fixture["posted"],
+            "lineage_records": len(records),
+            "epcis_events": len(epcis_events),
+        }
+    finally:
+        if owns_client:
+            client.close()
+
+
+def request_json(
+    client: httpx.Client,
+    config: RemoteSmokeConfig,
+    method: str,
+    path: str,
+    *,
+    authenticated: bool = True,
+    headers: dict[str, str] | None = None,
+    json: dict[str, Any] | None = None,
+    params: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    response = request(
+        client,
+        config,
+        method,
+        path,
+        authenticated=authenticated,
+        headers=headers,
+        json=json,
+        params=params,
+    )
+    assert_status(config, response, 200, path)
+    try:
+        payload = response.json()
+    except ValueError as exc:
+        raise RemoteSmokeFailure(
+            f"{path}: expected JSON response, got "
+            f"{config.redact(response.text[:300])!r}"
+        ) from exc
+    if not isinstance(payload, dict):
+        raise RemoteSmokeFailure(f"{path}: expected JSON object response")
+    return payload
+
+
+def request(
+    client: httpx.Client,
+    config: RemoteSmokeConfig,
+    method: str,
+    path: str,
+    *,
+    authenticated: bool = True,
+    headers: dict[str, str] | None = None,
+    json: dict[str, Any] | None = None,
+    params: dict[str, str] | None = None,
+) -> httpx.Response:
+    request_headers = {"X-RegEngine-Tenant": config.tenant}
+    request_headers.update(headers or {})
+    auth = httpx.BasicAuth(config.username, config.password) if authenticated else None
+    return client.request(
+        method,
+        path,
+        headers=request_headers,
+        json=json,
+        params=params,
+        auth=auth,
+    )
+
+
+def health_response_header(
+    client: httpx.Client,
+    config: RemoteSmokeConfig,
+    origin: str,
+) -> httpx.Response:
+    return request(
+        client,
+        config,
+        "GET",
+        "/api/health",
+        headers={"Origin": origin},
+    )
+
+
+def assert_status(
+    config: RemoteSmokeConfig,
+    response: httpx.Response,
+    expected_status: int,
+    label: str,
+) -> None:
+    if response.status_code != expected_status:
+        body = config.redact(response.text[:500])
+        raise RemoteSmokeFailure(
+            f"{label}: expected HTTP {expected_status}, got "
+            f"{response.status_code}: {body}"
+        )
+
+
+def assert_header(
+    config: RemoteSmokeConfig,
+    response: httpx.Response,
+    header_name: str,
+    expected_value: str,
+    label: str,
+) -> None:
+    actual = response.headers.get(header_name)
+    if actual != expected_value:
+        raise RemoteSmokeFailure(
+            f"{label}: expected {header_name}={expected_value!r}, got "
+            f"{config.redact(str(actual))!r}"
+        )
+
+
+def assert_equal(actual: Any, expected: Any, label: str) -> None:
+    if actual != expected:
+        raise RemoteSmokeFailure(f"{label}: expected {expected!r}, got {actual!r}")
+
+
+def assert_in(member: Any, container: Any, label: str) -> None:
+    if member not in container:
+        raise RemoteSmokeFailure(f"{label}: expected {member!r} to be present")
+
+
+def normalize_base_url(value: str) -> str:
+    base_url = value.strip().rstrip("/")
+    parsed = urlparse(base_url)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise RemoteSmokeFailure(
+            "REGENGINE_REMOTE_BASE_URL must be an HTTP(S) URL such as "
+            "https://demo.example.com"
+        )
+    return base_url
+
+
+def normalize_optional_origin(value: str | None) -> str | None:
+    if not value or not value.strip():
+        return None
+    origin = value.strip().rstrip("/")
+    parsed = urlparse(origin)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise RemoteSmokeFailure(
+            "Remote smoke CORS origins must be HTTP(S) origins such as "
+            "https://demo.example.com"
+        )
+    return f"{parsed.scheme}://{parsed.netloc}"
+
+
+def origin_from_url(value: str) -> str:
+    parsed = urlparse(value)
+    port = f":{parsed.port}" if parsed.port else ""
+    return f"{parsed.scheme}://{parsed.hostname}{port}"
+
+
+def secret_values(*extra_values: str | None) -> set[str]:
+    values = {value for value in extra_values if value}
+    for key, value in os.environ.items():
+        key_lower = key.lower()
+        if value and any(token in key_lower for token in ("password", "api_key", "apikey", "secret", "token")):
+            values.add(value)
+    return {value for value in values if len(value) >= 4}
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_remote_smoke.py
+++ b/tests/test_remote_smoke.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from scripts.remote_smoke import (
+    DEFAULT_TENANT,
+    FRESH_CUT_OUTPUT_LOT,
+    RemoteSmokeConfig,
+    RemoteSmokeFailure,
+    config_from_env,
+    run_remote_smoke,
+)
+
+
+def test_config_from_env_requires_connection_and_auth_values():
+    with pytest.raises(RemoteSmokeFailure, match="REGENGINE_REMOTE_BASE_URL"):
+        config_from_env({})
+
+    config = config_from_env(
+        {
+            "REGENGINE_REMOTE_BASE_URL": "https://demo.example.com/",
+            "REGENGINE_REMOTE_USERNAME": "demo",
+            "REGENGINE_REMOTE_PASSWORD": "secret-password",
+        }
+    )
+
+    assert config.base_url == "https://demo.example.com"
+    assert config.tenant == DEFAULT_TENANT
+    assert config.allowed_origin == "https://demo.example.com"
+
+
+def test_remote_smoke_success_uses_basic_auth_and_dedicated_tenant():
+    server = FakeRemoteServer()
+    config = RemoteSmokeConfig(
+        base_url="https://demo.example.com",
+        username="demo",
+        password="secret-password",
+    )
+
+    with httpx.Client(
+        base_url=config.base_url,
+        transport=httpx.MockTransport(server.handle),
+    ) as client:
+        summary = run_remote_smoke(config, client=client)
+
+    assert summary == {
+        "tenant": DEFAULT_TENANT,
+        "fixture_stored": 13,
+        "fixture_posted": 13,
+        "lineage_records": 3,
+        "epcis_events": 1,
+    }
+
+    healthz = server.requests[0]
+    unauthenticated_health = server.requests[1]
+    authenticated_requests = server.requests[2:]
+
+    assert healthz.url.path == "/api/healthz"
+    assert "authorization" not in healthz.headers
+    assert unauthenticated_health.url.path == "/api/health"
+    assert "authorization" not in unauthenticated_health.headers
+    assert all("authorization" in request.headers for request in authenticated_requests)
+    assert all(
+        request.headers["x-regengine-tenant"] == DEFAULT_TENANT
+        for request in authenticated_requests
+    )
+    assert server.fixture_request_json == {
+        "reset": True,
+        "source": "remote-smoke",
+        "delivery": {"mode": "mock"},
+    }
+
+
+def test_remote_smoke_redacts_password_from_failure_messages():
+    server = FakeRemoteServer(fail_reset=True)
+    config = RemoteSmokeConfig(
+        base_url="https://demo.example.com",
+        username="demo",
+        password="secret-password",
+    )
+
+    with httpx.Client(
+        base_url=config.base_url,
+        transport=httpx.MockTransport(server.handle),
+    ) as client:
+        with pytest.raises(RemoteSmokeFailure) as exc_info:
+            run_remote_smoke(config, client=client)
+
+    failure_message = str(exc_info.value)
+    assert "secret-password" not in failure_message
+    assert "[redacted]" in failure_message
+
+
+class FakeRemoteServer:
+    def __init__(self, *, fail_reset: bool = False) -> None:
+        self.fail_reset = fail_reset
+        self.requests: list[httpx.Request] = []
+        self.fixture_request_json: dict | None = None
+
+    def handle(self, request: httpx.Request) -> httpx.Response:
+        self.requests.append(request)
+        path = request.url.path
+        if path == "/api/healthz":
+            return httpx.Response(200, json={"ok": True})
+        if path == "/api/health":
+            if "authorization" not in request.headers:
+                return httpx.Response(401, json={"detail": "Not authenticated"})
+            headers = self.cors_headers(request)
+            return httpx.Response(
+                200,
+                headers=headers,
+                json={
+                    "ok": True,
+                    "tenant": request.headers["x-regengine-tenant"],
+                    "auth": {
+                        "enabled": True,
+                        "username": "demo",
+                        "uses_default_storage": False,
+                    },
+                    "status": {
+                        "config": {
+                            "persist_path": "data/tenants/remote-smoke/events.jsonl",
+                            "delivery": {"mode": "mock"},
+                        }
+                    },
+                },
+            )
+        if path == "/api/simulate/reset":
+            if self.fail_reset:
+                return httpx.Response(
+                    500,
+                    text="reset failed while handling secret-password",
+                )
+            return httpx.Response(200, json={"status": "reset"})
+        if path == "/api/demo-fixtures/fresh_cut_transformation/load":
+            self.fixture_request_json = decode_json(request)
+            return httpx.Response(
+                200,
+                json={
+                    "status": "loaded",
+                    "fixture_id": "fresh_cut_transformation",
+                    "scenario": "fresh_cut_processor",
+                    "loaded": 13,
+                    "stored": 13,
+                    "posted": 13,
+                    "failed": 0,
+                    "source": "remote-smoke",
+                    "delivery_mode": "mock",
+                    "delivery_attempts": 1,
+                    "lot_codes": [FRESH_CUT_OUTPUT_LOT],
+                    "response": {},
+                    "error": None,
+                },
+            )
+        if path == f"/api/lineage/{FRESH_CUT_OUTPUT_LOT}":
+            return httpx.Response(
+                200,
+                json={
+                    "traceability_lot_code": FRESH_CUT_OUTPUT_LOT,
+                    "records": [
+                        {"event": {"traceability_lot_code": "TLC-DEMO-FC-HARVEST-001"}},
+                        {"event": {"traceability_lot_code": "TLC-DEMO-FC-PACK-001"}},
+                        {"event": {"traceability_lot_code": FRESH_CUT_OUTPUT_LOT}},
+                    ],
+                    "nodes": [],
+                    "edges": [],
+                },
+            )
+        if path == "/api/mock/regengine/export/fda-request":
+            return httpx.Response(200, text="traceability_lot_code,batch\nTLC,BATCH-DEMO-FC-001\n")
+        if path == "/api/mock/regengine/export/epcis":
+            return httpx.Response(
+                200,
+                json={"epcisBody": {"eventList": [{"type": "TransformationEvent"}]}},
+            )
+        return httpx.Response(404, text=f"Unhandled path {path}")
+
+    def cors_headers(self, request: httpx.Request) -> dict[str, str]:
+        origin = request.headers.get("origin")
+        if origin == "https://demo.example.com":
+            return {
+                "access-control-allow-origin": origin,
+                "access-control-allow-credentials": "true",
+            }
+        return {}
+
+
+def decode_json(request: httpx.Request) -> dict:
+    body = request.content.decode("utf-8")
+    return httpx.Response(200, content=body).json()


### PR DESCRIPTION
## Summary
- Add `scripts/remote_smoke.py` for deployed shared-demo validation over HTTP using `httpx`
- Validate healthz, Basic Auth enforcement, CORS allow/block behavior, mock fixture load, transformed-lot lineage, FDA CSV, and EPCIS JSON-LD
- Document the remote smoke env vars in README, deployment profiles, and the release checklist

## Verification
- `pytest`
- `python3 scripts/smoke_regression.py`
- `node --check app/static/app.js`
- `python3 -m compileall app scripts`
- `git diff --check`
- Remote smoke against `https://regengine-inflow-lab-production.up.railway.app`
- `railway deployment list` shows latest deployment `SUCCESS`

## Notes
- Remote fixture delivery stays in `mock` mode.
- The default remote smoke tenant is `remote-smoke`.
- Passwords and credential-like environment values are redacted from failure messages.
