### PR TITLE
Expose build metadata in health checks

### DIFF
--- a/.github/workflows/remote-browser-smoke.yml
+++ b/.github/workflows/remote-browser-smoke.yml
@@ -62,4 +62,5 @@ jobs:
           REGENGINE_BROWSER_USERNAME: ${{ secrets.REGENGINE_REMOTE_USERNAME }}
           REGENGINE_BROWSER_PASSWORD: ${{ secrets.REGENGINE_REMOTE_PASSWORD }}
           REGENGINE_BROWSER_TENANT: ${{ github.event.inputs.tenant || 'remote-browser-smoke-nightly' }}
+          REGENGINE_BROWSER_EXPECTED_BUILD_SHA: ${{ github.sha }}
         run: python3 scripts/browser_smoke.py

--- a/.github/workflows/remote-smoke.yml
+++ b/.github/workflows/remote-smoke.yml
@@ -60,4 +60,5 @@ jobs:
           REGENGINE_REMOTE_USERNAME: ${{ secrets.REGENGINE_REMOTE_USERNAME }}
           REGENGINE_REMOTE_PASSWORD: ${{ secrets.REGENGINE_REMOTE_PASSWORD }}
           REGENGINE_REMOTE_TENANT: ${{ github.event.inputs.tenant || 'remote-smoke-nightly' }}
+          REGENGINE_EXPECTED_BUILD_SHA: ${{ github.sha }}
         run: python3 scripts/remote_smoke.py

--- a/DEPLOYMENT_PROFILES.md
+++ b/DEPLOYMENT_PROFILES.md
@@ -227,9 +227,19 @@ REGENGINE_BASIC_AUTH_PASSWORD=<strong generated password>
 REGENGINE_DEFAULT_TENANT=demo-default
 REGENGINE_CORS_ORIGINS=https://<railway-domain>
 REGENGINE_DATA_DIR=/data
+REGENGINE_BUILD_SHA=<deployed git sha>
+REGENGINE_BUILD_BRANCH=main
 ```
 
 Attach a Railway volume at `/data` before using the service for partner demos. After a Railway domain is generated, update `REGENGINE_CORS_ORIGINS` to that exact HTTPS origin.
+
+When deploying from the CLI, update the non-secret build variables before `railway up` so health checks can identify stale deployments:
+
+```bash
+railway variable set --skip-deploys REGENGINE_BUILD_SHA="$(git rev-parse HEAD)" \
+  REGENGINE_BUILD_BRANCH="$(git branch --show-current)"
+railway up --ci -m "Deploy $(git rev-parse --short HEAD)"
+```
 
 Validate the deployed Railway demo with the remote smoke harness:
 
@@ -269,7 +279,7 @@ Then run `.github/workflows/remote-smoke.yml` or `.github/workflows/remote-brows
 | `base_url` | `https://regengine-inflow-lab-production.up.railway.app` | Deployed shared-demo URL to validate |
 | `tenant` | `remote-smoke` or `remote-browser-smoke` | Tenant used for isolated smoke data |
 
-The workflows install repo dependencies and run `python3 scripts/remote_smoke.py` or `python3 scripts/browser_smoke.py`. They do not require live RegEngine credentials and keep delivery in `mock` mode. Nightly scheduled runs target the Railway shared-demo URL with `remote-smoke-nightly` and `remote-browser-smoke-nightly` tenants.
+The workflows install repo dependencies and run `python3 scripts/remote_smoke.py` or `python3 scripts/browser_smoke.py`. They do not require live RegEngine credentials and keep delivery in `mock` mode. Nightly scheduled runs target the Railway shared-demo URL with `remote-smoke-nightly` and `remote-browser-smoke-nightly` tenants, and both remote workflows compare `/api/healthz` build metadata to the workflow commit.
 
 Railway log triage:
 
@@ -291,8 +301,9 @@ Use these patterns when diagnosing a shared demo:
 
 ## Profile Verification Checklist
 
-- `GET /api/health` returns the expected tenant and auth context.
-- `GET /api/healthz` returns `{"ok": true, ...}` without credentials for platform healthchecks.
+- `GET /api/health` returns the expected tenant, auth context, and build metadata.
+- `GET /api/healthz` returns `{"ok": true, "build": ...}` without credentials for platform healthchecks.
+- `build.commit_sha_short` matches the deployed git commit before manual or nightly remote smoke runs.
 - Browser requests from the intended HTTPS origin receive the `access-control-allow-origin` response header; untrusted origins do not.
 - `REGENGINE_DATA_DIR` points at mounted persistent storage in shared-demo and live-trial deployments.
 - Dashboard stats match the chosen tenant/auth/storage profile.

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Each event is persisted with `event_id`, `sha256_hash`, and `chain_hash` so the 
 ```text
 app/
   auth.py                # Optional Basic Auth and tenant context resolution
+  build_info.py          # Public non-secret build/deployment metadata for health checks
   controller.py          # Simulator lifecycle (start/stop/step/reset)
   demo_fixtures.py       # Deterministic demo playback fixtures
   engine.py              # CTE generation and lot lineage logic
@@ -153,9 +154,9 @@ export REGENGINE_REMOTE_TENANT=remote-smoke
 python3 scripts/remote_smoke.py
 ```
 
-`scripts/remote_smoke.py` uses `httpx` with normal TLS verification to check `/api/healthz`, Basic Auth enforcement, credentialed CORS allow/block behavior, mock fixture loading, transformed-lot lineage, FDA CSV export, and EPCIS JSON-LD export. The tenant defaults to `remote-smoke`, fixture delivery stays in `mock` mode, and failure messages redact configured passwords and credential-like environment values.
+`scripts/remote_smoke.py` uses `httpx` with normal TLS verification to check `/api/healthz`, Basic Auth enforcement, credentialed CORS allow/block behavior, mock fixture loading, transformed-lot lineage, FDA CSV export, and EPCIS JSON-LD export. The tenant defaults to `remote-smoke`, fixture delivery stays in `mock` mode, and failure messages redact configured passwords and credential-like environment values. Set `REGENGINE_EXPECTED_BUILD_SHA` to fail fast when a deployed instance is not running the expected commit.
 
-GitHub also has manual and nightly **Remote Smoke** and **Remote Browser Smoke** workflows for deployed demo validation. Configure repository secrets `REGENGINE_REMOTE_USERNAME` and `REGENGINE_REMOTE_PASSWORD`, then run `.github/workflows/remote-smoke.yml` for API/export checks or `.github/workflows/remote-browser-smoke.yml` for authenticated dashboard checks with optional `base_url` and `tenant` inputs. Scheduled runs target the Railway shared-demo URL with dedicated nightly tenants.
+GitHub also has manual and nightly **Remote Smoke** and **Remote Browser Smoke** workflows for deployed demo validation. Configure repository secrets `REGENGINE_REMOTE_USERNAME` and `REGENGINE_REMOTE_PASSWORD`, then run `.github/workflows/remote-smoke.yml` for API/export checks or `.github/workflows/remote-browser-smoke.yml` for authenticated dashboard checks with optional `base_url` and `tenant` inputs. Scheduled runs target the Railway shared-demo URL with dedicated nightly tenants and compare `/api/healthz` build metadata to the workflow commit.
 
 Use `RELEASE_CHECKLIST.md` as the full demo-ready gate. Use `DESIGN_PARTNER_DEMO_SCRIPT.md` for the call flow, expected talking points, fixture reset commands, and recovery steps.
 
@@ -343,8 +344,8 @@ The service wrapper examples below can be used with any profile; keep the profil
 
 | Method | Path | Purpose |
 |---|---|---|
-| `GET` | `/api/health` | Authenticated liveness probe, tenant/auth context, and current config snapshot |
-| `GET` | `/api/healthz` | Unauthenticated platform/container healthcheck |
+| `GET` | `/api/health` | Authenticated liveness probe, public build metadata, tenant/auth context, and current config snapshot |
+| `GET` | `/api/healthz` | Unauthenticated platform/container healthcheck with public build metadata |
 | `GET` | `/api/scenarios` | List available scenario presets |
 | `GET` | `/api/scenario-saves` | List saved per-scenario demo states |
 | `POST` | `/api/scenario-saves/{scenario_id}` | Save the current or supplied config and event log for a scenario |
@@ -642,6 +643,16 @@ docker run --rm \
 
 `railway.json` uses the same Dockerfile and healthcheck for Railway deployments. Mount persistent storage at `/data` and keep `REGENGINE_DATA_DIR=/data`.
 
+Expose non-secret build metadata so stale shared-demo deployments are obvious from `/api/healthz` and remote smoke failures:
+
+```bash
+railway variable set --skip-deploys REGENGINE_BUILD_SHA="$(git rev-parse HEAD)" \
+  REGENGINE_BUILD_BRANCH="$(git branch --show-current)"
+railway up --ci -m "Deploy $(git rev-parse --short HEAD)"
+```
+
+The health responses always include `build.version`; `build.commit_sha`, `build.commit_sha_short`, `build.branch`, and `build.deployment_id` are populated from whitelisted environment variables when available, or from local `.git` metadata during local development.
+
 ## Logs and troubleshooting
 
 Every HTTP request emits an application log line like:
@@ -669,6 +680,7 @@ systemctl status regengine                    # Linux
 
 # Health probe
 curl http://127.0.0.1:8000/api/health
+curl http://127.0.0.1:8000/api/healthz
 
 # Tail logs (macOS)
 tail -f ~/regengine_codex_workspace/uvicorn.err.log
@@ -683,6 +695,7 @@ Common failure patterns:
 - Auth failures: request logs show `status=401` on `/api/...`; confirm `REGENGINE_BASIC_AUTH_USERNAME` and `REGENGINE_BASIC_AUTH_PASSWORD` are set as intended.
 - CORS failures: Railway HTTP logs may show successful `OPTIONS` but the browser blocks a follow-up request; confirm `REGENGINE_CORS_ORIGINS` is the exact HTTPS dashboard origin.
 - Volume/storage failures: `/api/health` should report tenant-scoped paths under `REGENGINE_DATA_DIR`; confirm Railway has a volume mounted at `/data` and `REGENGINE_DATA_DIR=/data`.
+- Stale deployment failures: `/api/healthz` should report the expected `build.commit_sha_short`; if it does not, redeploy current `main` and update `REGENGINE_BUILD_SHA`.
 - Live delivery failures: request logs identify the route and tenant while dashboard delivery stats show the sanitized delivery error; confirm endpoint, API key, and tenant id before retrying.
 
 If the health check fails before request logs appear, the first place to look is `uvicorn.err.log` or `railway logs --deployment` for a Python traceback or startup error.

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -23,7 +23,7 @@ Use this checklist before tagging a demo-ready build or handing the simulator to
 ## Operator Flow Checks
 
 - [ ] Dashboard loads without credentials when Basic Auth env vars are unset.
-- [ ] `/api/healthz` remains available without credentials for container/platform healthchecks.
+- [ ] `/api/healthz` remains available without credentials for container/platform healthchecks and reports the expected `build.commit_sha_short`.
 - [ ] Basic Auth returns `401` without valid credentials when env vars are set.
 - [ ] Shared-demo or live-trial deployments set explicit `REGENGINE_CORS_ORIGINS` values instead of wildcard CORS.
 - [ ] Dashboard simulator actions do not return `403`; if they do, confirm the browser origin exactly matches `REGENGINE_CORS_ORIGINS`.
@@ -39,7 +39,7 @@ Use this checklist before tagging a demo-ready build or handing the simulator to
 - [ ] For shared-demo releases, `python3 scripts/remote_smoke.py` passes against the deployed HTTPS URL.
 - [ ] For shared-demo releases, the manual GitHub **Remote Smoke** workflow passes with repository secrets `REGENGINE_REMOTE_USERNAME` and `REGENGINE_REMOTE_PASSWORD`.
 - [ ] For shared-demo releases, the manual GitHub **Remote Browser Smoke** workflow passes with repository secrets `REGENGINE_REMOTE_USERNAME` and `REGENGINE_REMOTE_PASSWORD`.
-- [ ] For shared-demo releases, nightly GitHub **Remote Smoke** and **Remote Browser Smoke** schedules are enabled after those repository secrets are configured.
+- [ ] For shared-demo releases, nightly GitHub **Remote Smoke** and **Remote Browser Smoke** schedules are enabled after those repository secrets are configured and `REGENGINE_BUILD_SHA` is kept current on Railway.
 - [ ] For live-trial prep, `python3 scripts/live_trial.py --dry-run-only` passes before any confirmed live batch.
 
 ## Handoff Notes

--- a/app/build_info.py
+++ b/app/build_info.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+
+APP_VERSION = "0.1.0"
+SHA_RE = re.compile(r"^[0-9a-fA-F]{7,64}$")
+
+COMMIT_SHA_ENV_VARS = (
+    "REGENGINE_BUILD_SHA",
+    "RAILWAY_GIT_COMMIT_SHA",
+    "GITHUB_SHA",
+    "SOURCE_VERSION",
+    "COMMIT_SHA",
+    "GIT_COMMIT",
+)
+BRANCH_ENV_VARS = (
+    "REGENGINE_BUILD_BRANCH",
+    "RAILWAY_GIT_BRANCH",
+    "GITHUB_REF_NAME",
+    "SOURCE_BRANCH",
+    "BRANCH_NAME",
+    "GIT_BRANCH",
+)
+DEPLOYMENT_ID_ENV_VARS = (
+    "REGENGINE_DEPLOYMENT_ID",
+    "RAILWAY_DEPLOYMENT_ID",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class BuildInfo:
+    version: str
+    commit_sha: str | None = None
+    commit_sha_short: str | None = None
+    commit_source: str | None = None
+    branch: str | None = None
+    branch_source: str | None = None
+    deployment_id: str | None = None
+    deployment_source: str | None = None
+
+    def public_dict(self) -> dict[str, str | None]:
+        return {
+            "version": self.version,
+            "commit_sha": self.commit_sha,
+            "commit_sha_short": self.commit_sha_short,
+            "commit_source": self.commit_source,
+            "branch": self.branch,
+            "branch_source": self.branch_source,
+            "deployment_id": self.deployment_id,
+            "deployment_source": self.deployment_source,
+        }
+
+
+def current_build_info() -> BuildInfo:
+    commit_sha, commit_source = _first_env(COMMIT_SHA_ENV_VARS)
+    branch, branch_source = _first_env(BRANCH_ENV_VARS)
+
+    if commit_sha and not _looks_like_sha(commit_sha):
+        commit_sha = None
+        commit_source = None
+    if commit_sha is None:
+        commit_sha = _git_commit_sha()
+        commit_source = "local_git" if commit_sha else None
+    if branch is None:
+        branch = _git_branch()
+        branch_source = "local_git" if branch else None
+
+    deployment_id, deployment_source = _first_env(DEPLOYMENT_ID_ENV_VARS)
+    return BuildInfo(
+        version=_env_text("REGENGINE_APP_VERSION") or APP_VERSION,
+        commit_sha=commit_sha,
+        commit_sha_short=commit_sha[:7] if commit_sha else None,
+        commit_source=commit_source,
+        branch=branch,
+        branch_source=branch_source,
+        deployment_id=deployment_id,
+        deployment_source=deployment_source,
+    )
+
+
+def _first_env(names: tuple[str, ...]) -> tuple[str | None, str | None]:
+    for name in names:
+        value = _env_text(name)
+        if value:
+            return value, name
+    return None, None
+
+
+def _env_text(name: str) -> str | None:
+    value = os.getenv(name)
+    if value and value.strip():
+        return value.strip()
+    return None
+
+
+def _git_commit_sha() -> str | None:
+    git_dir = _git_dir()
+    if git_dir is None:
+        return None
+
+    head = _read_text(git_dir / "HEAD")
+    if not head:
+        return None
+    if head.startswith("ref: "):
+        return _normalize_sha(_read_text(git_dir / head.removeprefix("ref: ").strip()))
+    return _normalize_sha(head)
+
+
+def _git_branch() -> str | None:
+    git_dir = _git_dir()
+    if git_dir is None:
+        return None
+
+    head = _read_text(git_dir / "HEAD")
+    if not head or not head.startswith("ref: refs/heads/"):
+        return None
+    return head.removeprefix("ref: refs/heads/").strip()
+
+
+def _git_dir() -> Path | None:
+    repo_root = Path(__file__).resolve().parents[1]
+    git_path = repo_root / ".git"
+    if git_path.is_dir():
+        return git_path
+    if git_path.is_file():
+        gitdir_line = _read_text(git_path)
+        if gitdir_line and gitdir_line.startswith("gitdir: "):
+            resolved = (repo_root / gitdir_line.removeprefix("gitdir: ").strip()).resolve()
+            if resolved.is_dir():
+                return resolved
+    return None
+
+
+def _read_text(path: Path) -> str | None:
+    try:
+        return path.read_text(encoding="utf-8").strip()
+    except OSError:
+        return None
+
+
+def _normalize_sha(value: str | None) -> str | None:
+    if value and _looks_like_sha(value):
+        return value
+    return None
+
+
+def _looks_like_sha(value: str) -> bool:
+    return bool(SHA_RE.fullmatch(value.strip()))

--- a/app/main.py
+++ b/app/main.py
@@ -19,6 +19,7 @@ from fastapi.responses import FileResponse, JSONResponse, PlainTextResponse, Str
 from fastapi.staticfiles import StaticFiles
 
 from .auth import DEFAULT_TENANT_ID, TenantContext, normalize_tenant_id, tenant_context_from_request
+from .build_info import APP_VERSION, current_build_info
 from .controller import SimulationController
 from .demo_fixtures import list_demo_fixture_summaries
 from .engine import LegitFlowEngine
@@ -139,7 +140,7 @@ def _normalize_cors_origin(raw_origin: str) -> str | None:
 app = FastAPI(
     title="RegEngine Inflow Lab",
     description="Mock-first FSMA 204 CTE data-flow simulator for RegEngine-compatible payloads.",
-    version="0.1.0",
+    version=APP_VERSION,
     lifespan=lifespan,
 )
 app.add_middleware(
@@ -253,9 +254,11 @@ async def root() -> FileResponse:
 async def health(request: Request) -> dict[str, Any]:
     active_controller = _active_controller(request)
     context = _tenant_context(request)
+    build = current_build_info().public_dict()
     return {
         "ok": True,
         "utc_time": datetime.now(UTC).isoformat(),
+        "build": build,
         "tenant": context.tenant_id,
         "auth": {
             "enabled": context.auth_enabled,
@@ -271,6 +274,7 @@ async def healthz() -> dict[str, Any]:
     return {
         "ok": True,
         "utc_time": datetime.now(UTC).isoformat(),
+        "build": current_build_info().public_dict(),
     }
 
 

--- a/scripts/browser_smoke.py
+++ b/scripts/browser_smoke.py
@@ -13,6 +13,12 @@ from typing import Iterator
 
 import httpx
 
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from app.build_info import APP_VERSION
+
 
 CSV_WITH_KDE_WARNINGS = """cte_type,traceability_lot_code,product_description,quantity,unit_of_measure,location_name,timestamp,kdes
 harvesting,TLC-BROWSER-WARN,Romaine Lettuce,10,cases,Valley Fresh Farms,2026-02-10T08:00:00Z,"{""harvest_date"":""2026-02-10""}"
@@ -26,6 +32,7 @@ class BrowserSmokeConfig:
     username: str | None
     password: str | None
     tenant: str | None
+    expected_build_sha: str | None
 
 
 def main() -> int:
@@ -50,6 +57,8 @@ def _load_config() -> BrowserSmokeConfig:
         username=username,
         password=password,
         tenant=_env_text("REGENGINE_BROWSER_TENANT") or _env_text("REGENGINE_REMOTE_TENANT"),
+        expected_build_sha=_env_text("REGENGINE_BROWSER_EXPECTED_BUILD_SHA")
+        or _env_text("REGENGINE_EXPECTED_BUILD_SHA"),
     )
 
 
@@ -101,6 +110,8 @@ def _run_dashboard_smoke(base_url: str, config: BrowserSmokeConfig) -> None:
             "Playwright is not installed. Run: python3 -m pip install -r requirements-browser.txt "
             "&& python3 -m playwright install chromium"
         ) from exc
+
+    _check_healthz_build(base_url, config.expected_build_sha)
 
     output_dir = Path("output/playwright")
     console_errors: list[str] = []
@@ -185,6 +196,35 @@ def _browser_context_options(config: BrowserSmokeConfig) -> dict[str, object]:
     if config.tenant:
         options["extra_http_headers"] = {"X-RegEngine-Tenant": config.tenant}
     return options
+
+
+def _check_healthz_build(base_url: str, expected_build_sha: str | None) -> None:
+    response = httpx.get(f"{base_url}/api/healthz", timeout=5.0)
+    response.raise_for_status()
+    payload = response.json()
+    build = payload.get("build")
+    if not isinstance(build, dict):
+        raise RuntimeError("/api/healthz did not include build metadata")
+    if build.get("version") != APP_VERSION:
+        raise RuntimeError(
+            f"/api/healthz build version mismatch: expected {APP_VERSION}, got {build.get('version')!r}"
+        )
+    if expected_build_sha:
+        actual = build.get("commit_sha")
+        if not isinstance(actual, str) or not actual:
+            raise RuntimeError(
+                f"/api/healthz build commit mismatch: expected {expected_build_sha[:12]}, got none"
+            )
+        if not _sha_prefix_match(actual, expected_build_sha):
+            raise RuntimeError(
+                f"/api/healthz build commit mismatch: expected {expected_build_sha[:12]}, got {actual[:12]}"
+            )
+
+
+def _sha_prefix_match(actual: str, expected: str) -> bool:
+    actual = actual.strip().lower()
+    expected = expected.strip().lower()
+    return actual.startswith(expected) or expected.startswith(actual)
 
 
 def _wait_for_healthz(base_url: str, process: subprocess.Popen[str]) -> None:

--- a/scripts/remote_smoke.py
+++ b/scripts/remote_smoke.py
@@ -3,10 +3,17 @@ from __future__ import annotations
 import os
 import sys
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Any
 from urllib.parse import urlparse
 
 import httpx
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from app.build_info import APP_VERSION
 
 
 DEFAULT_TENANT = "remote-smoke"
@@ -26,6 +33,7 @@ class RemoteSmokeConfig:
     tenant: str = DEFAULT_TENANT
     cors_origin: str | None = None
     untrusted_origin: str = DEFAULT_UNTRUSTED_ORIGIN
+    expected_build_sha: str | None = None
     timeout_seconds: float = 30.0
 
     @property
@@ -57,7 +65,9 @@ def main() -> int:
         f"fixture_stored={summary['fixture_stored']}, "
         f"fixture_posted={summary['fixture_posted']}, "
         f"lineage_records={summary['lineage_records']}, "
-        f"epcis_events={summary['epcis_events']}"
+        f"epcis_events={summary['epcis_events']}, "
+        f"build_version={summary['build_version']}, "
+        f"build_commit={summary['build_commit'] or 'unknown'}"
     )
     return 0
 
@@ -89,6 +99,7 @@ def config_from_env(environ: dict[str, str] | None = None) -> RemoteSmokeConfig:
             environ.get("REGENGINE_REMOTE_UNTRUSTED_ORIGIN")
         )
         or DEFAULT_UNTRUSTED_ORIGIN,
+        expected_build_sha=environ.get("REGENGINE_EXPECTED_BUILD_SHA") or None,
     )
 
 
@@ -108,6 +119,13 @@ def run_remote_smoke(
     try:
         healthz = request_json(client, config, "GET", "/api/healthz", authenticated=False)
         assert_equal(healthz.get("ok"), True, "healthz ok")
+        build = assert_build_info(config, healthz.get("build"))
+        if config.expected_build_sha:
+            assert_build_sha(
+                actual=build.get("commit_sha"),
+                expected=config.expected_build_sha,
+                label="healthz build commit",
+            )
 
         unauthenticated_health = client.get("/api/health")
         assert_status(config, unauthenticated_health, 401, "Basic Auth enforcement")
@@ -223,6 +241,8 @@ def run_remote_smoke(
             "fixture_posted": fixture["posted"],
             "lineage_records": len(records),
             "epcis_events": len(epcis_events),
+            "build_version": build.get("version"),
+            "build_commit": build.get("commit_sha_short"),
         }
     finally:
         if owns_client:
@@ -338,6 +358,32 @@ def assert_equal(actual: Any, expected: Any, label: str) -> None:
 def assert_in(member: Any, container: Any, label: str) -> None:
     if member not in container:
         raise RemoteSmokeFailure(f"{label}: expected {member!r} to be present")
+
+
+def assert_build_info(config: RemoteSmokeConfig, build: Any) -> dict[str, Any]:
+    if not isinstance(build, dict):
+        raise RemoteSmokeFailure("healthz build: expected build metadata object")
+    assert_equal(build.get("version"), APP_VERSION, "healthz build version")
+    for field in ("commit_sha", "commit_sha_short", "branch", "deployment_id"):
+        value = build.get(field)
+        if value is not None and not isinstance(value, str):
+            raise RemoteSmokeFailure(f"healthz build {field}: expected string or null")
+    return build
+
+
+def assert_build_sha(actual: Any, expected: str, label: str) -> None:
+    if not isinstance(actual, str) or not actual:
+        raise RemoteSmokeFailure(f"{label}: expected deployed commit {expected[:12]}, got none")
+    if not _sha_prefix_match(actual, expected):
+        raise RemoteSmokeFailure(
+            f"{label}: expected deployed commit {expected[:12]}, got {actual[:12]}"
+        )
+
+
+def _sha_prefix_match(actual: str, expected: str) -> bool:
+    actual = actual.strip().lower()
+    expected = expected.strip().lower()
+    return actual.startswith(expected) or expected.startswith(actual)
 
 
 def normalize_base_url(value: str) -> str:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -8,6 +8,7 @@ import logging
 import pytest
 from fastapi.testclient import TestClient
 
+from app.build_info import BRANCH_ENV_VARS, COMMIT_SHA_ENV_VARS, DEPLOYMENT_ID_ENV_VARS
 from app.main import app, controller, cors_origins_from_env, scenario_saves
 from app.models import SimulationConfig
 from app.regengine_client import LiveIngestResult
@@ -182,6 +183,35 @@ def test_basic_auth_is_optional_but_enforced_when_configured(monkeypatch):
         "username": "demo-user",
         "uses_default_storage": False,
     }
+
+
+def test_health_routes_include_build_metadata_from_whitelisted_env(monkeypatch):
+    for name in COMMIT_SHA_ENV_VARS + BRANCH_ENV_VARS + DEPLOYMENT_ID_ENV_VARS:
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setenv("REGENGINE_APP_VERSION", "2.4.6")
+    monkeypatch.setenv("REGENGINE_BUILD_SHA", "abcdef1234567890")
+    monkeypatch.setenv("REGENGINE_BUILD_BRANCH", "codex/build-health-info")
+    monkeypatch.setenv("REGENGINE_DEPLOYMENT_ID", "deploy-123")
+    monkeypatch.setenv("REGENGINE_REMOTE_PASSWORD", "should-not-appear")
+
+    healthz = client.get("/api/healthz")
+    assert healthz.status_code == 200
+    healthz_build = healthz.json()["build"]
+    assert healthz_build == {
+        "version": "2.4.6",
+        "commit_sha": "abcdef1234567890",
+        "commit_sha_short": "abcdef1",
+        "commit_source": "REGENGINE_BUILD_SHA",
+        "branch": "codex/build-health-info",
+        "branch_source": "REGENGINE_BUILD_BRANCH",
+        "deployment_id": "deploy-123",
+        "deployment_source": "REGENGINE_DEPLOYMENT_ID",
+    }
+    assert "should-not-appear" not in json.dumps(healthz.json())
+
+    health = client.get("/api/health")
+    assert health.status_code == 200
+    assert health.json()["build"] == healthz_build
 
 
 def test_basic_auth_blocks_state_changes_from_untrusted_browser_origins(monkeypatch):

--- a/tests/test_browser_smoke.py
+++ b/tests/test_browser_smoke.py
@@ -1,6 +1,8 @@
+import httpx
 import pytest
 
-from scripts.browser_smoke import _browser_context_options, _load_config
+from app.build_info import APP_VERSION
+from scripts.browser_smoke import _browser_context_options, _check_healthz_build, _load_config
 
 
 def test_browser_smoke_config_uses_browser_env(monkeypatch):
@@ -8,6 +10,7 @@ def test_browser_smoke_config_uses_browser_env(monkeypatch):
     monkeypatch.setenv("REGENGINE_BROWSER_USERNAME", "demo-user")
     monkeypatch.setenv("REGENGINE_BROWSER_PASSWORD", "demo-pass")
     monkeypatch.setenv("REGENGINE_BROWSER_TENANT", "browser-smoke")
+    monkeypatch.setenv("REGENGINE_BROWSER_EXPECTED_BUILD_SHA", "abcdef1234567890")
 
     config = _load_config()
 
@@ -15,6 +18,7 @@ def test_browser_smoke_config_uses_browser_env(monkeypatch):
     assert config.username == "demo-user"
     assert config.password == "demo-pass"
     assert config.tenant == "browser-smoke"
+    assert config.expected_build_sha == "abcdef1234567890"
     assert _browser_context_options(config) == {
         "http_credentials": {
             "username": "demo-user",
@@ -29,6 +33,7 @@ def test_browser_smoke_config_falls_back_to_remote_env(monkeypatch):
     monkeypatch.setenv("REGENGINE_REMOTE_USERNAME", "remote-user")
     monkeypatch.setenv("REGENGINE_REMOTE_PASSWORD", "remote-pass")
     monkeypatch.setenv("REGENGINE_REMOTE_TENANT", "remote-browser-smoke")
+    monkeypatch.setenv("REGENGINE_EXPECTED_BUILD_SHA", "123456abcdef")
 
     config = _load_config()
 
@@ -36,6 +41,7 @@ def test_browser_smoke_config_falls_back_to_remote_env(monkeypatch):
     assert config.username == "remote-user"
     assert config.password == "remote-pass"
     assert config.tenant == "remote-browser-smoke"
+    assert config.expected_build_sha == "123456abcdef"
 
 
 def test_browser_smoke_config_requires_username_password_pair(monkeypatch):
@@ -45,3 +51,44 @@ def test_browser_smoke_config_requires_username_password_pair(monkeypatch):
 
     with pytest.raises(RuntimeError, match="must be provided together"):
         _load_config()
+
+
+def test_browser_smoke_checks_expected_healthz_build(monkeypatch):
+    def fake_get(url, timeout):
+        assert url == "https://demo.example.test/api/healthz"
+        assert timeout == 5.0
+        return httpx.Response(
+            200,
+            request=httpx.Request("GET", url),
+            json={
+                "ok": True,
+                "build": {
+                    "version": APP_VERSION,
+                    "commit_sha": "abcdef1234567890",
+                },
+            },
+        )
+
+    monkeypatch.setattr("scripts.browser_smoke.httpx.get", fake_get)
+
+    _check_healthz_build("https://demo.example.test", "abcdef1")
+
+
+def test_browser_smoke_rejects_stale_healthz_build(monkeypatch):
+    monkeypatch.setattr(
+        "scripts.browser_smoke.httpx.get",
+        lambda url, timeout: httpx.Response(
+            200,
+            request=httpx.Request("GET", url),
+            json={
+                "ok": True,
+                "build": {
+                    "version": APP_VERSION,
+                    "commit_sha": "abcdef1234567890",
+                },
+            },
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="build commit mismatch"):
+        _check_healthz_build("https://demo.example.test", "fedcba9876543210")

--- a/tests/test_remote_smoke.py
+++ b/tests/test_remote_smoke.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import httpx
 import pytest
 
+from app.build_info import APP_VERSION
 from scripts.remote_smoke import (
     DEFAULT_TENANT,
     FRESH_CUT_OUTPUT_LOT,
@@ -28,6 +29,17 @@ def test_config_from_env_requires_connection_and_auth_values():
     assert config.base_url == "https://demo.example.com"
     assert config.tenant == DEFAULT_TENANT
     assert config.allowed_origin == "https://demo.example.com"
+    assert config.expected_build_sha is None
+
+    expected_config = config_from_env(
+        {
+            "REGENGINE_REMOTE_BASE_URL": "https://demo.example.com/",
+            "REGENGINE_REMOTE_USERNAME": "demo",
+            "REGENGINE_REMOTE_PASSWORD": "secret-password",
+            "REGENGINE_EXPECTED_BUILD_SHA": "abcdef1234567890",
+        }
+    )
+    assert expected_config.expected_build_sha == "abcdef1234567890"
 
 
 def test_remote_smoke_success_uses_basic_auth_and_dedicated_tenant():
@@ -50,6 +62,8 @@ def test_remote_smoke_success_uses_basic_auth_and_dedicated_tenant():
         "fixture_posted": 13,
         "lineage_records": 3,
         "epcis_events": 1,
+        "build_version": APP_VERSION,
+        "build_commit": "abcdef1",
     }
 
     healthz = server.requests[0]
@@ -92,6 +106,23 @@ def test_remote_smoke_redacts_password_from_failure_messages():
     assert "[redacted]" in failure_message
 
 
+def test_remote_smoke_fails_when_expected_build_sha_does_not_match():
+    server = FakeRemoteServer()
+    config = RemoteSmokeConfig(
+        base_url="https://demo.example.com",
+        username="demo",
+        password="secret-password",
+        expected_build_sha="fedcba9876543210",
+    )
+
+    with httpx.Client(
+        base_url=config.base_url,
+        transport=httpx.MockTransport(server.handle),
+    ) as client:
+        with pytest.raises(RemoteSmokeFailure, match="healthz build commit"):
+            run_remote_smoke(config, client=client)
+
+
 class FakeRemoteServer:
     def __init__(self, *, fail_reset: bool = False) -> None:
         self.fail_reset = fail_reset
@@ -102,7 +133,17 @@ class FakeRemoteServer:
         self.requests.append(request)
         path = request.url.path
         if path == "/api/healthz":
-            return httpx.Response(200, json={"ok": True})
+            return httpx.Response(
+                200,
+                json={
+                    "ok": True,
+                    "build": {
+                        "version": APP_VERSION,
+                        "commit_sha": "abcdef1234567890",
+                        "commit_sha_short": "abcdef1",
+                    },
+                },
+            )
         if path == "/api/health":
             if "authorization" not in request.headers:
                 return httpx.Response(401, json={"detail": "Not authenticated"})


### PR DESCRIPTION
## Summary
- add public non-secret build metadata to `/api/healthz` and `/api/health`
- make remote smoke and browser smoke fail fast when expected build SHA does not match the deployed health metadata
- pass the workflow commit into manual/nightly remote smoke workflows and document Railway build SHA variables

## Tests
- `pytest`
- `python3 scripts/smoke_regression.py`
- `python3 scripts/browser_smoke.py`
- `node --check app/static/app.js`
- `python3 -m compileall app scripts`
- `git diff --check`