### PR TITLE
Guard state changes by trusted browser origin

### DIFF
--- a/DEPLOYMENT_PROFILES.md
+++ b/DEPLOYMENT_PROFILES.md
@@ -110,7 +110,7 @@ Shared-demo operating notes:
 - Keep delivery mode set to `mock` unless there is an explicit live-ingest trial.
 - Use a distinct tenant value per partner or workshop.
 - Rotate `REGENGINE_BASIC_AUTH_PASSWORD` between external demos.
-- Keep `REGENGINE_CORS_ORIGINS` limited to the HTTPS origins that should run the browser dashboard.
+- Keep `REGENGINE_CORS_ORIGINS` limited to the HTTPS origins that should run the browser dashboard; Basic Auth deployments reject state-changing browser requests from origins outside that list.
 - Mount persistent storage at `REGENGINE_DATA_DIR` so event logs and scenario saves survive restarts.
 - Back up or delete `data/tenants/{tenant_id}/` according to the partner's data-retention expectation.
 
@@ -272,6 +272,7 @@ Use these patterns when diagnosing a shared demo:
 
 - `status=401` on API routes usually means the Basic Auth username/password in the operator environment or GitHub secret is wrong.
 - Missing browser CORS headers usually means `REGENGINE_CORS_ORIGINS` does not exactly match the deployed HTTPS origin.
+- `status=403` on simulator actions with valid Basic Auth usually means the browser `Origin` or `Referer` is not in `REGENGINE_CORS_ORIGINS`.
 - Empty state after restart usually means the Railway volume is missing or `REGENGINE_DATA_DIR` is not `/data`.
 - Live delivery failures should be diagnosed from the dashboard delivery monitor and sanitized record status before retrying with corrected live endpoint, API key, and tenant id.
 

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ Credentialed browser requests are limited to explicit CORS origins. By default t
 export REGENGINE_CORS_ORIGINS=https://demo.example.com,https://partner-demo.example.com
 ```
 
-Wildcard CORS origins are rejected because Basic Auth and tenant-scoped requests may carry credentials.
+Wildcard CORS origins are rejected because Basic Auth and tenant-scoped requests may carry credentials. When Basic Auth is enabled, state-changing browser requests such as simulator start, step, reset, fixture load, import, replay, retry, and scenario save/load must present a trusted `Origin` or `Referer` from `REGENGINE_CORS_ORIGINS`; command-line and server-to-server calls without browser origin headers continue to work with valid Basic credentials.
 
 ## Replay mode
 

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -25,6 +25,7 @@ Use this checklist before tagging a demo-ready build or handing the simulator to
 - [ ] `/api/healthz` remains available without credentials for container/platform healthchecks.
 - [ ] Basic Auth returns `401` without valid credentials when env vars are set.
 - [ ] Shared-demo or live-trial deployments set explicit `REGENGINE_CORS_ORIGINS` values instead of wildcard CORS.
+- [ ] Dashboard simulator actions do not return `403`; if they do, confirm the browser origin exactly matches `REGENGINE_CORS_ORIGINS`.
 - [ ] Shared-demo or live-trial deployments set `REGENGINE_DATA_DIR` to mounted persistent storage.
 - [ ] Demo fixture loading resets to a known event log.
 - [ ] Start, stop, single-step, and reset work from the dashboard.

--- a/app/main.py
+++ b/app/main.py
@@ -71,6 +71,7 @@ from .store import EventStore
 DATA_ROOT = Path(os.getenv("REGENGINE_DATA_DIR", "data"))
 TENANT_DATA_ROOT = DATA_ROOT / "tenants"
 DEFAULT_CORS_ORIGINS = ("http://127.0.0.1:8000", "http://localhost:8000")
+UNSAFE_METHODS = {"POST", "PUT", "PATCH", "DELETE"}
 REQUEST_LOGGER = logging.getLogger("regengine.request")
 
 engine = LegitFlowEngine(seed=204)
@@ -161,6 +162,10 @@ async def auth_and_tenant_middleware(request: Request, call_next):
             response = context
             return response
         request.state.tenant_context = context
+        unsafe_origin_response = _reject_untrusted_unsafe_origin(request, context)
+        if unsafe_origin_response is not None:
+            response = unsafe_origin_response
+            return response
         response = await call_next(request)
         return response
     except Exception:
@@ -193,6 +198,42 @@ def _request_delivery_mode(request: Request) -> str:
         return str(_active_controller(request).config.delivery.mode.value)
     except Exception:
         return "unknown"
+
+
+def _reject_untrusted_unsafe_origin(request: Request, context: TenantContext) -> JSONResponse | None:
+    if not context.auth_enabled or request.method.upper() not in UNSAFE_METHODS:
+        return None
+
+    request_origin = _browser_request_origin(request)
+    if request_origin is None:
+        return None
+
+    if request_origin in cors_origins_from_env():
+        return None
+
+    return JSONResponse(
+        status_code=403,
+        content={"detail": "State-changing requests require a trusted browser origin"},
+    )
+
+
+def _browser_request_origin(request: Request) -> str | None:
+    origin = request.headers.get("origin")
+    if origin:
+        return _origin_from_url(origin) or ""
+
+    referer = request.headers.get("referer")
+    if referer:
+        return _origin_from_url(referer) or ""
+
+    return None
+
+
+def _origin_from_url(raw_url: str) -> str | None:
+    parsed = urlparse(raw_url.strip())
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        return None
+    return f"{parsed.scheme}://{parsed.netloc}"
 
 static_dir = Path(__file__).parent / "static"
 app.mount("/static", StaticFiles(directory=static_dir), name="static")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -183,6 +183,49 @@ def test_basic_auth_is_optional_but_enforced_when_configured(monkeypatch):
     }
 
 
+def test_basic_auth_blocks_state_changes_from_untrusted_browser_origins(monkeypatch):
+    monkeypatch.setenv("REGENGINE_BASIC_AUTH_USERNAME", "demo-user")
+    monkeypatch.setenv("REGENGINE_BASIC_AUTH_PASSWORD", "demo-pass")
+    headers = basic_auth_header("demo-user", "demo-pass") | {
+        "X-RegEngine-Tenant": "origin-guard-test"
+    }
+    reset = client.post(
+        "/api/simulate/reset",
+        headers=headers,
+        json={"batch_size": 3, "seed": 204, "delivery": {"mode": "none"}},
+    )
+    assert reset.status_code == 200
+
+    blocked = client.post(
+        "/api/simulate/step",
+        headers=headers | {"Origin": "https://untrusted.example"},
+    )
+    assert blocked.status_code == 403
+    assert blocked.json()["detail"] == "State-changing requests require a trusted browser origin"
+
+    null_origin = client.post("/api/simulate/step", headers=headers | {"Origin": "null"})
+    assert null_origin.status_code == 403
+
+    blocked_referer = client.post(
+        "/api/simulate/step",
+        headers=headers | {"Referer": "https://untrusted.example/form"},
+    )
+    assert blocked_referer.status_code == 403
+
+    status = client.get("/api/simulate/status", headers=headers).json()
+    assert status["stats"]["total_records"] == 0
+
+    allowed_origin = client.post(
+        "/api/simulate/step",
+        headers=headers | {"Origin": "http://127.0.0.1:8000"},
+    )
+    assert allowed_origin.status_code == 200
+    assert allowed_origin.json()["generated"] == 3
+
+    script_style = client.post("/api/simulate/stop", headers=headers)
+    assert script_style.status_code == 200
+
+
 def test_request_logging_includes_ops_fields_without_auth_or_query_secrets(monkeypatch, caplog):
     monkeypatch.setenv("REGENGINE_BASIC_AUTH_USERNAME", "demo-user")
     monkeypatch.setenv("REGENGINE_BASIC_AUTH_PASSWORD", "demo-pass")


### PR DESCRIPTION
## Summary
- reject state-changing browser requests from untrusted Origin/Referer values when Basic Auth is enabled
- keep script and server-to-server calls without browser origin headers working with valid Basic credentials
- document the 403 behavior in operator docs and the release checklist

## Tests
- pytest
- python3 scripts/smoke_regression.py
- node --check app/static/app.js
- python3 -m compileall app scripts
- git diff --check