### PR TITLE
Harden stack validation and automation backlog

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,16 +26,23 @@ jobs:
           cache: pip
           cache-dependency-path: |
             requirements.txt
+            requirements-dev.txt
             requirements-browser.txt
             pyproject.toml
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
+          pip install -r requirements-dev.txt
 
       - name: Run tests
         run: pytest
+
+      - name: Check dependency health
+        run: |
+          pip check
+          pip-audit -r requirements.txt
+          bandit -q -r app scripts
 
   browser-smoke:
     runs-on: ubuntu-latest

--- a/.github/workflows/codex-autopilot.yml
+++ b/.github/workflows/codex-autopilot.yml
@@ -38,15 +38,22 @@ jobs:
           cache: pip
           cache-dependency-path: |
             requirements.txt
+            requirements-dev.txt
             pyproject.toml
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
+          pip install -r requirements-dev.txt
 
       - name: Run baseline tests
         run: pytest
+
+      - name: Validate Codex Autopilot secrets
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: |
+          test -n "$OPENAI_API_KEY" || { echo "OPENAI_API_KEY secret is required for Codex Autopilot"; exit 1; }
 
       - name: Run Codex
         id: run_codex
@@ -58,6 +65,12 @@ jobs:
           safety-strategy: drop-sudo
           sandbox: workspace-write
           codex-args: '["--full-auto"]'
+
+      - name: Explain Codex Action failure
+        if: failure() && steps.run_codex.outcome == 'failure'
+        run: |
+          echo "::error::Codex Action failed before producing an output file. Confirm OPENAI_API_KEY is valid, then inspect the uploaded Codex artifact and action logs."
+          exit 1
 
       - name: Run post-change tests
         run: pytest
@@ -107,9 +120,6 @@ jobs:
             - Prompt file: `.github/codex/prompts/autobuild.md`
             - Guidance files: `AGENTS.md` and `.agents/skills/regengine-api-contract/SKILL.md`
             - Transcript + patch: download the workflow artifact from this run
-          labels: |
-            codex
-            autopilot
           add-paths: |
             .github/**
             .agents/**
@@ -122,6 +132,8 @@ jobs:
             tests/**
             pyproject.toml
             requirements.txt
+            requirements-dev.txt
+            requirements-browser.txt
 
       - name: Enable auto-merge
         if: >-

--- a/DEPLOYMENT_PROFILES.md
+++ b/DEPLOYMENT_PROFILES.md
@@ -298,6 +298,7 @@ Use these patterns when diagnosing a shared demo:
 - `status=403` on simulator actions with valid Basic Auth usually means the browser `Origin` or `Referer` is not in `REGENGINE_CORS_ORIGINS`.
 - Empty state after restart usually means the Railway volume is missing or `REGENGINE_DATA_DIR` is not `/data`.
 - Live delivery failures should be diagnosed from the dashboard delivery monitor and sanitized record status before retrying with corrected live endpoint, API key, and tenant id.
+- Uvicorn startup `INFO` lines can appear as `level=error` in Railway logs. Treat that as log-label noise unless there is a Python traceback, failed deployment status, or HTTP 5xx.
 
 ## Profile Verification Checklist
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,9 @@ PROMPT_FOR_CODEX.md      # Paste-ready Codex task prompt
 RELEASE_CHECKLIST.md     # Demo-ready release gate
 pyproject.toml
 railway.json             # Railway Docker build and healthcheck config
-requirements.txt
+requirements.txt         # Runtime dependencies used by Docker/shared demo
+requirements-dev.txt     # Local test, audit, and maintenance tooling
+requirements-browser.txt # Runtime + Playwright for dashboard smoke checks
 ```
 
 ## Quick start (local dev)
@@ -96,7 +98,7 @@ Requires **Python 3.11+**.
 # From the project root
 python3 -m venv .venv
 source .venv/bin/activate
-pip install -r requirements.txt
+pip install -r requirements-dev.txt
 
 # Run the dev server (auto-reload)
 uvicorn app.main:app --reload
@@ -115,6 +117,7 @@ Event records are stored as JSONL at `config.persist_path` (`data/events.jsonl` 
 ## Running tests
 
 ```bash
+pip install -r requirements-dev.txt
 pytest
 ```
 
@@ -303,7 +306,7 @@ The dashboard fixture loader resets the current event log before loading the sel
 
 ## FDA export presets
 
-`GET /api/mock/regengine/export/fda-request` still returns the same 11-column FDA request CSV and remains backward compatible with optional `start_date` and `end_date` filters. It now also accepts:
+`GET /api/mock/regengine/export/fda-request` still returns the same 11-column FDA request CSV and remains backward compatible with optional `start_date` and `end_date` filters. Date filters must be valid inclusive `YYYY-MM-DD` dates, and `start_date` must not be later than `end_date`. It now also accepts:
 
 - `preset`: one of `all_records`, `lot_trace`, `shipment_handoff`, `receiving_log`, or `transformation_batches`
 - `traceability_lot_code`: optional for most presets, required for `lot_trace`
@@ -319,6 +322,8 @@ Supported query parameters:
 - `start_date`: optional inclusive `YYYY-MM-DD`
 - `end_date`: optional inclusive `YYYY-MM-DD`
 - `traceability_lot_code`: optional lot code; when supplied, the export uses the same transitive lineage graph as `/api/lineage/{traceability_lot_code}`
+
+Invalid date formats, impossible dates, and inverted ranges return `400` so operators catch export filter mistakes before sharing files.
 
 The dashboard exposes a `Download EPCIS` control beside the FDA CSV export. It uses the same optional lot code and date filters as the CSV export panel, but does not apply FDA-only preset filters.
 
@@ -697,6 +702,8 @@ Common failure patterns:
 - Volume/storage failures: `/api/health` should report tenant-scoped paths under `REGENGINE_DATA_DIR`; confirm Railway has a volume mounted at `/data` and `REGENGINE_DATA_DIR=/data`.
 - Stale deployment failures: `/api/healthz` should report the expected `build.commit_sha_short`; if it does not, redeploy current `main` and update `REGENGINE_BUILD_SHA`.
 - Live delivery failures: request logs identify the route and tenant while dashboard delivery stats show the sanitized delivery error; confirm endpoint, API key, and tenant id before retrying.
+- Local dependency conflicts: create a fresh `.venv` and install `requirements-dev.txt` before diagnosing app failures; global Python packages such as OpenTelemetry or Semgrep can drift independently of this repo.
+- Railway startup log noise: Uvicorn startup messages may appear with `level=error` in Railway logs. Treat them as noise unless there is a traceback, failed deployment, or HTTP 5xx.
 
 If the health check fails before request logs appear, the first place to look is `uvicorn.err.log` or `railway logs --deployment` for a Python traceback or startup error.
 

--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -9,6 +9,9 @@ Use this checklist before tagging a demo-ready build or handing the simulator to
 - [ ] `python3 scripts/browser_smoke.py`
 - [ ] `node --check app/static/app.js`
 - [ ] `python3 -m compileall app scripts`
+- [ ] `pip check`
+- [ ] `pip-audit -r requirements.txt`
+- [ ] `bandit -q -r app scripts`
 - [ ] `git diff --check`
 
 ## Contract Checks

--- a/app/controller.py
+++ b/app/controller.py
@@ -15,6 +15,7 @@ from .models import (
     DemoFixtureId,
     DemoFixtureLoadRequest,
     DemoFixtureLoadResponse,
+    DeliveryConfig,
     DeliveryRetryRequest,
     DeliveryRetryResponse,
     DestinationMode,
@@ -81,6 +82,7 @@ class SimulationController:
 
     async def start(self, config: SimulationConfig) -> None:
         async with self._lock:
+            _validate_live_delivery(config.delivery)
             previous_config = self.config
             self.config = config
             self.store.configure(config.persist_path)
@@ -95,8 +97,10 @@ class SimulationController:
         if not self.running:
             return
         self._stop_event.set()
-        assert self._task is not None
-        await self._task
+        task = self._task
+        if task is None:
+            return
+        await task
         self._task = None
         await self._publish_update()
 
@@ -116,6 +120,7 @@ class SimulationController:
 
     async def step(self, batch_size: int | None = None) -> StepResponse:
         async with self._lock:
+            _validate_live_delivery(self.config.delivery)
             size = batch_size or self.config.batch_size
             events = []
             lineages = []
@@ -170,6 +175,7 @@ class SimulationController:
             persist_path = request.persist_path or self.config.persist_path
             source = request.source or self.config.source
             delivery = request.delivery or self.config.delivery
+            _validate_live_delivery(delivery)
             replay_config = self.config.model_copy(
                 update={
                     "source": source,
@@ -220,6 +226,7 @@ class SimulationController:
         async with self._lock:
             source = request.source or self.config.source
             delivery = request.delivery or self.config.delivery
+            _validate_live_delivery(delivery)
             import_config = self.config.model_copy(
                 update={
                     "source": source,
@@ -303,6 +310,7 @@ class SimulationController:
         async with self._lock:
             source = request.source or self.config.source
             delivery = request.delivery or self.config.delivery
+            _validate_live_delivery(delivery)
             self.config = self.config.model_copy(
                 update={
                     "source": source,
@@ -448,6 +456,7 @@ class SimulationController:
                     error="Retry requires mock or live delivery mode.",
                 )
             else:
+                _validate_live_delivery(delivery)
                 posted = 0
                 failed = 0
                 updated_records: list[StoredEventRecord] = []
@@ -660,3 +669,8 @@ class SimulationController:
             persist_path=snapshot.config.persist_path,
             delivery_mode=snapshot.config.delivery.mode,
         )
+
+
+def _validate_live_delivery(delivery: DeliveryConfig) -> None:
+    if delivery.mode == DestinationMode.LIVE and (not delivery.api_key or not delivery.tenant_id):
+        raise ValueError("Live delivery requires both api_key and tenant_id")

--- a/app/csv_importer.py
+++ b/app/csv_importer.py
@@ -90,7 +90,11 @@ def parse_csv_import(
         if row_errors:
             errors.extend(row_errors)
             continue
-        assert event is not None
+        if event is None:
+            errors.append(
+                CSVImportError(row=row_number, field="row", message="Row could not be parsed")
+            )
+            continue
         events.append(event)
         parent_lot_codes.append(parents)
         warnings.extend(row_warnings)

--- a/app/engine.py
+++ b/app/engine.py
@@ -52,7 +52,8 @@ class LegitFlowEngine:
         self.reset(seed, scenario=scenario)
 
     def reset(self, seed: int | None = None, scenario: ScenarioId | str | None = None) -> None:
-        self.rng = random.Random(seed if seed is not None else self._initial_seed)
+        # Deterministic simulator RNG, not security-sensitive.
+        self.rng = random.Random(seed if seed is not None else self._initial_seed)  # nosec B311
         self._lot_counter = count(1)
         self._ref_counter = count(1)
         self._time_cursor = datetime.now(UTC) - timedelta(hours=12)
@@ -166,7 +167,7 @@ class LegitFlowEngine:
                 "harvest_date": timestamp.date().isoformat(),
                 "farm_location": farm.name,
                 "field_name": f"Field-{self.rng.randint(1, 18)}",
-                "immediate_subsequent_recipient": self.rng.choice(self.coolers + self.packers).name,
+                "immediate_subsequent_recipient": self.rng.choice(self.coolers).name,
                 "reference_document_type": lot.current_reference_type,
                 "reference_document_number": reference_number,
                 "traceability_lot_code_source_reference": lot.tlc_source_reference,

--- a/app/main.py
+++ b/app/main.py
@@ -4,10 +4,11 @@ import asyncio
 import json
 import logging
 import os
+import re
 import shutil
 import time
 from contextlib import asynccontextmanager
-from datetime import UTC, datetime
+from datetime import UTC, date, datetime
 from pathlib import Path
 from threading import RLock
 from typing import Any
@@ -516,6 +517,7 @@ async def mock_fda_request_export(
     traceability_lot_code: str | None = Query(default=None),
 ) -> PlainTextResponse:
     active_controller = _active_controller(request)
+    start_filter, end_filter = _parse_export_date_filters(start_date=start_date, end_date=end_date)
     definition = FDA_EXPORT_PRESETS[preset]
     if definition.requires_lot_code and not traceability_lot_code:
         raise HTTPException(status_code=400, detail="traceability_lot_code is required for this export preset")
@@ -524,9 +526,12 @@ async def mock_fda_request_export(
         records = active_controller.store.lineage(traceability_lot_code)
         if not records:
             raise HTTPException(status_code=404, detail="No records found for that lot code")
-        records = _filter_records_between(records, start_date=start_date, end_date=end_date)
+        records = _filter_records_between(records, start_date=start_filter, end_date=end_filter)
     else:
-        records = active_controller.store.all_between(start_date=start_date, end_date=end_date)
+        records = active_controller.store.all_between(
+            start_date=start_filter.isoformat() if start_filter else None,
+            end_date=end_filter.isoformat() if end_filter else None,
+        )
     records = apply_fda_export_preset(records, preset)
     csv_text = render_fda_request_csv(records, location_gln=active_controller.engine.location_gln)
     return PlainTextResponse(
@@ -544,13 +549,17 @@ async def mock_epcis_export(
     traceability_lot_code: str | None = Query(default=None),
 ) -> JSONResponse:
     active_controller = _active_controller(request)
+    start_filter, end_filter = _parse_export_date_filters(start_date=start_date, end_date=end_date)
     if traceability_lot_code:
         records = active_controller.store.lineage(traceability_lot_code)
         if not records:
             raise HTTPException(status_code=404, detail="No records found for that lot code")
-        records = _filter_records_between(records, start_date=start_date, end_date=end_date)
+        records = _filter_records_between(records, start_date=start_filter, end_date=end_filter)
     else:
-        records = active_controller.store.all_between(start_date=start_date, end_date=end_date)
+        records = active_controller.store.all_between(
+            start_date=start_filter.isoformat() if start_filter else None,
+            end_date=end_filter.isoformat() if end_filter else None,
+        )
 
     document = render_epcis_document(
         records,
@@ -566,18 +575,40 @@ async def mock_epcis_export(
 
 def _filter_records_between(
     records: list[Any],
-    start_date: str | None = None,
-    end_date: str | None = None,
+    start_date: date | None = None,
+    end_date: date | None = None,
 ) -> list[Any]:
     filtered = []
     for record in records:
-        day = record.event.timestamp.date().isoformat()
+        day = record.event.timestamp.date()
         if start_date and day < start_date:
             continue
         if end_date and day > end_date:
             continue
         filtered.append(record)
     return sorted(filtered, key=lambda record: record.event.timestamp)
+
+
+def _parse_export_date_filters(
+    start_date: str | None,
+    end_date: str | None,
+) -> tuple[date | None, date | None]:
+    start_filter = _parse_export_date("start_date", start_date)
+    end_filter = _parse_export_date("end_date", end_date)
+    if start_filter and end_filter and start_filter > end_filter:
+        raise HTTPException(status_code=400, detail="start_date must be before or equal to end_date")
+    return start_filter, end_filter
+
+
+def _parse_export_date(field_name: str, value: str | None) -> date | None:
+    if value is None:
+        return None
+    if not re.fullmatch(r"\d{4}-\d{2}-\d{2}", value):
+        raise HTTPException(status_code=400, detail=f"{field_name} must be YYYY-MM-DD")
+    try:
+        return date.fromisoformat(value)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=f"{field_name} must be a valid date") from exc
 
 
 def _tenant_context(request: Request) -> TenantContext:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,4 @@
+-r requirements.txt
+pytest>=8.0.0
+bandit>=1.7.10
+pip-audit>=2.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@ fastapi>=0.111.0
 uvicorn[standard]>=0.30.0
 httpx>=0.27.0
 pydantic>=2.8.0
-pytest>=8.0.0

--- a/scripts/browser_smoke.py
+++ b/scripts/browser_smoke.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import os
 import socket
-import subprocess
+import subprocess  # nosec B404
 import sys
 import tempfile
 import time
@@ -76,7 +76,8 @@ def _base_url(configured_base_url: str | None) -> Iterator[str]:
         env["REGENGINE_CORS_ORIGINS"] = base_url
         env.pop("REGENGINE_BASIC_AUTH_USERNAME", None)
         env.pop("REGENGINE_BASIC_AUTH_PASSWORD", None)
-        process = subprocess.Popen(
+        # Local smoke harness starts a fixed uvicorn argv with no user input.
+        process = subprocess.Popen(  # nosec B603
             [
                 sys.executable,
                 "-m",
@@ -180,7 +181,7 @@ def _run_dashboard_smoke(base_url: str, config: BrowserSmokeConfig) -> None:
                 output_dir.mkdir(parents=True, exist_ok=True)
                 page.screenshot(path=str(output_dir / "browser_smoke_failure.png"), full_page=True)
             except Exception:
-                pass
+                console_errors.append("Could not capture failure screenshot")
         raise
     finally:
         if console_errors and not failed:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -11,7 +11,7 @@ from fastapi.testclient import TestClient
 from app.build_info import BRANCH_ENV_VARS, COMMIT_SHA_ENV_VARS, DEPLOYMENT_ID_ENV_VARS
 from app.main import app, controller, cors_origins_from_env, scenario_saves
 from app.models import SimulationConfig
-from app.regengine_client import LiveIngestResult
+from app.regengine_client import LiveIngestResult, LiveRegEngineDeliveryError
 from app.scenarios import ScenarioId, get_scenario
 
 
@@ -919,6 +919,23 @@ def test_epcis_export_supports_date_filters_and_missing_lot_errors(tmp_path):
     assert missing_response.status_code == 404
 
 
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/api/mock/regengine/export/fda-request?start_date=banana",
+        "/api/mock/regengine/export/fda-request?end_date=2026-99-99",
+        "/api/mock/regengine/export/fda-request?start_date=2026-03-01&end_date=2026-02-01",
+        "/api/mock/regengine/export/epcis?start_date=banana",
+        "/api/mock/regengine/export/epcis?end_date=2026-99-99",
+        "/api/mock/regengine/export/epcis?start_date=2026-03-01&end_date=2026-02-01",
+    ],
+)
+def test_exports_reject_invalid_date_filters(path):
+    response = client.get(path)
+
+    assert response.status_code == 400
+
+
 def test_start_applies_configured_persist_path_and_keeps_mock_default(tmp_path):
     custom_path = tmp_path / "start-events.jsonl"
     response = client.post(
@@ -940,6 +957,61 @@ def test_start_applies_configured_persist_path_and_keeps_mock_default(tmp_path):
         assert body["stats"]["persist_path"] == str(custom_path)
     finally:
         client.post("/api/simulate/stop")
+
+
+def test_start_rejects_live_delivery_without_credentials(tmp_path):
+    custom_path = tmp_path / "start-live-missing-creds.jsonl"
+    response = client.post(
+        "/api/simulate/start",
+        json={
+            "config": {
+                "interval_seconds": 0.01,
+                "batch_size": 1,
+                "seed": 204,
+                "persist_path": str(custom_path),
+                "delivery": {"mode": "live"},
+            }
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Live delivery requires both api_key and tenant_id"
+    assert client.get("/api/simulate/status").json()["running"] is False
+    assert not custom_path.exists()
+
+
+def test_live_delivery_operations_reject_missing_credentials(tmp_path):
+    custom_path = tmp_path / "live-missing-creds-events.jsonl"
+    client.post(
+        "/api/simulate/reset",
+        json={
+            "batch_size": 1,
+            "seed": 204,
+            "persist_path": str(custom_path),
+            "delivery": {"mode": "live"},
+        },
+    )
+
+    operations = [
+        client.post("/api/simulate/step"),
+        client.post("/api/simulate/replay"),
+        client.post(
+            "/api/demo-fixtures/fresh_cut_transformation/load",
+            json={"delivery": {"mode": "live"}},
+        ),
+        client.post(
+            "/api/import/csv",
+            json={
+                "import_type": "seed_lots",
+                "csv_text": "traceability_lot_code,product_description,quantity,unit_of_measure,location_name\nTLC-LIVE,Romaine,1,cases,Farm",
+                "delivery": {"mode": "live"},
+            },
+        ),
+    ]
+
+    for response in operations:
+        assert response.status_code == 400
+        assert response.json()["detail"] == "Live delivery requires both api_key and tenant_id"
 
 
 def test_reset_applies_configured_persist_path_for_next_step(tmp_path):
@@ -967,18 +1039,40 @@ def test_reset_applies_configured_persist_path_for_next_step(tmp_path):
 
 
 def test_failed_live_delivery_surfaces_retry_feedback_and_can_retry_to_mock(tmp_path):
-    custom_path = tmp_path / "failed-delivery-events.jsonl"
-    client.post(
-        "/api/simulate/reset",
-        json={
-            "batch_size": 1,
-            "seed": 204,
-            "persist_path": str(custom_path),
-            "delivery": {"mode": "live"},
-        },
-    )
+    class FailingLiveClient:
+        async def ingest(self, payload, config):  # noqa: ANN001
+            raise LiveRegEngineDeliveryError(
+                "temporary outage",
+                {
+                    "delivery_mode": "live",
+                    "endpoint_host": "www.regengine.co",
+                    "endpoint_path": "/api/v1/webhooks/ingest",
+                    "idempotency_key": "idem-failure-123",
+                    "status_code": 503,
+                },
+            )
 
-    step_response = client.post("/api/simulate/step")
+    original_live_client = controller.live_client
+    controller.live_client = FailingLiveClient()
+    custom_path = tmp_path / "failed-delivery-events.jsonl"
+    try:
+        client.post(
+            "/api/simulate/reset",
+            json={
+                "batch_size": 1,
+                "seed": 204,
+                "persist_path": str(custom_path),
+                "delivery": {
+                    "mode": "live",
+                    "api_key": "live-api-secret",
+                    "tenant_id": "live-tenant-secret",
+                },
+            },
+        )
+
+        step_response = client.post("/api/simulate/step")
+    finally:
+        controller.live_client = original_live_client
 
     assert step_response.status_code == 200
     step_body = step_response.json()
@@ -988,13 +1082,13 @@ def test_failed_live_delivery_surfaces_retry_feedback_and_can_retry_to_mock(tmp_
     assert step_body["delivery_status"] == "failed"
     assert step_body["delivery_mode"] == "live"
     assert step_body["delivery_attempts"] == 1
-    assert "api_key" in step_body["error"]
+    assert "temporary outage" in step_body["error"]
 
     status = client.get("/api/simulate/status").json()
     assert status["stats"]["delivery"]["failed"] == 1
     assert status["stats"]["delivery"]["retryable"] == 1
     assert status["stats"]["delivery"]["attempts"] == 1
-    assert "api_key" in status["stats"]["delivery"]["last_error"]
+    assert "temporary outage" in status["stats"]["delivery"]["last_error"]
 
     failed_record = client.get("/api/events?limit=1").json()["events"][0]
     assert failed_record["delivery_status"] == "failed"

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -21,6 +21,20 @@ def test_initial_packing_sources_previously_cooled_lots():
     assert packing_seen
 
 
+def test_harvest_immediate_subsequent_recipients_are_coolers():
+    engine = LegitFlowEngine(seed=204)
+    cooler_names = {cooler.name for cooler in engine.coolers}
+    harvest_recipients = set()
+
+    for _ in range(80):
+        event, _ = engine.next_event()
+        if event.cte_type == CTEType.HARVESTING:
+            harvest_recipients.add(event.kdes["immediate_subsequent_recipient"])
+
+    assert harvest_recipients
+    assert harvest_recipients <= cooler_names
+
+
 def test_engine_emits_all_supported_ctes_and_lineage():
     engine = LegitFlowEngine(seed=204)
     expected_ctes = set(CTEType)


### PR DESCRIPTION
## Summary
- create the stack findings backlog and implement the actionable hardening items
- add Codex Autopilot secret preflight and remove missing custom labels from PR creation
- enforce cooler-only harvest recipients, strict export dates, and live credential preflight before delivery operations
- split runtime/dev dependencies and add CI dependency/security checks
- document venv-first troubleshooting and Railway startup log label noise

## Tests
- `pytest`
- `python3 scripts/smoke_regression.py`
- `python3 scripts/browser_smoke.py`
- `node --check app/static/app.js`
- `python3 -m compileall app scripts`
- `bandit -q -r app scripts`
- clean temp venv: `pip check`
- clean temp venv: `pip-audit -r requirements.txt`
- `git diff --check`
- Railway health probe: `/api/healthz` 200, `/api/health` 401 without auth

Closes #30
Closes #31
Closes #32
Closes #33
Closes #34
Closes #35
Closes #36
Closes #37
Closes #38
