### PR TITLE
Add protected tenant operations

### DIFF
--- a/DEPLOYMENT_PROFILES.md
+++ b/DEPLOYMENT_PROFILES.md
@@ -113,6 +113,7 @@ Shared-demo operating notes:
 - Keep `REGENGINE_CORS_ORIGINS` limited to the HTTPS origins that should run the browser dashboard; Basic Auth deployments reject state-changing browser requests from origins outside that list.
 - Mount persistent storage at `REGENGINE_DATA_DIR` so event logs and scenario saves survive restarts.
 - Back up or delete `data/tenants/{tenant_id}/` according to the partner's data-retention expectation.
+- Use the protected `/api/operator/tenants` endpoints to list, reset, or delete tenant scopes instead of shelling into the volume during a live demo.
 
 ## Live Ingest Trial Profile
 

--- a/DESIGN_PARTNER_DEMO_SCRIPT.md
+++ b/DESIGN_PARTNER_DEMO_SCRIPT.md
@@ -131,6 +131,13 @@ export DEMO_PASSWORD="$(cat /tmp/regengine_inflow_lab_demo_basic_auth_password)"
 export DEMO_TENANT='partner-acme'
 ```
 
+List tenant scopes before a call:
+
+```bash
+curl -fsS -u "$DEMO_USERNAME:$DEMO_PASSWORD" \
+  "$DEMO_BASE_URL/api/operator/tenants" | python3 -m json.tool
+```
+
 Rotate the shared-demo password between external demos:
 
 ```bash
@@ -162,6 +169,14 @@ curl -fsS -u "$DEMO_USERNAME:$DEMO_PASSWORD" \
   -H 'Content-Type: application/json' \
   -X POST "$DEMO_BASE_URL/api/simulate/reset" \
   -d '{"scenario":"fresh_cut_processor","batch_size":3,"seed":204,"delivery":{"mode":"mock"}}'
+```
+
+Alternatively, clear only the selected tenant's stored event log through the operator endpoint:
+
+```bash
+curl -fsS -u "$DEMO_USERNAME:$DEMO_PASSWORD" \
+  -X POST "$DEMO_BASE_URL/api/operator/tenants/$DEMO_TENANT/reset" \
+  | python3 -m json.tool
 ```
 
 Load the fresh-cut fixture in mock mode:
@@ -213,6 +228,7 @@ Post-call cleanup checklist:
 
 - Stop the simulation loop for the demo tenant.
 - Reset the tenant if the partner should not retain event history.
+- Delete the tenant with `DELETE /api/operator/tenants/$DEMO_TENANT` only when scenario saves and event history should both be removed.
 - Rotate the shared password after external demos.
 - Do not commit generated exports, request logs, tenant event data, or local credential files.
 - Capture product feedback and missing CTE/KDE notes in the follow-up tracker, not in fixture data.

--- a/README.md
+++ b/README.md
@@ -187,6 +187,14 @@ export REGENGINE_CORS_ORIGINS=https://demo.example.com,https://partner-demo.exam
 
 Wildcard CORS origins are rejected because Basic Auth and tenant-scoped requests may carry credentials. When Basic Auth is enabled, state-changing browser requests such as simulator start, step, reset, fixture load, import, replay, retry, and scenario save/load must present a trusted `Origin` or `Referer` from `REGENGINE_CORS_ORIGINS`; command-line and server-to-server calls without browser origin headers continue to work with valid Basic credentials.
 
+Protected tenant operations are available when Basic Auth is enabled:
+
+- `GET /api/operator/tenants` lists cached and on-disk tenant scopes, record counts, scenario-save counts, and storage paths.
+- `POST /api/operator/tenants/{tenant_id}/reset` stops that tenant's loop and clears its event log while preserving the tenant directory and scenario saves.
+- `DELETE /api/operator/tenants/{tenant_id}` stops that tenant's loop, evicts its cached controller, and deletes its tenant data directory.
+
+These endpoints reject unauthenticated requests and reject the default local tenant so the unprotected local demo surface stays simple.
+
 ## Replay mode
 
 Replay mode reads previously persisted `StoredEventRecord` JSONL lines, rebuilds the RegEngine ingest payload as:
@@ -328,6 +336,9 @@ The service wrapper examples below can be used with any profile; keep the profil
 | `GET` | `/api/demo-fixtures` | List deterministic demo playback fixtures |
 | `POST` | `/api/demo-fixtures/{fixture_id}/load` | Load a deterministic fixture into the event store |
 | `GET` | `/api/simulate/status` | Running state, config, and aggregate stats |
+| `GET` | `/api/operator/tenants` | List protected tenant scopes and storage counts |
+| `POST` | `/api/operator/tenants/{tenant_id}/reset` | Reset one protected tenant event log |
+| `DELETE` | `/api/operator/tenants/{tenant_id}` | Delete one protected tenant data directory |
 | `POST` | `/api/simulate/start` | Start the loop (accepts a `config` body) |
 | `POST` | `/api/simulate/stop` | Stop the loop |
 | `POST` | `/api/simulate/step` | Emit one batch synchronously |

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -34,6 +34,7 @@ Use this checklist before tagging a demo-ready build or handing the simulator to
 - [ ] FDA lot-trace export includes `BATCH-DEMO-FC-001`.
 - [ ] EPCIS export includes a `TransformationEvent`.
 - [ ] Tenant-scoped requests keep separate event logs and scenario saves.
+- [ ] Protected tenant operations can list, reset, and delete a test tenant when Basic Auth is enabled.
 - [ ] For shared-demo releases, `python3 scripts/remote_smoke.py` passes against the deployed HTTPS URL.
 - [ ] For shared-demo releases, the manual GitHub **Remote Smoke** workflow passes with repository secrets `REGENGINE_REMOTE_USERNAME` and `REGENGINE_REMOTE_PASSWORD`.
 - [ ] For live-trial prep, `python3 scripts/live_trial.py --dry-run-only` passes before any confirmed live batch.

--- a/app/main.py
+++ b/app/main.py
@@ -4,6 +4,7 @@ import asyncio
 import json
 import logging
 import os
+import shutil
 import time
 from contextlib import asynccontextmanager
 from datetime import UTC, datetime
@@ -17,7 +18,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, JSONResponse, PlainTextResponse, StreamingResponse
 from fastapi.staticfiles import StaticFiles
 
-from .auth import DEFAULT_TENANT_ID, TenantContext, tenant_context_from_request
+from .auth import DEFAULT_TENANT_ID, TenantContext, normalize_tenant_id, tenant_context_from_request
 from .controller import SimulationController
 from .demo_fixtures import list_demo_fixture_summaries
 from .engine import LegitFlowEngine
@@ -61,6 +62,9 @@ from .models import (
     StartRequest,
     StatusResponse,
     StepResponse,
+    TenantListResponse,
+    TenantOperationResponse,
+    TenantSummary,
 )
 from .regengine_client import LiveRegEngineClient
 from .scenario_saves import ScenarioSaveStore
@@ -235,6 +239,7 @@ def _origin_from_url(raw_url: str) -> str | None:
         return None
     return f"{parsed.scheme}://{parsed.netloc}"
 
+
 static_dir = Path(__file__).parent / "static"
 app.mount("/static", StaticFiles(directory=static_dir), name="static")
 
@@ -273,6 +278,47 @@ async def healthz() -> dict[str, Any]:
 async def simulate_status(request: Request) -> StatusResponse:
     status = _active_controller(request).status()
     return StatusResponse.model_validate(status)
+
+
+@app.get("/api/operator/tenants", response_model=TenantListResponse)
+async def list_operator_tenants(request: Request) -> TenantListResponse:
+    _require_operator_auth(request)
+    return TenantListResponse(
+        tenants=[
+            TenantSummary.model_validate(_tenant_summary(tenant_id))
+            for tenant_id in _known_tenant_ids()
+        ]
+    )
+
+
+@app.post("/api/operator/tenants/{tenant_id}/reset", response_model=TenantOperationResponse)
+async def reset_operator_tenant(request: Request, tenant_id: str) -> TenantOperationResponse:
+    _require_operator_auth(request)
+    normalized_tenant = _operator_tenant_id(tenant_id)
+    tenant_controller = _tenant_controller_for_id(normalized_tenant)
+    await tenant_controller.reset()
+    return TenantOperationResponse(status="reset", tenant_id=normalized_tenant)
+
+
+@app.delete("/api/operator/tenants/{tenant_id}", response_model=TenantOperationResponse)
+async def delete_operator_tenant(request: Request, tenant_id: str) -> TenantOperationResponse:
+    _require_operator_auth(request)
+    normalized_tenant = _operator_tenant_id(tenant_id)
+    tenant_dir = _tenant_dir(normalized_tenant)
+    removed_data = tenant_dir.exists()
+
+    with _tenant_lock:
+        tenant_controller = _tenant_controllers.pop(normalized_tenant, None)
+    if tenant_controller is not None:
+        await tenant_controller.shutdown()
+
+    shutil.rmtree(tenant_dir, ignore_errors=True)
+    return TenantOperationResponse(
+        status="deleted",
+        tenant_id=normalized_tenant,
+        removed_cached_controller=tenant_controller is not None,
+        removed_data=removed_data,
+    )
 
 
 @app.get("/api/scenarios", response_model=ScenarioListResponse)
@@ -539,14 +585,89 @@ def _active_controller(request: Request) -> SimulationController:
     if context.uses_default_storage:
         return controller
 
+    return _tenant_controller_for_id(context.tenant_id)
+
+
+def _tenant_controller_for_id(tenant_id: str) -> SimulationController:
     with _tenant_lock:
-        existing_controller = _tenant_controllers.get(context.tenant_id)
+        existing_controller = _tenant_controllers.get(tenant_id)
         if existing_controller is not None:
             return existing_controller
 
-        tenant_controller = _create_tenant_controller(context.tenant_id)
-        _tenant_controllers[context.tenant_id] = tenant_controller
+        tenant_controller = _create_tenant_controller(tenant_id)
+        _tenant_controllers[tenant_id] = tenant_controller
         return tenant_controller
+
+
+def _require_operator_auth(request: Request) -> None:
+    context = _tenant_context(request)
+    if not context.auth_enabled:
+        raise HTTPException(status_code=403, detail="Tenant operations require Basic Auth")
+
+
+def _operator_tenant_id(raw_tenant_id: str) -> str:
+    tenant_id = normalize_tenant_id(raw_tenant_id)
+    if tenant_id == DEFAULT_TENANT_ID:
+        raise HTTPException(status_code=400, detail="Default local tenant cannot be managed here")
+    return tenant_id
+
+
+def _known_tenant_ids() -> list[str]:
+    tenant_ids = set()
+    with _tenant_lock:
+        tenant_ids.update(
+            tenant_id for tenant_id in _tenant_controllers if tenant_id != DEFAULT_TENANT_ID
+        )
+
+    if TENANT_DATA_ROOT.exists():
+        for path in TENANT_DATA_ROOT.iterdir():
+            if path.is_dir():
+                try:
+                    tenant_ids.add(normalize_tenant_id(path.name))
+                except ValueError:
+                    continue
+    return sorted(tenant_ids)
+
+
+def _tenant_summary(tenant_id: str) -> dict[str, Any]:
+    tenant_dir = _tenant_dir(tenant_id)
+    persist_path = _tenant_events_path(tenant_id)
+    with _tenant_lock:
+        tenant_controller = _tenant_controllers.get(tenant_id)
+
+    if tenant_controller is not None:
+        stats = tenant_controller.store.stats()
+        running = tenant_controller.running
+        total_records = int(stats["total_records"])
+        persist_path_text = str(tenant_controller.store.persist_path)
+    else:
+        running = False
+        total_records = _count_jsonl_records(persist_path)
+        persist_path_text = str(persist_path)
+
+    return {
+        "tenant_id": tenant_id,
+        "cached": tenant_controller is not None,
+        "running": running,
+        "total_records": total_records,
+        "scenario_save_count": _count_scenario_saves(_tenant_saves_path(tenant_id)),
+        "persist_path": persist_path_text,
+        "data_path": str(tenant_dir),
+        "exists_on_disk": tenant_dir.exists(),
+    }
+
+
+def _count_jsonl_records(path: Path) -> int:
+    if not path.exists():
+        return 0
+    with path.open("r", encoding="utf-8") as handle:
+        return sum(1 for line in handle if line.strip())
+
+
+def _count_scenario_saves(path: Path) -> int:
+    if not path.exists():
+        return 0
+    return sum(1 for candidate in path.glob("*.json") if candidate.is_file())
 
 
 def _create_tenant_controller(tenant_id: str) -> SimulationController:

--- a/app/models.py
+++ b/app/models.py
@@ -134,6 +134,28 @@ class StatusResponse(BaseModel):
     stats: dict[str, Any]
 
 
+class TenantSummary(BaseModel):
+    tenant_id: str
+    cached: bool
+    running: bool
+    total_records: int
+    scenario_save_count: int
+    persist_path: str
+    data_path: str
+    exists_on_disk: bool
+
+
+class TenantListResponse(BaseModel):
+    tenants: list[TenantSummary]
+
+
+class TenantOperationResponse(BaseModel):
+    status: Literal["reset", "deleted"]
+    tenant_id: str
+    removed_cached_controller: bool = False
+    removed_data: bool = False
+
+
 class ScenarioSummary(BaseModel):
     id: ScenarioId
     label: str

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -336,6 +336,85 @@ def test_default_data_root_is_used_for_local_and_tenant_paths():
     )
 
 
+def test_operator_tenant_routes_require_basic_auth(monkeypatch):
+    disabled = client.get("/api/operator/tenants")
+    assert disabled.status_code == 403
+    assert disabled.json()["detail"] == "Tenant operations require Basic Auth"
+
+    monkeypatch.setenv("REGENGINE_BASIC_AUTH_USERNAME", "demo-user")
+    monkeypatch.setenv("REGENGINE_BASIC_AUTH_PASSWORD", "demo-pass")
+
+    unauthorized = client.get("/api/operator/tenants")
+    assert unauthorized.status_code == 401
+
+    authorized = client.get(
+        "/api/operator/tenants",
+        headers=basic_auth_header("demo-user", "demo-pass"),
+    )
+    assert authorized.status_code == 200
+    assert "tenants" in authorized.json()
+
+
+def test_operator_can_list_reset_and_delete_tenant_state(monkeypatch):
+    monkeypatch.setenv("REGENGINE_BASIC_AUTH_USERNAME", "demo-user")
+    monkeypatch.setenv("REGENGINE_BASIC_AUTH_PASSWORD", "demo-pass")
+    operator_headers = basic_auth_header("demo-user", "demo-pass")
+    tenant_id = "operator-tenant-alpha"
+    tenant_headers = operator_headers | {"X-RegEngine-Tenant": tenant_id}
+
+    reset = client.post(
+        "/api/simulate/reset",
+        headers=tenant_headers,
+        json={"batch_size": 3, "seed": 204, "delivery": {"mode": "none"}},
+    )
+    assert reset.status_code == 200
+    assert client.post("/api/simulate/step", headers=tenant_headers).status_code == 200
+
+    list_response = client.get("/api/operator/tenants", headers=operator_headers)
+    assert list_response.status_code == 200
+    tenants = {
+        tenant["tenant_id"]: tenant for tenant in list_response.json()["tenants"]
+    }
+    assert tenants[tenant_id]["cached"] is True
+    assert tenants[tenant_id]["running"] is False
+    assert tenants[tenant_id]["total_records"] == 3
+    assert tenants[tenant_id]["persist_path"] == f"data/tenants/{tenant_id}/events.jsonl"
+    assert tenants[tenant_id]["exists_on_disk"] is True
+
+    tenant_reset = client.post(
+        f"/api/operator/tenants/{tenant_id}/reset",
+        headers=operator_headers,
+    )
+    assert tenant_reset.status_code == 200
+    assert tenant_reset.json() == {
+        "status": "reset",
+        "tenant_id": tenant_id,
+        "removed_cached_controller": False,
+        "removed_data": False,
+    }
+    status = client.get("/api/simulate/status", headers=tenant_headers).json()
+    assert status["stats"]["total_records"] == 0
+
+    assert client.post("/api/simulate/step", headers=tenant_headers).status_code == 200
+    tenant_delete = client.delete(
+        f"/api/operator/tenants/{tenant_id}",
+        headers=operator_headers,
+    )
+    assert tenant_delete.status_code == 200
+    assert tenant_delete.json() == {
+        "status": "deleted",
+        "tenant_id": tenant_id,
+        "removed_cached_controller": True,
+        "removed_data": True,
+    }
+    list_after_delete = client.get("/api/operator/tenants", headers=operator_headers)
+    tenant_ids = {tenant["tenant_id"] for tenant in list_after_delete.json()["tenants"]}
+    assert tenant_id not in tenant_ids
+
+    default_delete = client.delete("/api/operator/tenants/local-demo", headers=operator_headers)
+    assert default_delete.status_code == 400
+
+
 def test_scenario_save_load_restores_config_and_event_log(tmp_path):
     scenario_saves.configure(str(tmp_path / "scenario-saves"))
     fresh_path = tmp_path / "fresh-cut-events.jsonl"


### PR DESCRIPTION
## Summary
- add Basic Auth-protected tenant operator endpoints to list, reset, and delete tenant scopes
- expose tenant record/save counts and storage paths without touching the ingest payload contract
- document operator commands in README, deployment profiles, demo script, and release checklist

## Tests
- pytest
- python3 scripts/smoke_regression.py
- node --check app/static/app.js
- python3 -m compileall app scripts
- git diff --check