### PR TITLE
Add remote smoke workflow

### DIFF
--- a/.github/workflows/remote-smoke.yml
+++ b/.github/workflows/remote-smoke.yml
@@ -1,0 +1,61 @@
+name: Remote Smoke
+
+on:
+  workflow_dispatch:
+    inputs:
+      base_url:
+        description: Deployed shared-demo base URL
+        required: false
+        type: string
+        default: https://regengine-inflow-lab-production.up.railway.app
+      tenant:
+        description: Tenant used for isolated remote smoke data
+        required: false
+        type: string
+        default: remote-smoke
+
+permissions:
+  contents: read
+
+concurrency:
+  group: remote-smoke-${{ github.event.inputs.base_url }}-${{ github.event.inputs.tenant }}
+  cancel-in-progress: false
+
+jobs:
+  remote-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+          cache: pip
+          cache-dependency-path: |
+            requirements.txt
+            pyproject.toml
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Validate remote smoke secrets
+        env:
+          REGENGINE_REMOTE_USERNAME: ${{ secrets.REGENGINE_REMOTE_USERNAME }}
+          REGENGINE_REMOTE_PASSWORD: ${{ secrets.REGENGINE_REMOTE_PASSWORD }}
+        run: |
+          test -n "$REGENGINE_REMOTE_USERNAME" || { echo "REGENGINE_REMOTE_USERNAME secret is required"; exit 1; }
+          test -n "$REGENGINE_REMOTE_PASSWORD" || { echo "REGENGINE_REMOTE_PASSWORD secret is required"; exit 1; }
+
+      - name: Run remote smoke
+        env:
+          REGENGINE_REMOTE_BASE_URL: ${{ inputs.base_url }}
+          REGENGINE_REMOTE_USERNAME: ${{ secrets.REGENGINE_REMOTE_USERNAME }}
+          REGENGINE_REMOTE_PASSWORD: ${{ secrets.REGENGINE_REMOTE_PASSWORD }}
+          REGENGINE_REMOTE_TENANT: ${{ inputs.tenant }}
+        run: python3 scripts/remote_smoke.py

--- a/DEPLOYMENT_PROFILES.md
+++ b/DEPLOYMENT_PROFILES.md
@@ -222,6 +222,22 @@ python3 scripts/remote_smoke.py
 
 The harness keeps delivery in `mock` mode, uses the dedicated smoke tenant by default, and verifies health, Basic Auth, CORS, fixture load, lineage, FDA CSV, and EPCIS JSON-LD without printing the password.
 
+You can run the same check from GitHub Actions with the manual **Remote Smoke** workflow. Configure these repository secrets first:
+
+```text
+REGENGINE_REMOTE_USERNAME=demo
+REGENGINE_REMOTE_PASSWORD=<shared-demo-password>
+```
+
+Then run `.github/workflows/remote-smoke.yml` from the Actions tab. The workflow inputs are:
+
+| Input | Default | Purpose |
+|---|---|---|
+| `base_url` | `https://regengine-inflow-lab-production.up.railway.app` | Deployed shared-demo URL to validate |
+| `tenant` | `remote-smoke` | Tenant used for isolated smoke data |
+
+The workflow installs the repo dependencies and runs `python3 scripts/remote_smoke.py`. It does not require live RegEngine credentials and still loads the fixture with `delivery.mode=mock`.
+
 ## Profile Verification Checklist
 
 - `GET /api/health` returns the expected tenant and auth context.
@@ -231,6 +247,7 @@ The harness keeps delivery in `mock` mode, uses the dedicated smoke tenant by de
 - Dashboard stats match the chosen tenant/auth/storage profile.
 - `POST /api/demo-fixtures/fresh_cut_transformation/load` succeeds in `mock` mode.
 - `python3 scripts/remote_smoke.py` passes for the deployed shared-demo URL.
+- The manual GitHub **Remote Smoke** workflow passes with the same shared-demo URL and smoke tenant.
 - Lineage for `TLC-DEMO-FC-OUT-001` includes upstream harvest and packed lots.
 - FDA CSV and EPCIS exports are derivable from stored records.
 - No generated `data/` files or secrets are staged before committing.

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ app/
   codex/prompts/autobuild.md
   workflows/ci.yml
   workflows/codex-autopilot.yml
+  workflows/remote-smoke.yml
 scripts/
   smoke_regression.py    # End-to-end API smoke for demo-ready release checks
   remote_smoke.py        # HTTP smoke harness for deployed shared-demo instances
@@ -136,6 +137,8 @@ python3 scripts/remote_smoke.py
 ```
 
 `scripts/remote_smoke.py` uses `httpx` with normal TLS verification to check `/api/healthz`, Basic Auth enforcement, credentialed CORS allow/block behavior, mock fixture loading, transformed-lot lineage, FDA CSV export, and EPCIS JSON-LD export. The tenant defaults to `remote-smoke`, fixture delivery stays in `mock` mode, and failure messages redact configured passwords and credential-like environment values.
+
+GitHub also has a manual **Remote Smoke** workflow for deployed demo validation. Configure repository secrets `REGENGINE_REMOTE_USERNAME` and `REGENGINE_REMOTE_PASSWORD`, then run `.github/workflows/remote-smoke.yml` with optional `base_url` and `tenant` inputs.
 
 Use `RELEASE_CHECKLIST.md` as the full demo-ready gate. Use `DESIGN_PARTNER_DEMO_SCRIPT.md` for the call flow, expected talking points, fixture reset commands, and recovery steps.
 

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -33,6 +33,7 @@ Use this checklist before tagging a demo-ready build or handing the simulator to
 - [ ] EPCIS export includes a `TransformationEvent`.
 - [ ] Tenant-scoped requests keep separate event logs and scenario saves.
 - [ ] For shared-demo releases, `python3 scripts/remote_smoke.py` passes against the deployed HTTPS URL.
+- [ ] For shared-demo releases, the manual GitHub **Remote Smoke** workflow passes with repository secrets `REGENGINE_REMOTE_USERNAME` and `REGENGINE_REMOTE_PASSWORD`.
 
 ## Handoff Notes
 


### PR DESCRIPTION
## Summary
- Add manual GitHub Actions workflow `.github/workflows/remote-smoke.yml`
- Wire workflow inputs for deployed `base_url` and isolated smoke `tenant`
- Document required repository secrets and the workflow in README, deployment profiles, and release checklist

## Verification
- `pytest`
- `python3 scripts/smoke_regression.py`
- `node --check app/static/app.js`
- `python3 -m compileall app scripts`
- `git diff --check`
- Ruby YAML parse check for `.github/workflows/remote-smoke.yml`
- Remote smoke against `https://regengine-inflow-lab-production.up.railway.app`
- `railway deployment list` shows latest deployment `SUCCESS`

## Notes
- Configured repository Actions secrets `REGENGINE_REMOTE_USERNAME` and `REGENGINE_REMOTE_PASSWORD` so the workflow can run after merge.
- The workflow still uses mock fixture delivery only; no live RegEngine credentials are required.
- Per the sprint acceptance, run the manual Remote Smoke workflow once after this merges to `main`.
