### PR TITLE
Schedule nightly remote smoke workflows

### DIFF
--- a/.github/workflows/remote-browser-smoke.yml
+++ b/.github/workflows/remote-browser-smoke.yml
@@ -1,6 +1,8 @@
 name: Remote Browser Smoke
 
 on:
+  schedule:
+    - cron: '47 10 * * *'
   workflow_dispatch:
     inputs:
       base_url:
@@ -18,7 +20,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: remote-browser-smoke-${{ github.event.inputs.base_url }}-${{ github.event.inputs.tenant }}
+  group: remote-browser-smoke-${{ github.event.inputs.base_url || 'https://regengine-inflow-lab-production.up.railway.app' }}-${{ github.event.inputs.tenant || 'remote-browser-smoke-nightly' }}
   cancel-in-progress: false
 
 jobs:
@@ -56,8 +58,8 @@ jobs:
 
       - name: Run remote browser smoke
         env:
-          REGENGINE_BROWSER_BASE_URL: ${{ inputs.base_url }}
+          REGENGINE_BROWSER_BASE_URL: ${{ github.event.inputs.base_url || 'https://regengine-inflow-lab-production.up.railway.app' }}
           REGENGINE_BROWSER_USERNAME: ${{ secrets.REGENGINE_REMOTE_USERNAME }}
           REGENGINE_BROWSER_PASSWORD: ${{ secrets.REGENGINE_REMOTE_PASSWORD }}
-          REGENGINE_BROWSER_TENANT: ${{ inputs.tenant }}
+          REGENGINE_BROWSER_TENANT: ${{ github.event.inputs.tenant || 'remote-browser-smoke-nightly' }}
         run: python3 scripts/browser_smoke.py

--- a/.github/workflows/remote-smoke.yml
+++ b/.github/workflows/remote-smoke.yml
@@ -1,6 +1,8 @@
 name: Remote Smoke
 
 on:
+  schedule:
+    - cron: '17 10 * * *'
   workflow_dispatch:
     inputs:
       base_url:
@@ -18,7 +20,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: remote-smoke-${{ github.event.inputs.base_url }}-${{ github.event.inputs.tenant }}
+  group: remote-smoke-${{ github.event.inputs.base_url || 'https://regengine-inflow-lab-production.up.railway.app' }}-${{ github.event.inputs.tenant || 'remote-smoke-nightly' }}
   cancel-in-progress: false
 
 jobs:
@@ -54,8 +56,8 @@ jobs:
 
       - name: Run remote smoke
         env:
-          REGENGINE_REMOTE_BASE_URL: ${{ inputs.base_url }}
+          REGENGINE_REMOTE_BASE_URL: ${{ github.event.inputs.base_url || 'https://regengine-inflow-lab-production.up.railway.app' }}
           REGENGINE_REMOTE_USERNAME: ${{ secrets.REGENGINE_REMOTE_USERNAME }}
           REGENGINE_REMOTE_PASSWORD: ${{ secrets.REGENGINE_REMOTE_PASSWORD }}
-          REGENGINE_REMOTE_TENANT: ${{ inputs.tenant }}
+          REGENGINE_REMOTE_TENANT: ${{ github.event.inputs.tenant || 'remote-smoke-nightly' }}
         run: python3 scripts/remote_smoke.py

--- a/DEPLOYMENT_PROFILES.md
+++ b/DEPLOYMENT_PROFILES.md
@@ -255,7 +255,7 @@ python3 scripts/browser_smoke.py
 
 The browser smoke forces dashboard delivery back to `mock`, uses the dedicated browser-smoke tenant, and verifies the real dashboard start/stop, reset, single-batch, fixture, lineage, and CSV warning flows without printing the password.
 
-You can run the same checks from GitHub Actions with the manual **Remote Smoke** and **Remote Browser Smoke** workflows. Configure these repository secrets first:
+You can run the same checks from GitHub Actions with the manual and nightly **Remote Smoke** and **Remote Browser Smoke** workflows. Configure these repository secrets first:
 
 ```text
 REGENGINE_REMOTE_USERNAME=demo
@@ -269,7 +269,7 @@ Then run `.github/workflows/remote-smoke.yml` or `.github/workflows/remote-brows
 | `base_url` | `https://regengine-inflow-lab-production.up.railway.app` | Deployed shared-demo URL to validate |
 | `tenant` | `remote-smoke` or `remote-browser-smoke` | Tenant used for isolated smoke data |
 
-The workflows install repo dependencies and run `python3 scripts/remote_smoke.py` or `python3 scripts/browser_smoke.py`. They do not require live RegEngine credentials and keep delivery in `mock` mode.
+The workflows install repo dependencies and run `python3 scripts/remote_smoke.py` or `python3 scripts/browser_smoke.py`. They do not require live RegEngine credentials and keep delivery in `mock` mode. Nightly scheduled runs target the Railway shared-demo URL with `remote-smoke-nightly` and `remote-browser-smoke-nightly` tenants.
 
 Railway log triage:
 
@@ -300,6 +300,7 @@ Use these patterns when diagnosing a shared demo:
 - `python3 scripts/remote_smoke.py` passes for the deployed shared-demo URL.
 - The manual GitHub **Remote Smoke** workflow passes with the same shared-demo URL and smoke tenant.
 - The manual GitHub **Remote Browser Smoke** workflow passes with the same shared-demo URL and browser-smoke tenant.
+- Nightly GitHub **Remote Smoke** and **Remote Browser Smoke** schedules are enabled after the shared-demo secrets are configured.
 - Lineage for `TLC-DEMO-FC-OUT-001` includes upstream harvest and packed lots.
 - FDA CSV and EPCIS exports are derivable from stored records.
 - No generated `data/` files or secrets are staged before committing.

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ python3 scripts/remote_smoke.py
 
 `scripts/remote_smoke.py` uses `httpx` with normal TLS verification to check `/api/healthz`, Basic Auth enforcement, credentialed CORS allow/block behavior, mock fixture loading, transformed-lot lineage, FDA CSV export, and EPCIS JSON-LD export. The tenant defaults to `remote-smoke`, fixture delivery stays in `mock` mode, and failure messages redact configured passwords and credential-like environment values.
 
-GitHub also has manual **Remote Smoke** and **Remote Browser Smoke** workflows for deployed demo validation. Configure repository secrets `REGENGINE_REMOTE_USERNAME` and `REGENGINE_REMOTE_PASSWORD`, then run `.github/workflows/remote-smoke.yml` for API/export checks or `.github/workflows/remote-browser-smoke.yml` for authenticated dashboard checks with optional `base_url` and `tenant` inputs.
+GitHub also has manual and nightly **Remote Smoke** and **Remote Browser Smoke** workflows for deployed demo validation. Configure repository secrets `REGENGINE_REMOTE_USERNAME` and `REGENGINE_REMOTE_PASSWORD`, then run `.github/workflows/remote-smoke.yml` for API/export checks or `.github/workflows/remote-browser-smoke.yml` for authenticated dashboard checks with optional `base_url` and `tenant` inputs. Scheduled runs target the Railway shared-demo URL with dedicated nightly tenants.
 
 Use `RELEASE_CHECKLIST.md` as the full demo-ready gate. Use `DESIGN_PARTNER_DEMO_SCRIPT.md` for the call flow, expected talking points, fixture reset commands, and recovery steps.
 

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -39,6 +39,7 @@ Use this checklist before tagging a demo-ready build or handing the simulator to
 - [ ] For shared-demo releases, `python3 scripts/remote_smoke.py` passes against the deployed HTTPS URL.
 - [ ] For shared-demo releases, the manual GitHub **Remote Smoke** workflow passes with repository secrets `REGENGINE_REMOTE_USERNAME` and `REGENGINE_REMOTE_PASSWORD`.
 - [ ] For shared-demo releases, the manual GitHub **Remote Browser Smoke** workflow passes with repository secrets `REGENGINE_REMOTE_USERNAME` and `REGENGINE_REMOTE_PASSWORD`.
+- [ ] For shared-demo releases, nightly GitHub **Remote Smoke** and **Remote Browser Smoke** schedules are enabled after those repository secrets are configured.
 - [ ] For live-trial prep, `python3 scripts/live_trial.py --dry-run-only` passes before any confirmed live batch.
 
 ## Handoff Notes


### PR DESCRIPTION
## Summary
- add nightly schedules to the API remote smoke and remote browser smoke workflows
- use explicit Railway URL and dedicated nightly tenants when the workflows run on schedule
- update deployment and release docs so operators know the schedules depend on shared-demo secrets

## Remote validation
- Manual Remote Browser Smoke run passed after redeploying Railway current `main`: https://github.com/PetrefiedThunder/regengine_codex_workspace/actions/runs/24947974157
- Manual Remote Smoke run passed: https://github.com/PetrefiedThunder/regengine_codex_workspace/actions/runs/24948012667

## Tests
- `pytest`
- `python3 scripts/smoke_regression.py`
- `python3 scripts/browser_smoke.py`
- `node --check app/static/app.js`
- `python3 -m compileall app scripts`
- `git diff --check`