### PR TITLE
Redact live credentials from status surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ When Basic Auth is enabled, requests without valid credentials receive `401` wit
 
 Use `X-RegEngine-Tenant` to select an explicit tenant scope. Tenant ids must be 1-64 characters and can contain only letters, numbers, dots, underscores, or hyphens. Tenant-scoped controllers keep separate simulator state, event logs, mock ingest responses, scenario saves, lineage, and exports under `data/tenants/{tenant_id}/`.
 
-`GET /api/health` and the dashboard stats area expose the active tenant id, whether Basic Auth is enabled, and whether storage is local default or tenant-scoped. Passwords, API keys, and other credentials are never returned.
+`GET /api/health` and the dashboard stats area expose the active tenant id, whether Basic Auth is enabled, and whether storage is local default or tenant-scoped. Passwords, API keys, and other credentials are never returned; live delivery status preserves the active mode and endpoint while redacting the RegEngine API key and tenant id.
 
 Credentialed browser requests are limited to explicit CORS origins. By default the app allows the local dashboard origins `http://127.0.0.1:8000` and `http://localhost:8000`. For shared demos, set comma-separated HTTPS origins:
 

--- a/app/controller.py
+++ b/app/controller.py
@@ -592,12 +592,18 @@ class SimulationController:
     def status(self) -> dict[str, Any]:
         return {
             "running": self.running,
-            "config": self.config.model_dump(mode="json"),
+            "config": self._sanitize_public_config(self.config).model_dump(mode="json"),
             "stats": {
                 **self.store.stats(),
                 "engine": self.engine.snapshot(),
             },
         }
+
+    def _sanitize_public_config(self, config: SimulationConfig) -> SimulationConfig:
+        delivery = config.delivery.model_copy(update={"api_key": None}, deep=True)
+        if delivery.mode == DestinationMode.LIVE:
+            delivery = delivery.model_copy(update={"tenant_id": None}, deep=True)
+        return config.model_copy(update={"delivery": delivery}, deep=True)
 
     def _sanitize_saved_config(self, config: SimulationConfig) -> SimulationConfig:
         delivery = config.delivery.model_copy(update={"api_key": None}, deep=True)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -21,6 +21,12 @@ def basic_auth_header(username: str, password: str) -> dict[str, str]:
     return {"Authorization": f"Basic {token}"}
 
 
+def assert_json_omits(payload: object, *needles: str) -> None:
+    dumped = json.dumps(payload, sort_keys=True)
+    for needle in needles:
+        assert needle not in dumped
+
+
 def setup_function() -> None:
     # reset shared app state between tests
     import asyncio
@@ -58,6 +64,47 @@ def test_sse_stream_emits_initial_snapshot():
     assert payload["revision"] == controller.revision
     assert payload["status"]["running"] is False
     assert payload["events"] == []
+
+
+def test_status_surfaces_redact_live_delivery_credentials(tmp_path):
+    api_key = "regengine-live-api-key-secret"
+    tenant_id = "regengine-live-tenant-secret"
+    reset_response = client.post(
+        "/api/simulate/reset",
+        json={
+            "batch_size": 1,
+            "seed": 204,
+            "persist_path": str(tmp_path / "live-status-events.jsonl"),
+            "delivery": {
+                "mode": "live",
+                "endpoint": "https://www.regengine.co/api/v1/webhooks/ingest",
+                "api_key": api_key,
+                "tenant_id": tenant_id,
+            },
+        },
+    )
+    assert reset_response.status_code == 200
+
+    status = client.get("/api/simulate/status").json()
+    health = client.get("/api/health").json()
+    stream_response = client.get("/api/simulate/stream?limit=5&once=true")
+    stream_data = next(
+        line.removeprefix("data: ")
+        for line in stream_response.text.splitlines()
+        if line.startswith("data: ")
+    )
+    snapshot = json.loads(stream_data)
+
+    for payload in (status, health, snapshot):
+        assert_json_omits(payload, api_key, tenant_id)
+
+    delivery = status["config"]["delivery"]
+    assert delivery["mode"] == "live"
+    assert delivery["endpoint"] == "https://www.regengine.co/api/v1/webhooks/ingest"
+    assert delivery["api_key"] is None
+    assert delivery["tenant_id"] is None
+    assert health["status"]["config"]["delivery"] == delivery
+    assert snapshot["status"]["config"]["delivery"] == delivery
 
 
 def test_scenario_catalog_endpoint_lists_supported_presets():


### PR DESCRIPTION
## Summary
- redact live RegEngine API key and tenant id from public status config responses
- cover /api/simulate/status, /api/health, and SSE snapshots with a live-config regression test
- document the redaction behavior for operators

## Tests
- pytest
- python3 scripts/smoke_regression.py
- node --check app/static/app.js
- python3 -m compileall app scripts
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * API health and status endpoints now properly redact sensitive credentials from public responses, including API keys and tenant IDs for live delivery configurations. Delivery mode and endpoint information remain visible for user reference.

* **Tests**
  * Added integration tests to verify credential redaction across API health, status, and event stream endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->