### PR TITLE
fix(dashboard): remove dead live_confirmed field crashing browser-smoke

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -65,7 +65,6 @@ class DeliveryConfig(BaseModel):
     endpoint: HttpUrl | None = None
     api_key: str | None = None
     tenant_id: str | None = None
-    live_confirmed: bool = False
 
 
 class SimulationConfig(BaseModel):

--- a/app/static/app.js
+++ b/app/static/app.js
@@ -86,7 +86,6 @@ function buildConfig() {
       endpoint: endpoint || null,
       api_key: apiKey || null,
       tenant_id: tenantId || null,
-      live_confirmed: ids.liveConfirmed.checked,
     },
   };
 }


### PR DESCRIPTION
Fixes the browser-smoke regression on main (also blocking PR #43).

## Root cause

Commit `273fd99` (merged via PR #40) restructured the dashboard into the current "1. Setup / 2. Run / 3. Monitor / 4. Trace / 5. Export" guided layout. The previous `liveConfirmed` checkbox was dropped from the HTML as part of the redesign, but the cleanup was incomplete:

- `app/static/app.js` `buildConfig()` still had `live_confirmed: ids.liveConfirmed.checked`, which crashes at runtime because `ids.liveConfirmed` is now undefined
- `app/models.py` `DeliveryConfig` still had a `live_confirmed: bool = False` field that nothing read

Backend confirms `live_confirmed` is dead: `_validate_live_delivery` in `app/controller.py` only checks `api_key` and `tenant_id`. The simulator's actual live-trial safety gate is the unrelated `scripts/live_trial.py --confirm-live` CLI flag, which stays.

## Diff summary

- `app/static/app.js` — remove dead JS reference
- `app/models.py` — remove dead model field
- (additional test fixture cleanups if found)

## Tests

- `python3 -m pytest` passes
- `bandit -q -r app scripts` passes
- browser-smoke should now pass; CI will confirm

## Why this is separate from PR #43

PR #43 is the RegEngine ↔ Inflow Lab contract alignment. The browser-smoke regression predates PR #43 and is unrelated to its changes. Fixing it on main first lets PR #43's CI go green so it can merge cleanly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only deletes an unused field and a broken DOM reference, and does not change live delivery validation or request flow.
> 
> **Overview**
> Fixes a dashboard runtime crash by removing the dead `live_confirmed` checkbox wiring from `buildConfig()` in `app/static/app.js`.
> 
> Cleans up the backend schema by dropping the unused `live_confirmed` field from `DeliveryConfig` in `app/models.py` so client/server configs stay aligned.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c269cd582ae29b43293f59a2e24c41d867cf45f0. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->