### PR TITLE
Record delivery audit metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ For controlled live workspace validation, use `scripts/live_trial.py`. It refuse
 ### `none`
 Generates and persists events locally without delivering them anywhere. Useful for seeding fixtures.
 
-Every stored record tracks `delivery_status`, `destination_mode`, `delivery_attempts`, and last delivery timestamps. The dashboard delivery monitor summarizes posted, failed, generated-only, and retryable records. Failed records can be retried through the dashboard or `POST /api/delivery/retry` after switching to a working `mock` or `live` delivery configuration.
+Every stored record tracks `delivery_status`, `destination_mode`, `delivery_attempts`, last delivery timestamps, and non-secret `delivery_metadata` such as delivery mode, attempted event count, live endpoint host/path, HTTP status, and idempotency key. The dashboard delivery monitor summarizes posted, failed, generated-only, and retryable records. Failed records can be retried through the dashboard or `POST /api/delivery/retry` after switching to a working `mock` or `live` delivery configuration.
 
 ## Basic auth and tenant storage
 

--- a/app/controller.py
+++ b/app/controller.py
@@ -31,7 +31,7 @@ from .models import (
     StepResponse,
     StoredEventRecord,
 )
-from .regengine_client import LiveRegEngineClient
+from .regengine_client import LiveRegEngineClient, LiveRegEngineDeliveryError
 from .scenario_saves import ScenarioSaveStore
 from .scenarios import ScenarioId, get_scenario
 from .store import EventStore
@@ -47,6 +47,7 @@ class DeliveryOutcome:
     attempted_at: datetime | None = None
     completed_at: datetime | None = None
     error_message: str | None = None
+    metadata: dict[str, Any] | None = None
 
 
 class SimulationController:
@@ -143,6 +144,7 @@ class SimulationController:
                         if outcome.delivery_status == "posted"
                         else None,
                         delivery_response=event_response,
+                        delivery_metadata=outcome.metadata,
                         error=outcome.error_message,
                     )
                 )
@@ -252,6 +254,7 @@ class SimulationController:
                             if outcome.delivery_status == "posted"
                             else None,
                             delivery_response=event_response,
+                            delivery_metadata=outcome.metadata,
                             error=outcome.error_message,
                         )
                     )
@@ -334,6 +337,7 @@ class SimulationController:
                         if outcome.delivery_status == "posted"
                         else None,
                         delivery_response=event_response,
+                        delivery_metadata=outcome.metadata,
                         error=outcome.error_message,
                     )
                 )
@@ -490,6 +494,7 @@ class SimulationController:
                                     if outcome.delivery_status == "posted"
                                     else record.last_delivery_success_at,
                                     "delivery_response": event_response,
+                                    "delivery_metadata": outcome.metadata,
                                     "error": None
                                     if outcome.delivery_status == "posted"
                                     else outcome.error_message,
@@ -538,18 +543,32 @@ class SimulationController:
                     delivery_attempts=1,
                     attempted_at=attempted_at,
                     completed_at=datetime.now(UTC),
+                    metadata={
+                        "delivery_mode": "mock",
+                        "attempted_event_count": len(payload.events),
+                    },
                 )
             if config.delivery.mode == DestinationMode.LIVE:
-                response = await self.live_client.ingest(payload, config)
+                result = await self.live_client.ingest(payload, config)
                 return DeliveryOutcome(
-                    response=response,
+                    response=result.response,
                     delivery_status="posted",
                     posted=len(payload.events),
                     delivery_attempts=1,
                     attempted_at=attempted_at,
                     completed_at=datetime.now(UTC),
+                    metadata=result.metadata | {"attempted_event_count": len(payload.events)},
                 )
             return DeliveryOutcome()
+        except LiveRegEngineDeliveryError as exc:
+            return DeliveryOutcome(
+                delivery_status="failed",
+                failed=len(payload.events),
+                delivery_attempts=1,
+                attempted_at=attempted_at,
+                error_message=str(exc),
+                metadata=exc.metadata | {"attempted_event_count": len(payload.events)},
+            )
         except Exception as exc:  # pragma: no cover - exercised by live integration, not unit tests
             return DeliveryOutcome(
                 delivery_status="failed",
@@ -557,6 +576,10 @@ class SimulationController:
                 delivery_attempts=1,
                 attempted_at=attempted_at,
                 error_message=str(exc),
+                metadata={
+                    "delivery_mode": config.delivery.mode.value,
+                    "attempted_event_count": len(payload.events),
+                },
             )
 
     async def _run_loop(self) -> None:

--- a/app/models.py
+++ b/app/models.py
@@ -103,6 +103,7 @@ class StoredEventRecord(BaseModel):
     last_delivery_attempt_at: datetime | None = None
     last_delivery_success_at: datetime | None = None
     delivery_response: dict[str, Any] | None = None
+    delivery_metadata: dict[str, Any] | None = None
     error: str | None = None
     created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
 

--- a/app/regengine_client.py
+++ b/app/regengine_client.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import uuid
+from dataclasses import dataclass
 from typing import Any
+from urllib.parse import urlparse
 
 import httpx
 
@@ -11,21 +13,54 @@ from .models import IngestPayload, SimulationConfig
 DEFAULT_LIVE_INGEST_ENDPOINT = "https://www.regengine.co/api/v1/webhooks/ingest"
 
 
+@dataclass(frozen=True, slots=True)
+class LiveIngestResult:
+    response: dict[str, Any]
+    metadata: dict[str, Any]
+
+
+class LiveRegEngineDeliveryError(RuntimeError):
+    def __init__(self, message: str, metadata: dict[str, Any]) -> None:
+        super().__init__(message)
+        self.metadata = metadata
+
+
 class LiveRegEngineClient:
-    async def ingest(self, payload: IngestPayload, config: SimulationConfig) -> dict[str, Any]:
+    async def ingest(self, payload: IngestPayload, config: SimulationConfig) -> LiveIngestResult:
         endpoint = str(config.delivery.endpoint) if config.delivery.endpoint else DEFAULT_LIVE_INGEST_ENDPOINT
         api_key = config.delivery.api_key
         tenant_id = config.delivery.tenant_id
         if not api_key or not tenant_id:
             raise ValueError("Live delivery requires both api_key and tenant_id")
 
+        idempotency_key = uuid.uuid4().hex
+        metadata = _delivery_metadata(endpoint=endpoint, idempotency_key=idempotency_key)
         headers = {
             "Content-Type": "application/json",
             "X-RegEngine-API-Key": api_key,
             "X-Tenant-ID": tenant_id,
-            "Idempotency-Key": uuid.uuid4().hex,
+            "Idempotency-Key": idempotency_key,
         }
-        async with httpx.AsyncClient(timeout=20.0) as client:
-            response = await client.post(endpoint, headers=headers, json=payload.model_dump(mode="json"))
+        try:
+            async with httpx.AsyncClient(timeout=20.0) as client:
+                response = await client.post(endpoint, headers=headers, json=payload.model_dump(mode="json"))
+        except httpx.HTTPError as exc:
+            raise LiveRegEngineDeliveryError(str(exc), metadata) from exc
+
+        metadata = metadata | {"status_code": response.status_code}
+        try:
             response.raise_for_status()
-            return response.json()
+        except httpx.HTTPStatusError as exc:
+            raise LiveRegEngineDeliveryError(str(exc), metadata) from exc
+        return LiveIngestResult(response=response.json(), metadata=metadata)
+
+
+def _delivery_metadata(endpoint: str, idempotency_key: str) -> dict[str, Any]:
+    parsed = urlparse(endpoint)
+    return {
+        "delivery_mode": "live",
+        "endpoint_host": parsed.netloc,
+        "endpoint_path": parsed.path or "/",
+        "idempotency_key": idempotency_key,
+        "status_code": None,
+    }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -10,6 +10,7 @@ from fastapi.testclient import TestClient
 
 from app.main import app, controller, cors_origins_from_env, scenario_saves
 from app.models import SimulationConfig
+from app.regengine_client import LiveIngestResult
 from app.scenarios import ScenarioId, get_scenario
 
 
@@ -993,6 +994,62 @@ def test_failed_live_delivery_surfaces_retry_feedback_and_can_retry_to_mock(tmp_
     assert retried_record["delivery_attempts"] == 2
     assert retried_record["last_delivery_success_at"]
     assert retried_record["error"] is None
+
+
+def test_successful_live_delivery_records_sanitized_audit_metadata(monkeypatch, tmp_path):
+    class FakeLiveClient:
+        async def ingest(self, payload, config):  # noqa: ANN001
+            return LiveIngestResult(
+                response={
+                    "accepted": len(payload.events),
+                    "events": [
+                        {
+                            "traceability_lot_code": event.traceability_lot_code,
+                            "status": "accepted",
+                        }
+                        for event in payload.events
+                    ],
+                },
+                metadata={
+                    "delivery_mode": "live",
+                    "endpoint_host": "www.regengine.co",
+                    "endpoint_path": "/api/v1/webhooks/ingest",
+                    "idempotency_key": "idem-test-123",
+                    "status_code": 200,
+                },
+            )
+
+    monkeypatch.setattr(controller, "live_client", FakeLiveClient())
+    custom_path = tmp_path / "live-audit-events.jsonl"
+    reset_response = client.post(
+        "/api/simulate/reset",
+        json={
+            "batch_size": 1,
+            "seed": 204,
+            "persist_path": str(custom_path),
+            "delivery": {
+                "mode": "live",
+                "api_key": "live-api-secret",
+                "tenant_id": "live-tenant-secret",
+            },
+        },
+    )
+    assert reset_response.status_code == 200
+
+    step_response = client.post("/api/simulate/step")
+
+    assert step_response.status_code == 200
+    assert step_response.json()["delivery_status"] == "posted"
+    record = client.get("/api/events?limit=1").json()["events"][0]
+    assert record["delivery_metadata"] == {
+        "delivery_mode": "live",
+        "endpoint_host": "www.regengine.co",
+        "endpoint_path": "/api/v1/webhooks/ingest",
+        "idempotency_key": "idem-test-123",
+        "status_code": 200,
+        "attempted_event_count": 1,
+    }
+    assert_json_omits(record["delivery_metadata"], "live-api-secret", "live-tenant-secret")
 
 
 def test_delivery_retry_empty_when_no_failed_records():

--- a/tests/test_regengine_client.py
+++ b/tests/test_regengine_client.py
@@ -9,6 +9,8 @@ from app.regengine_client import DEFAULT_LIVE_INGEST_ENDPOINT, LiveRegEngineClie
 
 
 class FakeResponse:
+    status_code = 200
+
     def raise_for_status(self) -> None:
         return None
 
@@ -79,7 +81,12 @@ def run_ingest(monkeypatch: Any, config: SimulationConfig) -> dict[str, Any]:
 
     result = asyncio.run(LiveRegEngineClient().ingest(make_payload(), config))
 
-    assert result == {"accepted": 1}
+    assert result.response == {"accepted": 1}
+    assert result.metadata["delivery_mode"] == "live"
+    assert result.metadata["endpoint_host"]
+    assert result.metadata["endpoint_path"]
+    assert result.metadata["idempotency_key"]
+    assert result.metadata["status_code"] == 200
     assert len(RecordingAsyncClient.calls) == 1
     return RecordingAsyncClient.calls[0]
 
@@ -105,6 +112,7 @@ def test_live_client_sends_required_headers_and_contract_payload(monkeypatch: An
     assert call["headers"]["Content-Type"] == "application/json"
     assert call["headers"]["X-RegEngine-API-Key"] == "test-api-key"
     assert call["headers"]["X-Tenant-ID"] == "test-tenant-id"
+    assert call["headers"]["Idempotency-Key"]
 
     payload = call["json"]
     assert set(payload) == {"source", "events"}


### PR DESCRIPTION
## Summary
- store non-secret delivery_metadata on generated records for mock and live delivery attempts
- expose live endpoint host/path, HTTP status, idempotency key, and attempted event count without API keys or tenant ids
- preserve the existing delivery_response shape for mock/live response payloads

## Tests
- pytest
- python3 scripts/smoke_regression.py
- node --check app/static/app.js
- python3 -m compileall app scripts
- git diff --check