### PR TITLE
Add deployment request logging

### DIFF
--- a/DEPLOYMENT_PROFILES.md
+++ b/DEPLOYMENT_PROFILES.md
@@ -238,6 +238,23 @@ Then run `.github/workflows/remote-smoke.yml` from the Actions tab. The workflow
 
 The workflow installs the repo dependencies and runs `python3 scripts/remote_smoke.py`. It does not require live RegEngine credentials and still loads the fixture with `delivery.mode=mock`.
 
+Railway log triage:
+
+```bash
+railway logs --lines 100
+railway logs --http --status ">=400" --lines 50
+railway logs --http --path /api/health --lines 20
+```
+
+Application request logs include `method`, `path`, `status`, `duration_ms`, `tenant`, and `delivery_mode`. They do not include Authorization headers, API keys, query strings, request bodies, response bodies, FDA CSV contents, or EPCIS export contents.
+
+Use these patterns when diagnosing a shared demo:
+
+- `status=401` on API routes usually means the Basic Auth username/password in the operator environment or GitHub secret is wrong.
+- Missing browser CORS headers usually means `REGENGINE_CORS_ORIGINS` does not exactly match the deployed HTTPS origin.
+- Empty state after restart usually means the Railway volume is missing or `REGENGINE_DATA_DIR` is not `/data`.
+- Live delivery failures should be diagnosed from the dashboard delivery monitor and sanitized record status before retrying with corrected live endpoint, API key, and tenant id.
+
 ## Profile Verification Checklist
 
 - `GET /api/health` returns the expected tenant and auth context.

--- a/README.md
+++ b/README.md
@@ -614,6 +614,14 @@ docker run --rm \
 
 ## Logs and troubleshooting
 
+Every HTTP request emits an application log line like:
+
+```text
+request method=POST path=/api/demo-fixtures/fresh_cut_transformation/load status=200 duration_ms=42.10 tenant=remote-smoke delivery_mode=mock
+```
+
+The request log intentionally excludes headers, credentials, query strings, request bodies, response bodies, and export contents. Use it to correlate route failures, tenant scope, and the active delivery mode without exposing Basic Auth passwords, API keys, live tenant ids, or downloaded FDA/EPCIS data.
+
 | Location | What it contains |
 |---|---|
 | `uvicorn.out.log` | Server stdout (request logs, lifecycle messages) |
@@ -634,9 +642,20 @@ curl http://127.0.0.1:8000/api/health
 
 # Tail logs (macOS)
 tail -f ~/regengine_codex_workspace/uvicorn.err.log
+
+# Railway logs
+railway logs --lines 100
+railway logs --http --status ">=400" --lines 50
 ```
 
-If the health check fails, the first place to look is `uvicorn.err.log` for a Python traceback.
+Common failure patterns:
+
+- Auth failures: request logs show `status=401` on `/api/...`; confirm `REGENGINE_BASIC_AUTH_USERNAME` and `REGENGINE_BASIC_AUTH_PASSWORD` are set as intended.
+- CORS failures: Railway HTTP logs may show successful `OPTIONS` but the browser blocks a follow-up request; confirm `REGENGINE_CORS_ORIGINS` is the exact HTTPS dashboard origin.
+- Volume/storage failures: `/api/health` should report tenant-scoped paths under `REGENGINE_DATA_DIR`; confirm Railway has a volume mounted at `/data` and `REGENGINE_DATA_DIR=/data`.
+- Live delivery failures: request logs identify the route and tenant while dashboard delivery stats show the sanitized delivery error; confirm endpoint, API key, and tenant id before retrying.
+
+If the health check fails before request logs appear, the first place to look is `uvicorn.err.log` or `railway logs --deployment` for a Python traceback or startup error.
 
 ## Contributing
 

--- a/app/main.py
+++ b/app/main.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import os
+import time
 from contextlib import asynccontextmanager
 from datetime import UTC, datetime
 from pathlib import Path
@@ -69,6 +71,7 @@ from .store import EventStore
 DATA_ROOT = Path(os.getenv("REGENGINE_DATA_DIR", "data"))
 TENANT_DATA_ROOT = DATA_ROOT / "tenants"
 DEFAULT_CORS_ORIGINS = ("http://127.0.0.1:8000", "http://localhost:8000")
+REQUEST_LOGGER = logging.getLogger("regengine.request")
 
 engine = LegitFlowEngine(seed=204)
 store = EventStore(persist_path=str(DATA_ROOT / "events.jsonl"))
@@ -145,14 +148,51 @@ app.add_middleware(
 
 @app.middleware("http")
 async def auth_and_tenant_middleware(request: Request, call_next):
-    if request.method == "OPTIONS" or request.url.path == "/api/healthz":
-        return await call_next(request)
+    started_at = time.perf_counter()
+    response = None
 
-    context = tenant_context_from_request(request)
-    if isinstance(context, JSONResponse):
-        return context
-    request.state.tenant_context = context
-    return await call_next(request)
+    try:
+        if request.method == "OPTIONS" or request.url.path == "/api/healthz":
+            response = await call_next(request)
+            return response
+
+        context = tenant_context_from_request(request)
+        if isinstance(context, JSONResponse):
+            response = context
+            return response
+        request.state.tenant_context = context
+        response = await call_next(request)
+        return response
+    except Exception:
+        _log_request(request, status_code=500, started_at=started_at)
+        raise
+    finally:
+        if response is not None:
+            _log_request(request, status_code=response.status_code, started_at=started_at)
+
+
+def _log_request(request: Request, status_code: int, started_at: float) -> None:
+    duration_ms = (time.perf_counter() - started_at) * 1000
+    context = _tenant_context(request)
+    delivery_mode = _request_delivery_mode(request)
+    REQUEST_LOGGER.info(
+        "request method=%s path=%s status=%s duration_ms=%.2f tenant=%s delivery_mode=%s",
+        request.method,
+        request.url.path,
+        status_code,
+        duration_ms,
+        context.tenant_id,
+        delivery_mode,
+    )
+
+
+def _request_delivery_mode(request: Request) -> str:
+    if not hasattr(request.state, "tenant_context") and request.url.path != "/api/healthz":
+        return "unknown"
+    try:
+        return str(_active_controller(request).config.delivery.mode.value)
+    except Exception:
+        return "unknown"
 
 static_dir = Path(__file__).parent / "static"
 app.mount("/static", StaticFiles(directory=static_dir), name="static")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -3,6 +3,7 @@ import base64
 import csv
 import io
 import json
+import logging
 
 import pytest
 from fastapi.testclient import TestClient
@@ -133,6 +134,64 @@ def test_basic_auth_is_optional_but_enforced_when_configured(monkeypatch):
         "username": "demo-user",
         "uses_default_storage": False,
     }
+
+
+def test_request_logging_includes_ops_fields_without_auth_or_query_secrets(monkeypatch, caplog):
+    monkeypatch.setenv("REGENGINE_BASIC_AUTH_USERNAME", "demo-user")
+    monkeypatch.setenv("REGENGINE_BASIC_AUTH_PASSWORD", "demo-pass")
+    caplog.set_level(logging.INFO, logger="regengine.request")
+
+    response = client.get(
+        "/api/health?api_key=query-secret",
+        headers={
+            **basic_auth_header("demo-user", "demo-pass"),
+            "X-RegEngine-Tenant": "ops-tenant",
+            "X-RegEngine-API-Key": "header-secret",
+        },
+    )
+
+    assert response.status_code == 200
+    messages = [
+        record.getMessage()
+        for record in caplog.records
+        if record.name == "regengine.request"
+    ]
+    assert any(
+        "method=GET" in message
+        and "path=/api/health" in message
+        and "status=200" in message
+        and "tenant=ops-tenant" in message
+        and "delivery_mode=mock" in message
+        for message in messages
+    )
+    log_text = "\n".join(messages)
+    assert "demo-pass" not in log_text
+    assert "query-secret" not in log_text
+    assert "header-secret" not in log_text
+    assert "Authorization" not in log_text
+    assert basic_auth_header("demo-user", "demo-pass")["Authorization"] not in log_text
+
+
+def test_request_logging_redacts_failed_basic_auth_attempts(monkeypatch, caplog):
+    monkeypatch.setenv("REGENGINE_BASIC_AUTH_USERNAME", "demo-user")
+    monkeypatch.setenv("REGENGINE_BASIC_AUTH_PASSWORD", "demo-pass")
+    caplog.set_level(logging.INFO, logger="regengine.request")
+
+    response = client.get(
+        "/api/health",
+        headers=basic_auth_header("demo-user", "wrong-password"),
+    )
+
+    assert response.status_code == 401
+    messages = [
+        record.getMessage()
+        for record in caplog.records
+        if record.name == "regengine.request"
+    ]
+    assert any("path=/api/health" in message and "status=401" in message for message in messages)
+    log_text = "\n".join(messages)
+    assert "wrong-password" not in log_text
+    assert basic_auth_header("demo-user", "wrong-password")["Authorization"] not in log_text
 
 
 def test_tenant_header_scopes_event_storage_and_rejects_invalid_ids(tmp_path):


### PR DESCRIPTION
## Summary
- Add application request logging for method, path, status, duration, tenant, and delivery mode
- Keep logs free of Authorization headers, API keys, query strings, request bodies, response bodies, and export contents
- Document Railway log triage for auth, CORS, volume, and live delivery failures

## Verification
- `pytest`
- `python3 scripts/smoke_regression.py`
- `node --check app/static/app.js`
- `python3 -m compileall app scripts`
- `git diff --check`
- Remote smoke against `https://regengine-inflow-lab-production.up.railway.app`
- `railway deployment list` shows latest deployment `SUCCESS`

## Notes
- No RegEngine ingest payload contract changes.
- Tests cover successful authenticated request logging and failed Basic Auth logging without exposing passwords or auth headers.
