### PR TITLE
fix: restore defense-in-depth api_key masking dropped in #40 merge

### DIFF
--- a/app/controller.py
+++ b/app/controller.py
@@ -35,7 +35,7 @@ from .models import (
 from .regengine_client import LiveRegEngineClient, LiveRegEngineDeliveryError
 from .scenario_saves import ScenarioSaveStore
 from .scenarios import ScenarioId, get_scenario
-from .store import EventStore
+from .store import EventStore, mask_secret_in_payload, mask_secret_in_string
 
 
 @dataclass(slots=True)
@@ -541,12 +541,13 @@ class SimulationController:
         if config.delivery.mode == DestinationMode.NONE:
             return DeliveryOutcome()
 
+        api_key = config.delivery.api_key
         attempted_at = datetime.now(UTC)
         try:
             if config.delivery.mode == DestinationMode.MOCK:
                 response = self.mock_service.ingest(payload).model_dump(mode="json")
                 return DeliveryOutcome(
-                    response=response,
+                    response=mask_secret_in_payload(response, api_key),
                     delivery_status="posted",
                     posted=len(payload.events),
                     delivery_attempts=1,
@@ -560,7 +561,7 @@ class SimulationController:
             if config.delivery.mode == DestinationMode.LIVE:
                 result = await self.live_client.ingest(payload, config)
                 return DeliveryOutcome(
-                    response=result.response,
+                    response=mask_secret_in_payload(result.response, api_key),
                     delivery_status="posted",
                     posted=len(payload.events),
                     delivery_attempts=1,
@@ -575,7 +576,7 @@ class SimulationController:
                 failed=len(payload.events),
                 delivery_attempts=1,
                 attempted_at=attempted_at,
-                error_message=str(exc),
+                error_message=mask_secret_in_string(str(exc), api_key),
                 metadata=exc.metadata | {"attempted_event_count": len(payload.events)},
             )
         except Exception as exc:  # pragma: no cover - exercised by live integration, not unit tests
@@ -584,7 +585,7 @@ class SimulationController:
                 failed=len(payload.events),
                 delivery_attempts=1,
                 attempted_at=attempted_at,
-                error_message=str(exc),
+                error_message=mask_secret_in_string(str(exc), api_key),
                 metadata={
                     "delivery_mode": config.delivery.mode.value,
                     "attempted_event_count": len(payload.events),

--- a/app/store.py
+++ b/app/store.py
@@ -25,6 +25,29 @@ def _scrub_secrets(value: Any) -> Any:
     return value
 
 
+def mask_secret_in_string(message: str | None, secret: str | None) -> str | None:
+    if message is None or not secret:
+        return message
+    return message.replace(secret, MASKED_SECRET)
+
+
+def mask_secret_in_payload(value: Any, secret: str | None = None) -> Any:
+    if isinstance(value, dict):
+        masked: dict[str, Any] = {}
+        for key, item in value.items():
+            normalized_key = key.lower().replace("-", "_")
+            if normalized_key in SECRET_FIELD_NAMES:
+                masked[key] = MASKED_SECRET
+            else:
+                masked[key] = mask_secret_in_payload(item, secret)
+        return masked
+    if isinstance(value, list):
+        return [mask_secret_in_payload(item, secret) for item in value]
+    if isinstance(value, str) and secret and secret in value:
+        return value.replace(secret, MASKED_SECRET)
+    return value
+
+
 class EventStore:
     def __init__(self, persist_path: str = "data/events.jsonl", max_records: int = 5000) -> None:
         self.persist_path = Path(persist_path)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1181,6 +1181,101 @@ def test_successful_live_delivery_records_sanitized_audit_metadata(monkeypatch, 
     assert_json_omits(record["delivery_metadata"], "live-api-secret", "live-tenant-secret")
 
 
+def test_failed_live_delivery_masks_api_key_in_error_message(tmp_path):
+    api_key = "live-api-secret-leak"
+
+    class LeakyLiveClient:
+        async def ingest(self, payload, config):  # noqa: ANN001
+            raise LiveRegEngineDeliveryError(
+                f"upstream rejected request with key={api_key} for tenant",
+                {
+                    "delivery_mode": "live",
+                    "endpoint_host": "www.regengine.co",
+                    "endpoint_path": "/api/v1/webhooks/ingest",
+                    "idempotency_key": "idem-leak-1",
+                    "status_code": 401,
+                },
+            )
+
+    original_live_client = controller.live_client
+    controller.live_client = LeakyLiveClient()
+    try:
+        client.post(
+            "/api/simulate/reset",
+            json={
+                "batch_size": 1,
+                "seed": 204,
+                "persist_path": str(tmp_path / "leak-events.jsonl"),
+                "delivery": {
+                    "mode": "live",
+                    "api_key": api_key,
+                    "tenant_id": "live-tenant",
+                },
+            },
+        )
+        step_response = client.post("/api/simulate/step")
+    finally:
+        controller.live_client = original_live_client
+
+    assert step_response.status_code == 200
+    body = step_response.json()
+    assert body["delivery_status"] == "failed"
+    assert "***MASKED***" in body["error"]
+    assert api_key not in body["error"]
+
+    record = client.get("/api/events?limit=1").json()["events"][0]
+    assert_json_omits(record, api_key)
+
+
+def test_successful_live_delivery_masks_api_key_echoed_in_response(monkeypatch, tmp_path):
+    api_key = "live-api-secret-echo"
+
+    class EchoLiveClient:
+        async def ingest(self, payload, config):  # noqa: ANN001
+            return LiveIngestResult(
+                response={
+                    "accepted": len(payload.events),
+                    "events": [
+                        {
+                            "traceability_lot_code": event.traceability_lot_code,
+                            "status": "accepted",
+                        }
+                        for event in payload.events
+                    ],
+                    "echoed_api_key": api_key,
+                    "debug_message": f"received key {api_key}",
+                },
+                metadata={
+                    "delivery_mode": "live",
+                    "endpoint_host": "www.regengine.co",
+                    "endpoint_path": "/api/v1/webhooks/ingest",
+                    "idempotency_key": "idem-echo-1",
+                    "status_code": 200,
+                },
+            )
+
+    monkeypatch.setattr(controller, "live_client", EchoLiveClient())
+    client.post(
+        "/api/simulate/reset",
+        json={
+            "batch_size": 1,
+            "seed": 204,
+            "persist_path": str(tmp_path / "echo-events.jsonl"),
+            "delivery": {
+                "mode": "live",
+                "api_key": api_key,
+                "tenant_id": "live-tenant",
+            },
+        },
+    )
+    step_response = client.post("/api/simulate/step")
+
+    assert step_response.status_code == 200
+    assert step_response.json()["delivery_status"] == "posted"
+    record = client.get("/api/events?limit=1").json()["events"][0]
+    assert_json_omits(record, api_key)
+
+
 def test_delivery_retry_empty_when_no_failed_records():
     response = client.post("/api/delivery/retry")
 


### PR DESCRIPTION
Follow-up to #40 (merged in 6919d70). The merge resolution preserved `_sanitize_public_config` (api_key=None on returned configs) but dropped the original PR's runtime masking on `_deliver_payload` outcomes.

## Context — what's preserved vs. what was dropped

- **Preserved:** `_sanitize_public_config` (`controller.py:635`) zeroes `api_key` on every status/health/stream response. `test_status_surfaces_redact_live_delivery_credentials` covers this.
- **Dropped:** runtime substring masking of `outcome.response` and `outcome.error_message` inside `_deliver_payload`. If the live API ever echoes the key in its body, or if an httpx error string ever contains it, the unmasked key would land in `StoredEventRecord.delivery_response` or `.error`.

## This PR

- Adds `mask_secret_in_payload` and `mask_secret_in_string` in `app/store.py`, alongside the existing `_scrub_secrets` (which only does key-name scrubbing for the persistence path).
- Wires both into `_deliver_payload` at the four post-merge sites: MOCK response, LIVE response, `LiveRegEngineDeliveryError` handler, generic exception handler.
- Adds two regression tests:
  - `LeakyLiveClient` raises an error containing the api_key — asserts the masked sentinel appears and the key doesn't.
  - `EchoLiveClient` returns a response with `echoed_api_key` and a `debug_message` containing the key — asserts it's masked in the persisted record.

Both tests would have failed without these changes, so future merges can't silently drop the masking again.

## Test plan

- [x] `pytest tests/` — 83 passed locally
- [ ] CI green on the PR