### PR TITLE
Align Inflow Lab live ingest with RegEngine webhook contract

### DIFF
--- a/.agents/skills/regengine-api-contract/references/contract.md
+++ b/.agents/skills/regengine-api-contract/references/contract.md
@@ -1,24 +1,131 @@
 # RegEngine integration notes
 
-Reference points captured for this repo:
+Source of truth for what the Inflow Lab sends on the wire when
+`delivery.mode=live`. Mirror of RegEngine's `services/ingestion/app/`
+contract — keep these in sync when the live webhook contract changes.
+
+## Endpoints
 
 - Ingest endpoint: `POST /api/v1/webhooks/ingest`
 - Export endpoint: `GET /v1/fsma/export/fda-request`
 - Forward trace: `GET /v1/fsma/trace/forward/{tlc}`
 - Backward trace: `GET /v1/fsma/trace/backward/{tlc}`
 
-Documented event payload fields:
+## Required headers on `POST /api/v1/webhooks/ingest`
 
-- `cte_type`
-- `traceability_lot_code`
-- `product_description`
-- `quantity`
-- `unit_of_measure`
-- `location_name`
-- `timestamp`
-- `kdes`
+| Header | Required | Source / format |
+|---|---|---|
+| `Content-Type: application/json` | Yes | Always |
+| `X-RegEngine-API-Key` | Yes | Per-tenant API key issued by RegEngine |
+| `X-Tenant-ID` | Recommended | RegEngine resolves tenant from body, then API-key lookup, then RBAC principal — but explicit is safer |
+| `Idempotency-Key` | **Required** | UUID per logical request; RegEngine caches 2xx for 24h tenant-scoped |
+| `X-Webhook-Signature: sha256=<hex>` | Required when `WEBHOOK_HMAC_SECRET` is set on RegEngine | HMAC-SHA256 over the raw request body bytes |
 
-Mock export columns expected by this repo:
+## Webhook HMAC signing
+
+RegEngine's `_verify_webhook_signature` (services/ingestion/app/webhook_router_v2.py
+lines 130–217) enforces HMAC-SHA256 when `WEBHOOK_HMAC_SECRET` is set
+on the ingest service.
+
+The simulator's `LiveRegEngineClient` reads `REGENGINE_WEBHOOK_HMAC_SECRET`
+from the environment. When set:
+
+- Body is JSON-serialized once with `separators=(",",":"), sort_keys=True`.
+- Those exact bytes are sent via `httpx` `content=` (NOT `json=`) so the
+  signed bytes equal the wire bytes.
+- HMAC-SHA256 of body bytes is sent as `X-Webhook-Signature: sha256=<hex>`.
+
+When unset, no signature header is sent and RegEngine's verifier no-ops.
+This matches both sides' migration ramp.
+
+**Production deployments must set the same secret on both sides.**
+
+## CTE types accepted by RegEngine
+
+RegEngine's `WebhookCTEType` (services/ingestion/app/webhook_models.py line 41):
+
+- `growing` — legacy back-compat, normalizes to farm metadata. Simulator never emits.
+- `harvesting`
+- `cooling`
+- `initial_packing`
+- `first_land_based_receiving` — 21 CFR §1.1325, seafood / first-receiver flows.
+  Simulator's `CTEType` enum includes this for hand-crafted fixture / CSV
+  parity, but the default `LegitFlowEngine` does not emit it (no seafood
+  scenario exists yet).
+- `shipping`
+- `receiving`
+- `transformation`
+
+## Per-event payload fields
+
+```json
+{
+  "cte_type": "harvesting",
+  "traceability_lot_code": "TLC-20260427-000001",
+  "product_description": "Romaine Lettuce",
+  "quantity": 500,
+  "unit_of_measure": "cases",
+  "location_name": "Valley Fresh Farms",
+  "location_gln": "0850000001001",
+  "timestamp": "2026-04-27T08:30:00Z",
+  "kdes": { "...": "..." },
+  "input_traceability_lot_codes": null
+}
+```
+
+- `traceability_lot_code` — `min_length=3`, simulator emits `TLC-YYYYMMDD-NNNNNN`.
+- `product_description` — `min_length=1, max_length=500`.
+- `quantity` — `gt=0`.
+- `unit_of_measure` — RegEngine logs but accepts unknown units; simulator
+  uses values in the canonical valid set (`cases`, `lbs`, `kg`, `pallets`, etc.).
+- `location_name` and `location_gln` — at least one required; if both absent,
+  RegEngine's `require_location` validator looks for location-bearing KDEs
+  (`ship_from_location`, `ship_to_location`, `receiving_location`, etc.).
+  The simulator currently emits `location_name` only.
+- `timestamp` — ISO 8601 string. Must not be more than 24h in the future.
+  Older than 90 days accepted but flagged with `_historical_warning`.
+- `input_traceability_lot_codes` — Optional first-class field on RegEngine's
+  `IngestEvent` for transformation CTEs. RegEngine actually reads this from
+  the `kdes` dict in practice, so the simulator passes the value via
+  `kdes["input_traceability_lot_codes"]` and that works on both sides.
+
+## Required KDEs per CTE (RegEngine `REQUIRED_KDES_BY_CTE`)
+
+KDE validation is **strict string lookup**. A typo or a split key (e.g.
+`reference_document_type` instead of `reference_document`) causes the
+event to be rejected with `Missing required KDE '<n>' for <cte> CTE`.
+
+| CTE | Required KDEs (beyond top-level fields) |
+|---|---|
+| `harvesting` | `harvest_date`, `reference_document` (§1.1327(b)(5)) |
+| `cooling` | `cooling_date`, `reference_document` (§1.1330(b)(6)) |
+| `initial_packing` | `packing_date`, `reference_document` (§1.1335(c)(7)), `harvester_business_name` (§1.1335(c)(8)) |
+| `first_land_based_receiving` | `landing_date`, `receiving_location`, `reference_document` (§1.1325(c)(7)) |
+| `shipping` | `ship_date`, `ship_from_location`, `ship_to_location`, `reference_document` (§1.1340(c)(6)), `tlc_source_reference` (§1.1340(c)(7)) |
+| `receiving` | `receive_date`, `receiving_location`, `immediate_previous_source` (§1.1345(c)(5)), `reference_document` (§1.1345(c)(6)), `tlc_source_reference` (§1.1345(c)(7)) |
+| `transformation` | `transformation_date`, `reference_document` (§1.1350(c)(6)) |
+
+**Top-level fields RegEngine treats as KDEs during validation:**
+`traceability_lot_code`, `product_description`, `quantity`,
+`unit_of_measure`, `location_name`, `location_gln`. These come from the
+typed `IngestEvent` fields, not the `kdes` dict — but the simulator
+satisfies them as typed fields too, so the distinction is invisible.
+
+## Idempotency
+
+`Idempotency-Key` is required (`webhook_router_v2.py` line 933,
+`IdempotencyDependency(strict=True)`). The middleware caches 2xx
+responses for 24h, scoped per tenant. The simulator generates a fresh
+`uuid4().hex` per call.
+
+**Known limitation:** if the simulator retries after a 5xx with a fresh
+UUID, RegEngine treats it as a new event. Keep the same idempotency
+key across retries of the same logical event.
+
+## Mock export columns expected by this repo
+
+(Used by the simulator's mock RegEngine endpoint for dashboard / FDA
+preset rendering — does NOT affect live ingest.)
 
 - Traceability Lot Code
 - Traceability Lot Code Description

--- a/app/engine.py
+++ b/app/engine.py
@@ -168,6 +168,7 @@ class LegitFlowEngine:
                 "farm_location": farm.name,
                 "field_name": f"Field-{self.rng.randint(1, 18)}",
                 "immediate_subsequent_recipient": self.rng.choice(self.coolers).name,
+                "reference_document": self._reference_document(lot.current_reference_type, reference_number),
                 "reference_document_type": lot.current_reference_type,
                 "reference_document_number": reference_number,
                 "traceability_lot_code_source_reference": lot.tlc_source_reference,

--- a/app/epcis_export.py
+++ b/app/epcis_export.py
@@ -14,6 +14,7 @@ _BIZ_STEPS = {
     CTEType.HARVESTING: "urn:epcglobal:cbv:bizstep:commissioning",
     CTEType.COOLING: "urn:epcglobal:cbv:bizstep:storing",
     CTEType.INITIAL_PACKING: "urn:epcglobal:cbv:bizstep:packing",
+    CTEType.FIRST_LAND_BASED_RECEIVING: "urn:epcglobal:cbv:bizstep:receiving",
     CTEType.SHIPPING: "urn:epcglobal:cbv:bizstep:shipping",
     CTEType.RECEIVING: "urn:epcglobal:cbv:bizstep:receiving",
     CTEType.TRANSFORMATION: "urn:epcglobal:cbv:bizstep:transforming",
@@ -23,6 +24,7 @@ _DISPOSITIONS = {
     CTEType.HARVESTING: "urn:epcglobal:cbv:disp:active",
     CTEType.COOLING: "urn:epcglobal:cbv:disp:active",
     CTEType.INITIAL_PACKING: "urn:epcglobal:cbv:disp:active",
+    CTEType.FIRST_LAND_BASED_RECEIVING: "urn:epcglobal:cbv:disp:active",
     CTEType.SHIPPING: "urn:epcglobal:cbv:disp:in_transit",
     CTEType.RECEIVING: "urn:epcglobal:cbv:disp:active",
     CTEType.TRANSFORMATION: "urn:epcglobal:cbv:disp:active",
@@ -32,6 +34,7 @@ _OBJECT_ACTIONS = {
     CTEType.HARVESTING: "ADD",
     CTEType.COOLING: "OBSERVE",
     CTEType.INITIAL_PACKING: "ADD",
+    CTEType.FIRST_LAND_BASED_RECEIVING: "ADD",
     CTEType.SHIPPING: "OBSERVE",
     CTEType.RECEIVING: "OBSERVE",
 }

--- a/app/fda_export.py
+++ b/app/fda_export.py
@@ -48,13 +48,21 @@ FDA_EXPORT_PRESETS = {
         id=FDAExportPreset.SHIPMENT_HANDOFF,
         label="Shipment handoff",
         description="Shipping and receiving records with reference documents.",
-        cte_types=frozenset({CTEType.SHIPPING, CTEType.RECEIVING}),
+        cte_types=frozenset(
+            {
+                CTEType.SHIPPING,
+                CTEType.RECEIVING,
+                CTEType.FIRST_LAND_BASED_RECEIVING,
+            }
+        ),
     ),
     FDAExportPreset.RECEIVING_LOG: FDAExportPresetDefinition(
         id=FDAExportPreset.RECEIVING_LOG,
         label="Receiving log",
         description="Receiving records for destination-focused FDA requests.",
-        cte_types=frozenset({CTEType.RECEIVING}),
+        cte_types=frozenset(
+            {CTEType.RECEIVING, CTEType.FIRST_LAND_BASED_RECEIVING}
+        ),
     ),
     FDAExportPreset.TRANSFORMATION_BATCHES: FDAExportPresetDefinition(
         id=FDAExportPreset.TRANSFORMATION_BATCHES,

--- a/app/models.py
+++ b/app/models.py
@@ -14,6 +14,14 @@ class CTEType(str, Enum):
     HARVESTING = "harvesting"
     COOLING = "cooling"
     INITIAL_PACKING = "initial_packing"
+    # First land-based receiving — RegEngine's WebhookCTEType supports
+    # this CTE per 21 CFR §1.1325 (seafood / first-receiver flows). The
+    # default LegitFlowEngine doesn't emit it yet because the current
+    # scenarios are leafy-greens / fresh-cut / retailer-handoff. Including
+    # the value keeps it valid for CSV imports, hand-crafted fixtures, and
+    # future seafood scenarios so the simulator can exercise the same
+    # webhook code path RegEngine validates against.
+    FIRST_LAND_BASED_RECEIVING = "first_land_based_receiving"
     SHIPPING = "shipping"
     RECEIVING = "receiving"
     TRANSFORMATION = "transformation"

--- a/app/regengine_client.py
+++ b/app/regengine_client.py
@@ -22,7 +22,8 @@ DEFAULT_LIVE_INGEST_ENDPOINT = "https://www.regengine.co/api/v1/webhooks/ingest"
 # When unset, signing is skipped — RegEngine's _verify_webhook_signature
 # also no-ops when its WEBHOOK_HMAC_SECRET is unset, so this preserves the
 # pre-signing migration ramp on both sides.
-WEBHOOK_HMAC_SECRET_ENV = "REGENGINE_WEBHOOK_HMAC_SECRET"
+# Bandit B105 false positive: this is an env var key, not a secret literal.
+WEBHOOK_HMAC_SECRET_ENV = "REGENGINE_WEBHOOK_HMAC_SECRET"  # nosec B105
 
 
 @dataclass(frozen=True, slots=True)

--- a/app/regengine_client.py
+++ b/app/regengine_client.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+import hashlib
+import hmac
+import json
+import os
 import uuid
 from dataclasses import dataclass
 from typing import Any
@@ -11,6 +15,14 @@ from .models import IngestPayload, SimulationConfig
 
 
 DEFAULT_LIVE_INGEST_ENDPOINT = "https://www.regengine.co/api/v1/webhooks/ingest"
+
+# Env var used to share an HMAC secret with the RegEngine ingest service.
+# When set, every live ingest request is signed with HMAC-SHA256 over the
+# exact request body bytes and sent as `X-Webhook-Signature: sha256=<hex>`.
+# When unset, signing is skipped — RegEngine's _verify_webhook_signature
+# also no-ops when its WEBHOOK_HMAC_SECRET is unset, so this preserves the
+# pre-signing migration ramp on both sides.
+WEBHOOK_HMAC_SECRET_ENV = "REGENGINE_WEBHOOK_HMAC_SECRET"
 
 
 @dataclass(frozen=True, slots=True)
@@ -34,16 +46,35 @@ class LiveRegEngineClient:
             raise ValueError("Live delivery requires both api_key and tenant_id")
 
         idempotency_key = uuid.uuid4().hex
-        metadata = _delivery_metadata(endpoint=endpoint, idempotency_key=idempotency_key)
+        # Serialize the body exactly once so the bytes we sign are the same
+        # bytes httpx puts on the wire. If we passed json=payload.model_dump()
+        # to httpx, it would re-serialize and any whitespace/key-order drift
+        # between our HMAC input and the wire body would cause RegEngine's
+        # signature check to 401 on every request.
+        body_bytes = json.dumps(
+            payload.model_dump(mode="json"),
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("utf-8")
+
+        signature_header = _build_signature_header(body_bytes)
+
+        metadata = _delivery_metadata(
+            endpoint=endpoint,
+            idempotency_key=idempotency_key,
+            signed=signature_header is not None,
+        )
         headers = {
             "Content-Type": "application/json",
             "X-RegEngine-API-Key": api_key,
             "X-Tenant-ID": tenant_id,
             "Idempotency-Key": idempotency_key,
         }
+        if signature_header is not None:
+            headers["X-Webhook-Signature"] = signature_header
         try:
             async with httpx.AsyncClient(timeout=20.0) as client:
-                response = await client.post(endpoint, headers=headers, json=payload.model_dump(mode="json"))
+                response = await client.post(endpoint, headers=headers, content=body_bytes)
         except httpx.HTTPError as exc:
             raise LiveRegEngineDeliveryError(str(exc), metadata) from exc
 
@@ -55,12 +86,33 @@ class LiveRegEngineClient:
         return LiveIngestResult(response=response.json(), metadata=metadata)
 
 
-def _delivery_metadata(endpoint: str, idempotency_key: str) -> dict[str, Any]:
+def _build_signature_header(body_bytes: bytes) -> str | None:
+    """Build the X-Webhook-Signature header value, or None when unsigned.
+
+    Returns None when REGENGINE_WEBHOOK_HMAC_SECRET is unset or empty so
+    deployments still mid-migration to signed webhooks continue to work.
+    Production deployments MUST set the secret on both sides; RegEngine's
+    webhook router will reject signed-required requests without a matching
+    signature.
+    """
+    secret = os.getenv(WEBHOOK_HMAC_SECRET_ENV, "").strip()
+    if not secret:
+        return None
+    digest = hmac.new(secret.encode("utf-8"), body_bytes, hashlib.sha256).hexdigest()
+    return f"sha256={digest}"
+
+
+def _delivery_metadata(
+    endpoint: str,
+    idempotency_key: str,
+    signed: bool = False,
+) -> dict[str, Any]:
     parsed = urlparse(endpoint)
     return {
         "delivery_mode": "live",
         "endpoint_host": parsed.netloc,
         "endpoint_path": parsed.path or "/",
         "idempotency_key": idempotency_key,
+        "signed": signed,
         "status_code": None,
     }

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -71,6 +71,10 @@ def test_engine_emits_regengine_canonical_kdes_for_lab_contract():
     harvesting = seen[CTEType.HARVESTING]
     assert "reference_document_type" in harvesting.kdes
     assert "reference_document_number" in harvesting.kdes
+    # Required for RegEngine ingest contract — webhook_router_v2 KDE
+    # validator looks for the combined `reference_document` field on
+    # harvesting events, not just the split type/number fields.
+    assert harvesting.kdes["reference_document"]
 
     initial_packing = seen[CTEType.INITIAL_PACKING]
     assert initial_packing.kdes["packing_date"]

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -39,7 +39,20 @@ def test_harvest_immediate_subsequent_recipients_are_coolers():
 
 def test_engine_emits_all_supported_ctes_and_lineage():
     engine = LegitFlowEngine(seed=204)
-    expected_ctes = set(CTEType)
+    # CTEs the default LegitFlowEngine actively emits across the
+    # leafy-greens / fresh-cut / retailer scenarios. CTEType also
+    # includes FIRST_LAND_BASED_RECEIVING (21 CFR §1.1325) for
+    # contract parity with RegEngine's webhook ingest, but it is
+    # intentionally not part of this engine's flow until a seafood
+    # scenario is added.
+    expected_ctes = {
+        CTEType.HARVESTING,
+        CTEType.COOLING,
+        CTEType.INITIAL_PACKING,
+        CTEType.SHIPPING,
+        CTEType.RECEIVING,
+        CTEType.TRANSFORMATION,
+    }
     seen = set()
     parent_links = 0
 

--- a/tests/test_regengine_client.py
+++ b/tests/test_regengine_client.py
@@ -30,12 +30,29 @@ class RecordingAsyncClient:
     async def __aexit__(self, exc_type: object, exc: object, tb: object) -> None:
         return None
 
-    async def post(self, endpoint: str, *, headers: dict[str, str], json: dict[str, Any]) -> FakeResponse:
+    async def post(
+        self,
+        endpoint: str,
+        *,
+        headers: dict[str, str],
+        content: bytes | None = None,
+        json: dict[str, Any] | None = None,
+    ) -> FakeResponse:
+        # The live client now serializes the body once and sends it via
+        # `content=` so the bytes we sign equal the bytes on the wire.
+        # Old call sites passed `json=`; accept both so this fake stays
+        # useful for any future caller that still uses the json kwarg.
+        if content is not None:
+            import json as _json
+            decoded = _json.loads(content.decode("utf-8"))
+        else:
+            decoded = json
         self.calls.append(
             {
                 "endpoint": endpoint,
                 "headers": headers,
-                "json": json,
+                "json": decoded,
+                "content": content,
                 "timeout": self.timeout,
             }
         )
@@ -144,3 +161,73 @@ def test_live_client_sends_required_headers_and_contract_payload(monkeypatch: An
             "ship_from_location": "Valley Fresh Farms",
         },
     }
+
+
+# ---------------------------------------------------------------------------
+# Webhook HMAC signing — RegEngine #1243 contract alignment
+# ---------------------------------------------------------------------------
+
+
+def test_live_client_omits_signature_header_when_secret_unset(monkeypatch: Any) -> None:
+    """Without REGENGINE_WEBHOOK_HMAC_SECRET, the client must NOT send a
+    signature header — RegEngine's verifier no-ops in that mode and a
+    bogus header would still be rejected as 'unsupported_signature_scheme'."""
+    monkeypatch.delenv("REGENGINE_WEBHOOK_HMAC_SECRET", raising=False)
+
+    call = run_ingest(monkeypatch, make_live_config())
+
+    assert "X-Webhook-Signature" not in call["headers"]
+
+
+def test_live_client_signs_body_with_hmac_sha256_when_secret_set(monkeypatch: Any) -> None:
+    """With the secret set, the client must sign the exact body bytes and
+    send them via content= so the wire bytes match the HMAC input."""
+    import hashlib
+    import hmac as _hmac
+
+    secret = "test-shared-secret-do-not-use-in-prod"
+    monkeypatch.setenv("REGENGINE_WEBHOOK_HMAC_SECRET", secret)
+
+    call = run_ingest(monkeypatch, make_live_config())
+
+    assert call["content"] is not None, (
+        "Body must be sent via content= so signed bytes equal wire bytes"
+    )
+    assert "X-Webhook-Signature" in call["headers"]
+
+    header = call["headers"]["X-Webhook-Signature"]
+    scheme, _, provided = header.partition("=")
+    assert scheme == "sha256", "RegEngine only accepts the sha256 scheme"
+
+    expected = _hmac.new(
+        secret.encode("utf-8"), call["content"], hashlib.sha256
+    ).hexdigest()
+    assert _hmac.compare_digest(expected, provided), (
+        "Signature must match HMAC-SHA256(secret, raw_body) exactly"
+    )
+
+
+def test_live_client_signature_metadata_reflects_signing(monkeypatch: Any) -> None:
+    """Delivery metadata exposes whether the request was signed so the
+    operator dashboard and stored event records can show signing status
+    without leaking the secret."""
+    monkeypatch.setenv("REGENGINE_WEBHOOK_HMAC_SECRET", "any-non-empty-secret")
+    RecordingAsyncClient.calls = []
+    monkeypatch.setattr("app.regengine_client.httpx.AsyncClient", RecordingAsyncClient)
+    result = asyncio.run(LiveRegEngineClient().ingest(make_payload(), make_live_config()))
+    assert result.metadata["signed"] is True
+
+    monkeypatch.delenv("REGENGINE_WEBHOOK_HMAC_SECRET", raising=False)
+    RecordingAsyncClient.calls = []
+    result = asyncio.run(LiveRegEngineClient().ingest(make_payload(), make_live_config()))
+    assert result.metadata["signed"] is False
+
+
+def test_live_client_treats_blank_secret_as_unset(monkeypatch: Any) -> None:
+    """A whitespace-only secret would silently sign with a near-empty key.
+    Treat it as unset to match RegEngine's _webhook_hmac_secret() behavior."""
+    monkeypatch.setenv("REGENGINE_WEBHOOK_HMAC_SECRET", "   ")
+
+    call = run_ingest(monkeypatch, make_live_config())
+
+    assert "X-Webhook-Signature" not in call["headers"]


### PR DESCRIPTION
# Align Inflow Lab live ingest with RegEngine webhook contract

Closes the four contract gaps identified in the RegEngine ↔ Inflow Lab contract diff. After this PR, the simulator can run a live trial against any RegEngine deployment — including one with `WEBHOOK_HMAC_SECRET` enforcement on — without per-event 401s or KDE validation rejections.

## Summary

| # | Commit | What it does |
|---|---|---|
| 1 | `fix(engine): emit combined reference_document KDE on harvesting events` | Harvesting events now emit the combined `reference_document` KDE that RegEngine's `_validate_event_kdes` looks for. Before this, every harvesting event from a live trial was rejected. |
| 2 | `feat(client): sign live ingest requests with HMAC-SHA256` | Adds `X-Webhook-Signature: sha256=<hex>` over the exact wire bytes when `REGENGINE_WEBHOOK_HMAC_SECRET` is set. Matches RegEngine's `_verify_webhook_signature` migration ramp. |
| 3 | `feat(models): add FIRST_LAND_BASED_RECEIVING CTE for contract parity` | Adds `first_land_based_receiving` to `CTEType` and downstream EPCIS/FDA export maps. Default engine still doesn't emit it — additive parity for CSV imports and hand-crafted fixtures. |
| 4 | `docs(contract): expand API contract reference to cover headers, HMAC, KDEs` | Rewrites the Codex agent contract reference into a real source of truth that mirrors `services/ingestion/app/`. |

## Tests

- 4 new HMAC tests in `test_regengine_client.py` (signed, unsigned, signature correctness, blank-secret behavior)
- 1 new assertion in `test_engine.py` locking in harvesting `reference_document`
- 1 test scoped from "all CTEs" to "engine-flow CTEs" since `first_land_based_receiving` is intentionally unflowed

**87 tests pass** (was 82 before; net +5 tests).

## Deployment notes

After merge, before flipping HMAC enforcement on in RegEngine prod:
1. Set `WEBHOOK_HMAC_SECRET` on the RegEngine ingestion Railway service.
2. Set `REGENGINE_WEBHOOK_HMAC_SECRET` to the **same value** on every Inflow Lab deployment (Railway shared-demo + any local trial environments).
3. Run `scripts/live_trial.py --confirm-live` once against staging to confirm a 2xx response.
4. Then enable HMAC enforcement.

If you set them out of order, every live ingest 401s until step 2 catches up.

## Skipped from the contract diff

- **Hoisting `input_traceability_lot_codes` to a typed field** — RegEngine actually reads this from `kdes.get(...)` in `services/ingestion/app/sandbox/tracer.py`, not the typed attribute. The simulator's `csv_importer`, `cte_rules`, `demo_fixtures`, `epcis_export`, and `store` all also read from the dict. Moving it to a typed field would be churn with no functional gain and risk breaking 5+ call sites. Documented in the contract reference instead.

- **Emitting `location_gln` on the wire** — `engine.py` already has the GLN data via `engine.location_gln(name)`, but `RegEngineEvent` doesn't have a `location_gln` field. This is a separate, larger change (model addition + serialization + maybe schema migration on stored JSONL) and not blocking. Tracked as a follow-up.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes live webhook delivery semantics (raw-body serialization, optional HMAC signing, new metadata) and event payload KDE requirements, which can cause 401s/validation failures if misconfigured. Changes are additive/guarded by env var and covered by targeted tests.
> 
> **Overview**
> **Aligns `delivery.mode=live` with RegEngine’s webhook ingest contract.** Live ingest now JSON-serializes the payload once, optionally signs the *exact* body bytes with HMAC-SHA256 via `X-Webhook-Signature` when `REGENGINE_WEBHOOK_HMAC_SECRET` is set, sends via `httpx` `content=`, and records a `signed` flag in delivery metadata.
> 
> Harvesting events now emit the combined `reference_document` KDE required by RegEngine validation, and `CTEType` adds `first_land_based_receiving` with corresponding EPCIS/FDA export preset support (engine flow/tests explicitly exclude it for now). Contract documentation is expanded to capture required headers, signing rules, required KDEs, and idempotency behavior, with new tests covering signing on/off, signature correctness, blank-secret handling, and the new harvesting KDE.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e10f3fc9d1d2916244cf7d8f5d02387a6cebefa8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `FIRST_LAND_BASED_RECEIVING` event type support throughout the platform
  * Implemented optional HMAC-SHA256 signature verification for webhook ingest requests
  * Harvesting events now include a `reference_document` field in payloads

* **Documentation**
  * Expanded API contract documentation with ingest headers, HMAC signing specifications, CTE type enumeration, and event validation constraints

<!-- end of auto-generated comment: release notes by coderabbit.ai -->