### PR TITLE
Add remote browser smoke workflow

### DIFF
--- a/.github/workflows/remote-browser-smoke.yml
+++ b/.github/workflows/remote-browser-smoke.yml
@@ -1,0 +1,63 @@
+name: Remote Browser Smoke
+
+on:
+  workflow_dispatch:
+    inputs:
+      base_url:
+        description: Deployed shared-demo base URL
+        required: false
+        type: string
+        default: https://regengine-inflow-lab-production.up.railway.app
+      tenant:
+        description: Tenant used for isolated remote browser smoke data
+        required: false
+        type: string
+        default: remote-browser-smoke
+
+permissions:
+  contents: read
+
+concurrency:
+  group: remote-browser-smoke-${{ github.event.inputs.base_url }}-${{ github.event.inputs.tenant }}
+  cancel-in-progress: false
+
+jobs:
+  remote-browser-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+          cache: pip
+          cache-dependency-path: |
+            requirements.txt
+            requirements-browser.txt
+            pyproject.toml
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-browser.txt
+          python -m playwright install --with-deps chromium
+
+      - name: Validate remote browser smoke secrets
+        env:
+          REGENGINE_REMOTE_USERNAME: ${{ secrets.REGENGINE_REMOTE_USERNAME }}
+          REGENGINE_REMOTE_PASSWORD: ${{ secrets.REGENGINE_REMOTE_PASSWORD }}
+        run: |
+          test -n "$REGENGINE_REMOTE_USERNAME" || { echo "REGENGINE_REMOTE_USERNAME secret is required"; exit 1; }
+          test -n "$REGENGINE_REMOTE_PASSWORD" || { echo "REGENGINE_REMOTE_PASSWORD secret is required"; exit 1; }
+
+      - name: Run remote browser smoke
+        env:
+          REGENGINE_BROWSER_BASE_URL: ${{ inputs.base_url }}
+          REGENGINE_BROWSER_USERNAME: ${{ secrets.REGENGINE_REMOTE_USERNAME }}
+          REGENGINE_BROWSER_PASSWORD: ${{ secrets.REGENGINE_REMOTE_PASSWORD }}
+          REGENGINE_BROWSER_TENANT: ${{ inputs.tenant }}
+        run: python3 scripts/browser_smoke.py

--- a/DEPLOYMENT_PROFILES.md
+++ b/DEPLOYMENT_PROFILES.md
@@ -243,21 +243,33 @@ python3 scripts/remote_smoke.py
 
 The harness keeps delivery in `mock` mode, uses the dedicated smoke tenant by default, and verifies health, Basic Auth, CORS, fixture load, lineage, FDA CSV, and EPCIS JSON-LD without printing the password.
 
-You can run the same check from GitHub Actions with the manual **Remote Smoke** workflow. Configure these repository secrets first:
+Validate the deployed browser dashboard through the same shared-demo auth path:
+
+```bash
+export REGENGINE_BROWSER_BASE_URL=https://regengine-inflow-lab-production.up.railway.app
+export REGENGINE_BROWSER_USERNAME=demo
+export REGENGINE_BROWSER_PASSWORD='<shared-demo-password>'
+export REGENGINE_BROWSER_TENANT=remote-browser-smoke
+python3 scripts/browser_smoke.py
+```
+
+The browser smoke forces dashboard delivery back to `mock`, uses the dedicated browser-smoke tenant, and verifies the real dashboard start/stop, reset, single-batch, fixture, lineage, and CSV warning flows without printing the password.
+
+You can run the same checks from GitHub Actions with the manual **Remote Smoke** and **Remote Browser Smoke** workflows. Configure these repository secrets first:
 
 ```text
 REGENGINE_REMOTE_USERNAME=demo
 REGENGINE_REMOTE_PASSWORD=<shared-demo-password>
 ```
 
-Then run `.github/workflows/remote-smoke.yml` from the Actions tab. The workflow inputs are:
+Then run `.github/workflows/remote-smoke.yml` or `.github/workflows/remote-browser-smoke.yml` from the Actions tab. The workflow inputs are:
 
 | Input | Default | Purpose |
 |---|---|---|
 | `base_url` | `https://regengine-inflow-lab-production.up.railway.app` | Deployed shared-demo URL to validate |
-| `tenant` | `remote-smoke` | Tenant used for isolated smoke data |
+| `tenant` | `remote-smoke` or `remote-browser-smoke` | Tenant used for isolated smoke data |
 
-The workflow installs the repo dependencies and runs `python3 scripts/remote_smoke.py`. It does not require live RegEngine credentials and still loads the fixture with `delivery.mode=mock`.
+The workflows install repo dependencies and run `python3 scripts/remote_smoke.py` or `python3 scripts/browser_smoke.py`. They do not require live RegEngine credentials and keep delivery in `mock` mode.
 
 Railway log triage:
 
@@ -287,6 +299,7 @@ Use these patterns when diagnosing a shared demo:
 - `POST /api/demo-fixtures/fresh_cut_transformation/load` succeeds in `mock` mode.
 - `python3 scripts/remote_smoke.py` passes for the deployed shared-demo URL.
 - The manual GitHub **Remote Smoke** workflow passes with the same shared-demo URL and smoke tenant.
+- The manual GitHub **Remote Browser Smoke** workflow passes with the same shared-demo URL and browser-smoke tenant.
 - Lineage for `TLC-DEMO-FC-OUT-001` includes upstream harvest and packed lots.
 - FDA CSV and EPCIS exports are derivable from stored records.
 - No generated `data/` files or secrets are staged before committing.

--- a/README.md
+++ b/README.md
@@ -129,7 +129,9 @@ python3 -m playwright install chromium
 python3 scripts/browser_smoke.py
 ```
 
-The smoke starts a temporary local server with mock delivery, drives Chromium through the dashboard start/stop, reset, single-batch, fixture load, transformed-lot lineage lookup, and CSV warning display flows, then exits nonzero with a clear failure message if a browser assertion fails. Set `REGENGINE_BROWSER_BASE_URL` to run against an already-started local instance instead of letting the script start one.
+The smoke starts a temporary local server with mock delivery, drives Chromium through the dashboard start/stop, reset, single-batch, fixture load, transformed-lot lineage lookup, and CSV warning display flows, then exits nonzero with a clear failure message if a browser assertion fails. It forces the dashboard delivery mode to `mock` before taking any action.
+
+Set `REGENGINE_BROWSER_BASE_URL` to run against an already-started local or remote instance instead of letting the script start one. For Basic Auth deployments, set `REGENGINE_BROWSER_USERNAME` and `REGENGINE_BROWSER_PASSWORD`; set `REGENGINE_BROWSER_TENANT` to send `X-RegEngine-Tenant` for an isolated smoke tenant. The script also accepts the equivalent `REGENGINE_REMOTE_*` variables used by `scripts/remote_smoke.py`.
 
 ## Release smoke regression
 
@@ -153,7 +155,7 @@ python3 scripts/remote_smoke.py
 
 `scripts/remote_smoke.py` uses `httpx` with normal TLS verification to check `/api/healthz`, Basic Auth enforcement, credentialed CORS allow/block behavior, mock fixture loading, transformed-lot lineage, FDA CSV export, and EPCIS JSON-LD export. The tenant defaults to `remote-smoke`, fixture delivery stays in `mock` mode, and failure messages redact configured passwords and credential-like environment values.
 
-GitHub also has a manual **Remote Smoke** workflow for deployed demo validation. Configure repository secrets `REGENGINE_REMOTE_USERNAME` and `REGENGINE_REMOTE_PASSWORD`, then run `.github/workflows/remote-smoke.yml` with optional `base_url` and `tenant` inputs.
+GitHub also has manual **Remote Smoke** and **Remote Browser Smoke** workflows for deployed demo validation. Configure repository secrets `REGENGINE_REMOTE_USERNAME` and `REGENGINE_REMOTE_PASSWORD`, then run `.github/workflows/remote-smoke.yml` for API/export checks or `.github/workflows/remote-browser-smoke.yml` for authenticated dashboard checks with optional `base_url` and `tenant` inputs.
 
 Use `RELEASE_CHECKLIST.md` as the full demo-ready gate. Use `DESIGN_PARTNER_DEMO_SCRIPT.md` for the call flow, expected talking points, fixture reset commands, and recovery steps.
 

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -38,6 +38,7 @@ Use this checklist before tagging a demo-ready build or handing the simulator to
 - [ ] Protected tenant operations can list, reset, and delete a test tenant when Basic Auth is enabled.
 - [ ] For shared-demo releases, `python3 scripts/remote_smoke.py` passes against the deployed HTTPS URL.
 - [ ] For shared-demo releases, the manual GitHub **Remote Smoke** workflow passes with repository secrets `REGENGINE_REMOTE_USERNAME` and `REGENGINE_REMOTE_PASSWORD`.
+- [ ] For shared-demo releases, the manual GitHub **Remote Browser Smoke** workflow passes with repository secrets `REGENGINE_REMOTE_USERNAME` and `REGENGINE_REMOTE_PASSWORD`.
 - [ ] For live-trial prep, `python3 scripts/live_trial.py --dry-run-only` passes before any confirmed live batch.
 
 ## Handoff Notes

--- a/scripts/browser_smoke.py
+++ b/scripts/browser_smoke.py
@@ -23,17 +23,34 @@ harvesting,TLC-BROWSER-WARN,Romaine Lettuce,10,cases,Valley Fresh Farms,2026-02-
 class BrowserSmokeConfig:
     base_url: str | None
     headless: bool
+    username: str | None
+    password: str | None
+    tenant: str | None
 
 
 def main() -> int:
-    config = BrowserSmokeConfig(
-        base_url=_env_text("REGENGINE_BROWSER_BASE_URL"),
-        headless=os.getenv("REGENGINE_BROWSER_HEADLESS", "1").lower() not in {"0", "false", "no"},
-    )
+    config = _load_config()
     with _base_url(config.base_url) as base_url:
-        _run_dashboard_smoke(base_url=base_url, headless=config.headless)
+        _run_dashboard_smoke(base_url=base_url, config=config)
     print("Browser smoke passed.")
     return 0
+
+
+def _load_config() -> BrowserSmokeConfig:
+    username = _env_text("REGENGINE_BROWSER_USERNAME") or _env_text("REGENGINE_REMOTE_USERNAME")
+    password = _env_text("REGENGINE_BROWSER_PASSWORD") or _env_text("REGENGINE_REMOTE_PASSWORD")
+    if bool(username) != bool(password):
+        raise RuntimeError(
+            "REGENGINE_BROWSER_USERNAME and REGENGINE_BROWSER_PASSWORD must be provided together"
+        )
+
+    return BrowserSmokeConfig(
+        base_url=_env_text("REGENGINE_BROWSER_BASE_URL") or _env_text("REGENGINE_REMOTE_BASE_URL"),
+        headless=os.getenv("REGENGINE_BROWSER_HEADLESS", "1").lower() not in {"0", "false", "no"},
+        username=username,
+        password=password,
+        tenant=_env_text("REGENGINE_BROWSER_TENANT") or _env_text("REGENGINE_REMOTE_TENANT"),
+    )
 
 
 @contextmanager
@@ -76,7 +93,7 @@ def _base_url(configured_base_url: str | None) -> Iterator[str]:
             _terminate(process)
 
 
-def _run_dashboard_smoke(base_url: str, headless: bool) -> None:
+def _run_dashboard_smoke(base_url: str, config: BrowserSmokeConfig) -> None:
     try:
         from playwright.sync_api import expect, sync_playwright
     except ModuleNotFoundError as exc:
@@ -91,17 +108,24 @@ def _run_dashboard_smoke(base_url: str, headless: bool) -> None:
     failed = False
     try:
         with sync_playwright() as playwright:
-            browser = playwright.chromium.launch(headless=headless)
-            page = browser.new_page()
+            browser = playwright.chromium.launch(headless=config.headless)
+            context_options = _browser_context_options(config)
+            context = browser.new_context(**context_options)
+            page = context.new_page()
             page.on("console", lambda message: console_errors.append(message.text) if message.type == "error" else None)
             page.on("pageerror", lambda error: console_errors.append(str(error)))
 
             page.goto(base_url, wait_until="domcontentloaded")
             expect(page.get_by_role("heading", name="RegEngine Inflow Lab")).to_be_visible()
-            expect(page.locator("#statusMessage")).to_contain_text("Simulator loop is stopped")
 
             page.locator("#batchSize").fill("1")
             page.locator("#interval").fill("0.1")
+            page.locator("#deliveryMode").select_option("mock")
+            page.locator("#endpoint").fill("")
+            page.locator("#apiKey").fill("")
+            page.locator("#tenantId").fill("")
+            page.locator("#stopBtn").click()
+            expect(page.locator("#statusMessage")).to_contain_text("Stopped simulator loop")
 
             page.locator("#startBtn").click()
             expect(page.locator("#statusMessage")).to_contain_text("Started simulator loop")
@@ -149,6 +173,18 @@ def _run_dashboard_smoke(base_url: str, headless: bool) -> None:
     finally:
         if console_errors and not failed:
             raise RuntimeError(f"Browser console errors: {console_errors}")
+
+
+def _browser_context_options(config: BrowserSmokeConfig) -> dict[str, object]:
+    options: dict[str, object] = {}
+    if config.username and config.password:
+        options["http_credentials"] = {
+            "username": config.username,
+            "password": config.password,
+        }
+    if config.tenant:
+        options["extra_http_headers"] = {"X-RegEngine-Tenant": config.tenant}
+    return options
 
 
 def _wait_for_healthz(base_url: str, process: subprocess.Popen[str]) -> None:

--- a/tests/test_browser_smoke.py
+++ b/tests/test_browser_smoke.py
@@ -1,0 +1,47 @@
+import pytest
+
+from scripts.browser_smoke import _browser_context_options, _load_config
+
+
+def test_browser_smoke_config_uses_browser_env(monkeypatch):
+    monkeypatch.setenv("REGENGINE_BROWSER_BASE_URL", "https://demo.example.test/")
+    monkeypatch.setenv("REGENGINE_BROWSER_USERNAME", "demo-user")
+    monkeypatch.setenv("REGENGINE_BROWSER_PASSWORD", "demo-pass")
+    monkeypatch.setenv("REGENGINE_BROWSER_TENANT", "browser-smoke")
+
+    config = _load_config()
+
+    assert config.base_url == "https://demo.example.test/"
+    assert config.username == "demo-user"
+    assert config.password == "demo-pass"
+    assert config.tenant == "browser-smoke"
+    assert _browser_context_options(config) == {
+        "http_credentials": {
+            "username": "demo-user",
+            "password": "demo-pass",
+        },
+        "extra_http_headers": {"X-RegEngine-Tenant": "browser-smoke"},
+    }
+
+
+def test_browser_smoke_config_falls_back_to_remote_env(monkeypatch):
+    monkeypatch.setenv("REGENGINE_REMOTE_BASE_URL", "https://railway.example.test")
+    monkeypatch.setenv("REGENGINE_REMOTE_USERNAME", "remote-user")
+    monkeypatch.setenv("REGENGINE_REMOTE_PASSWORD", "remote-pass")
+    monkeypatch.setenv("REGENGINE_REMOTE_TENANT", "remote-browser-smoke")
+
+    config = _load_config()
+
+    assert config.base_url == "https://railway.example.test"
+    assert config.username == "remote-user"
+    assert config.password == "remote-pass"
+    assert config.tenant == "remote-browser-smoke"
+
+
+def test_browser_smoke_config_requires_username_password_pair(monkeypatch):
+    monkeypatch.setenv("REGENGINE_BROWSER_USERNAME", "demo-user")
+    monkeypatch.delenv("REGENGINE_BROWSER_PASSWORD", raising=False)
+    monkeypatch.delenv("REGENGINE_REMOTE_PASSWORD", raising=False)
+
+    with pytest.raises(RuntimeError, match="must be provided together"):
+        _load_config()


### PR DESCRIPTION
## Summary
- extend `scripts/browser_smoke.py` so it can validate authenticated remote deployments with an isolated tenant header
- force dashboard delivery back to mock before browser actions to keep remote smoke safe
- add a manual GitHub Actions workflow plus docs/checklist coverage for remote browser smoke

## Tests
- `pytest`
- `python3 scripts/smoke_regression.py`
- `python3 scripts/browser_smoke.py`
- `node --check app/static/app.js`
- `python3 -m compileall app scripts`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a manual "Remote Browser Smoke" GitHub Actions workflow for dashboard testing with configurable base URL and tenant options.
  * Enhanced browser smoke testing with authentication and tenant isolation support for external instance validation.

* **Documentation**
  * Updated guides documenting the new browser smoke workflow and environment variable configuration.

* **Tests**
  * Added test coverage for browser smoke authentication and tenant configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->