### PR TITLE
chore(ci): suppress bandit B105 false positive on MASKED_SECRET sentinel

### DIFF
--- a/app/store.py
+++ b/app/store.py
@@ -9,7 +9,8 @@ from typing import Any, Iterable
 from .models import LineageEdge, LineageNode, StoredEventRecord
 
 
-MASKED_SECRET = "***MASKED***"
+# Sentinel that replaces secrets in scrubbed output. Not a credential.
+MASKED_SECRET = "***MASKED***"  # nosec B105
 SECRET_FIELD_NAMES = {"api_key", "apikey", "x_regengine_api_key", "authorization"}
 
 


### PR DESCRIPTION
`bandit -q -r app scripts` (the "Check dependency health" step in CI's `pytest` job) has been failing on every push to main since PR #40 merged, blocking green CI for everyone. Same failure on the merge runs for #40, #41, and any new PR.

```
>> Issue: [B105:hardcoded_password_string] Possible hardcoded password: '***MASKED***'
   Severity: Low   Confidence: Medium
   Location: app/store.py:12:16
12  MASKED_SECRET = "***MASKED***"
```

This is a false positive — `MASKED_SECRET` is a sentinel that *replaces* secrets in scrubbed output (used by `_scrub_secrets`, `mask_secret_in_payload`, `mask_secret_in_string`). The "SECRET" in the variable name triggers bandit's heuristic.

## This PR

Adds a bare `# nosec B105` annotation matching existing repo convention (`app/engine.py:56`, `scripts/browser_smoke.py:5,80`), plus a preceding explanatory comment.

## Verified locally

- `bandit -q -r app scripts` → exit 0, no warnings
- `pytest tests/` → 83 passed

## What this unblocks

Every PR going forward gets a green `pytest` job again (the bandit step runs first; if it fails the actual pytest run never happens, but locally pytest is still 83/83 so nothing's regressed).

Note: the `browser-smoke` job is also failing on main with an unrelated JS bug (`Cannot read properties of undefined (reading 'checked')`) — that's a separate fix.