### PR TITLE
Add CTE KDE import warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ Replay responses include `status`, `read`, `replayed`, `posted`, `failed`, `sour
 
 ## CSV import
 
-`POST /api/import/csv` accepts CSV text and imports either scheduled RegEngine-shaped events or seed lots. Valid rows are delivered through the selected delivery mode and persisted as `StoredEventRecord` JSONL entries. Invalid rows are skipped, with deterministic row-level errors in the response. The default dashboard/API delivery remains **`mock`** unless you explicitly submit a different `delivery` object.
+`POST /api/import/csv` accepts CSV text and imports either scheduled RegEngine-shaped events or seed lots. Valid rows are delivered through the selected delivery mode and persisted as `StoredEventRecord` JSONL entries. Invalid rows are skipped, with deterministic row-level errors in the response. Accepted rows are also checked against CTE-specific KDE expectations and can return warnings for missing lineage, document, location, or date context. The default dashboard/API delivery remains **`mock`** unless you explicitly submit a different `delivery` object.
 
 Request body:
 
@@ -254,7 +254,7 @@ traceability_lot_code,product_description,quantity,unit_of_measure,location_name
 
 Seed lots become valid `harvesting` events. Optional `timestamp`, `harvest_date`, `field_name`, `immediate_subsequent_recipient`, reference document columns, `kdes` JSON, and other KDE columns are preserved. If no timestamp is supplied, the import time is used.
 
-Import responses include `status`, `total`, `accepted`, `rejected`, `stored`, `posted`, `failed`, `delivery_attempts`, `lot_codes`, and `errors[]` with row number, field, and message.
+Import responses include `status`, `total`, `accepted`, `rejected`, `stored`, `posted`, `failed`, `delivery_attempts`, `lot_codes`, `errors[]`, and `warnings[]` with row number, field, and message. Warnings are advisory and do not change the RegEngine ingest payload shape.
 
 ## Scenario presets
 

--- a/app/controller.py
+++ b/app/controller.py
@@ -281,6 +281,7 @@ class SimulationController:
                 delivery_attempts=outcome.delivery_attempts,
                 lot_codes=[event.traceability_lot_code for event in parsed.events],
                 errors=parsed.errors,
+                warnings=parsed.warnings,
                 response=outcome.response,
                 error=outcome.error_message,
             )

--- a/app/csv_importer.py
+++ b/app/csv_importer.py
@@ -10,7 +10,8 @@ from typing import Any
 
 from pydantic import ValidationError
 
-from .models import CSVImportError, CSVImportType, CTEType, RegEngineEvent
+from .cte_rules import validate_event_kdes
+from .models import CSVImportError, CSVImportType, CSVImportWarning, CTEType, RegEngineEvent
 
 
 EVENT_REQUIRED_FIELDS = (
@@ -47,6 +48,7 @@ class ParsedCSVImport:
     events: list[RegEngineEvent]
     parent_lot_codes: list[list[str]]
     errors: list[CSVImportError]
+    warnings: list[CSVImportWarning]
 
 
 def parse_csv_import(
@@ -61,17 +63,19 @@ def parse_csv_import(
             events=[],
             parent_lot_codes=[],
             errors=[CSVImportError(row=0, field="csv_text", message="CSV content is empty")],
+            warnings=[],
         )
 
     reader = csv.DictReader(io.StringIO(csv_text.lstrip("\ufeff")), skipinitialspace=True)
     header_errors = _header_errors(reader.fieldnames)
     if header_errors:
-        return ParsedCSVImport(total=0, events=[], parent_lot_codes=[], errors=header_errors)
+        return ParsedCSVImport(total=0, events=[], parent_lot_codes=[], errors=header_errors, warnings=[])
 
     total = 0
     events: list[RegEngineEvent] = []
     parent_lot_codes: list[list[str]] = []
     errors: list[CSVImportError] = []
+    warnings: list[CSVImportWarning] = []
 
     for row_number, raw_row in enumerate(reader, start=2):
         row = _normalize_row(raw_row)
@@ -79,9 +83,9 @@ def parse_csv_import(
             continue
         total += 1
         if import_type == CSVImportType.SCHEDULED_EVENTS:
-            event, parents, row_errors = _parse_scheduled_event(row, row_number)
+            event, parents, row_errors, row_warnings = _parse_scheduled_event(row, row_number)
         else:
-            event, parents, row_errors = _parse_seed_lot(row, row_number, default_timestamp)
+            event, parents, row_errors, row_warnings = _parse_seed_lot(row, row_number, default_timestamp)
 
         if row_errors:
             errors.extend(row_errors)
@@ -89,20 +93,27 @@ def parse_csv_import(
         assert event is not None
         events.append(event)
         parent_lot_codes.append(parents)
+        warnings.extend(row_warnings)
 
     if total == 0 and not errors:
         errors.append(CSVImportError(row=0, field="csv_text", message="CSV contains no data rows"))
 
-    return ParsedCSVImport(total=total, events=events, parent_lot_codes=parent_lot_codes, errors=errors)
+    return ParsedCSVImport(
+        total=total,
+        events=events,
+        parent_lot_codes=parent_lot_codes,
+        errors=errors,
+        warnings=warnings,
+    )
 
 
 def _parse_scheduled_event(
     row: dict[str, str],
     row_number: int,
-) -> tuple[RegEngineEvent | None, list[str], list[CSVImportError]]:
+) -> tuple[RegEngineEvent | None, list[str], list[CSVImportError], list[CSVImportWarning]]:
     errors = _missing_required(row, row_number, EVENT_REQUIRED_FIELDS)
     if errors:
-        return None, [], errors
+        return None, [], errors, []
 
     quantity = _parse_quantity(row["quantity"], row_number, errors)
     timestamp = _parse_timestamp(row["timestamp"], row_number, "timestamp", errors)
@@ -110,7 +121,7 @@ def _parse_scheduled_event(
     kdes = _parse_kdes(row, row_number, errors)
 
     if errors:
-        return None, [], errors
+        return None, [], errors, []
 
     return _build_event(
         row=row,
@@ -127,10 +138,10 @@ def _parse_seed_lot(
     row: dict[str, str],
     row_number: int,
     default_timestamp: datetime,
-) -> tuple[RegEngineEvent | None, list[str], list[CSVImportError]]:
+) -> tuple[RegEngineEvent | None, list[str], list[CSVImportError], list[CSVImportWarning]]:
     errors = _missing_required(row, row_number, SEED_REQUIRED_FIELDS)
     if errors:
-        return None, [], errors
+        return None, [], errors, []
 
     quantity = _parse_quantity(row["quantity"], row_number, errors)
     timestamp = (
@@ -141,7 +152,7 @@ def _parse_seed_lot(
     kdes = _parse_kdes(row, row_number, errors)
 
     if errors:
-        return None, [], errors
+        return None, [], errors, []
 
     kdes.setdefault("harvest_date", timestamp.date().isoformat())
     kdes.setdefault("farm_location", row["location_name"])
@@ -172,10 +183,10 @@ def _build_event(
     timestamp: datetime | None,
     kdes: dict[str, Any],
     parent_lot_codes: list[str],
-) -> tuple[RegEngineEvent | None, list[str], list[CSVImportError]]:
+) -> tuple[RegEngineEvent | None, list[str], list[CSVImportError], list[CSVImportWarning]]:
     errors: list[CSVImportError] = []
     if cte_type is None or quantity is None or timestamp is None:
-        return None, [], errors
+        return None, [], errors, []
 
     try:
         event = RegEngineEvent(
@@ -195,9 +206,13 @@ def _build_event(
             errors.append(
                 CSVImportError(row=row_number, field=field, message=str(error.get("msg", "Invalid value")))
             )
-        return None, [], errors
+        return None, [], errors, []
 
-    return event, parent_lot_codes, []
+    warnings = [
+        CSVImportWarning(row=row_number, field=warning.field, message=warning.message)
+        for warning in validate_event_kdes(event)
+    ]
+    return event, parent_lot_codes, [], warnings
 
 
 def _header_errors(fieldnames: list[str] | None) -> list[CSVImportError]:

--- a/app/cte_rules.py
+++ b/app/cte_rules.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from .models import CTEType, RegEngineEvent
+
+
+@dataclass(frozen=True, slots=True)
+class CTEValidationWarning:
+    field: str
+    message: str
+
+
+REQUIRED_KDES: dict[CTEType, tuple[str, ...]] = {
+    CTEType.HARVESTING: (
+        "harvest_date",
+        "farm_location",
+        "reference_document_number",
+    ),
+    CTEType.COOLING: (
+        "cooling_date",
+        "cooling_location",
+        "reference_document_number",
+    ),
+    CTEType.INITIAL_PACKING: (
+        "pack_date",
+        "packing_location",
+        "source_traceability_lot_code",
+        "reference_document_number",
+    ),
+    CTEType.SHIPPING: (
+        "ship_date",
+        "ship_from_location",
+        "ship_to_location",
+        "reference_document_number",
+    ),
+    CTEType.RECEIVING: (
+        "receive_date",
+        "receiving_location",
+        "ship_from_location",
+        "reference_document_number",
+    ),
+    CTEType.TRANSFORMATION: (
+        "transformation_date",
+        "transformation_location",
+        "input_traceability_lot_codes",
+        "reference_document_number",
+    ),
+}
+
+RECOMMENDED_KDES: dict[CTEType, tuple[str, ...]] = {
+    CTEType.HARVESTING: ("field_name", "traceability_lot_code_source_reference"),
+    CTEType.COOLING: ("harvest_location", "traceability_lot_code_source_reference"),
+    CTEType.INITIAL_PACKING: ("farm_location", "traceability_lot_code_source_reference"),
+    CTEType.SHIPPING: ("carrier", "reference_document_type"),
+    CTEType.RECEIVING: ("reference_document_type", "traceability_lot_code_source_reference"),
+    CTEType.TRANSFORMATION: ("input_products", "reference_document_type"),
+}
+
+
+def validate_event_kdes(event: RegEngineEvent) -> list[CTEValidationWarning]:
+    warnings: list[CTEValidationWarning] = []
+    for field in REQUIRED_KDES[event.cte_type]:
+        if not _has_value(event.kdes.get(field)):
+            warnings.append(
+                CTEValidationWarning(
+                    field=field,
+                    message=f"Missing expected {event.cte_type.value} KDE: {field}",
+                )
+            )
+
+    for field in RECOMMENDED_KDES[event.cte_type]:
+        if not _has_value(event.kdes.get(field)):
+            warnings.append(
+                CTEValidationWarning(
+                    field=field,
+                    message=f"Missing recommended {event.cte_type.value} KDE: {field}",
+                )
+            )
+
+    if event.cte_type == CTEType.TRANSFORMATION:
+        input_lots = event.kdes.get("input_traceability_lot_codes")
+        if _has_value(input_lots) and not _is_nonempty_string_list(input_lots):
+            warnings.append(
+                CTEValidationWarning(
+                    field="input_traceability_lot_codes",
+                    message="Transformation input_traceability_lot_codes should be a non-empty list of lot codes",
+                )
+            )
+
+    return warnings
+
+
+def _has_value(value: Any) -> bool:
+    if value is None:
+        return False
+    if isinstance(value, str):
+        return bool(value.strip())
+    if isinstance(value, list):
+        return bool(value)
+    return True
+
+
+def _is_nonempty_string_list(value: Any) -> bool:
+    return isinstance(value, list) and bool(value) and all(
+        isinstance(item, str) and item.strip() for item in value
+    )

--- a/app/models.py
+++ b/app/models.py
@@ -324,6 +324,12 @@ class CSVImportError(BaseModel):
     message: str
 
 
+class CSVImportWarning(BaseModel):
+    row: int
+    field: str | None = None
+    message: str
+
+
 class CSVImportResponse(BaseModel):
     status: Literal["accepted", "partial", "rejected", "delivery_failed"]
     import_type: CSVImportType
@@ -338,6 +344,7 @@ class CSVImportResponse(BaseModel):
     delivery_attempts: int = 0
     lot_codes: list[str]
     errors: list[CSVImportError] = Field(default_factory=list)
+    warnings: list[CSVImportWarning] = Field(default_factory=list)
     response: dict[str, Any] | None = None
     error: str | None = None
 

--- a/app/static/app.js
+++ b/app/static/app.js
@@ -535,10 +535,17 @@ function renderLineage(payload, traceabilityLotCode) {
 function renderImportResult(result) {
   const tone = result.status === 'accepted' ? 'success' : result.status === 'delivery_failed' ? 'error' : 'neutral';
   const errors = (result.errors || []).slice(0, 8);
+  const warnings = (result.warnings || []).slice(0, 8);
   const errorList = errors
     .map((error) => {
       const field = error.field ? ` ${escapeHtml(error.field)}:` : '';
       return `<li>Row ${escapeHtml(error.row)}${field} ${escapeHtml(error.message)}</li>`;
+    })
+    .join('');
+  const warningList = warnings
+    .map((warning) => {
+      const field = warning.field ? ` ${escapeHtml(warning.field)}:` : '';
+      return `<li>Row ${escapeHtml(warning.row)}${field} ${escapeHtml(warning.message)}</li>`;
     })
     .join('');
   ids.importResults.innerHTML = `
@@ -548,6 +555,7 @@ function renderImportResult(result) {
       ${result.error ? `<span>${escapeHtml(result.error)}</span>` : ''}
     </div>
     ${errorList ? `<ul>${errorList}</ul>` : ''}
+    ${warningList ? `<ul>${warningList}</ul>` : ''}
   `;
 }
 
@@ -795,6 +803,8 @@ async function importCsv() {
       setStatus(`Imported ${result.accepted} row(s), but delivery failed: ${result.error || 'delivery error'}`, 'error', 7000);
     } else if (result.rejected > 0) {
       setStatus(`Imported ${result.accepted} row(s); rejected ${result.rejected}.`, 'error', 7000);
+    } else if ((result.warnings || []).length > 0) {
+      setStatus(`Imported ${result.accepted} CSV row(s) with ${result.warnings.length} warning(s).`, 'success', 4500);
     } else {
       setStatus(`Imported ${result.accepted} CSV row(s).`, 'success', 3500);
     }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1130,6 +1130,11 @@ receiving,TLC-CSV-BAD,Romaine Lettuce,,cases,Distribution Center #4,2026-02-05T1
     assert body["errors"] == [
         {"row": 4, "field": "quantity", "message": "Missing required field: quantity"}
     ]
+    assert {warning["field"] for warning in body["warnings"]} >= {
+        "farm_location",
+        "reference_document_number",
+        "packing_location",
+    }
 
     events = client.get("/api/events?limit=10").json()["events"]
     assert len(events) == 2

--- a/tests/test_csv_importer.py
+++ b/tests/test_csv_importer.py
@@ -51,3 +51,30 @@ transformation,TLC-OUT,Fresh Cut Salad Mix,50,cases,ReadyFresh Processing Plant,
     assert parsed.errors == []
     assert parsed.parent_lot_codes == [["TLC-IN-1", "TLC-IN-2"]]
     assert parsed.events[0].kdes["input_traceability_lot_codes"] == ["TLC-IN-1", "TLC-IN-2"]
+    assert {warning.field for warning in parsed.warnings} >= {
+        "transformation_date",
+        "transformation_location",
+        "reference_document_number",
+    }
+
+
+def test_parse_scheduled_event_warns_on_malformed_cte_kdes():
+    parsed = parse_csv_import(
+        CSVImportType.SCHEDULED_EVENTS,
+        """cte_type,traceability_lot_code,product_description,quantity,unit_of_measure,location_name,timestamp,kdes
+transformation,TLC-OUT,Fresh Cut Salad Mix,50,cases,ReadyFresh Processing Plant,2026-02-07T12:00:00Z,"{""input_traceability_lot_codes"":{""lot"":""TLC-IN-1""}}"
+""",
+    )
+
+    assert parsed.total == 1
+    assert parsed.errors == []
+    assert len(parsed.events) == 1
+    assert {
+        (warning.field, warning.message) for warning in parsed.warnings
+    } >= {
+        (
+            "input_traceability_lot_codes",
+            "Transformation input_traceability_lot_codes should be a non-empty list of lot codes",
+        ),
+        ("reference_document_number", "Missing expected transformation KDE: reference_document_number"),
+    }


### PR DESCRIPTION
## Summary
- add CTE-specific KDE validation warnings for CSV imports without changing the ingest payload contract
- return warning details through the import API and show them in the dashboard import results
- document advisory warnings for import operators

## Tests
- pytest
- python3 scripts/smoke_regression.py
- node --check app/static/app.js
- python3 -m compileall app scripts
- git diff --check