### PR TITLE
[codex] Align Inflow Lab standalone control room

### DIFF
--- a/app/static/index.html
+++ b/app/static/index.html
@@ -5,88 +5,169 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>RegEngine Inflow Lab</title>
     <link rel="icon" href="data:," />
-    <link rel="stylesheet" href="/static/styles.css" />
+    <link rel="stylesheet" href="/static/styles.css?v=2" />
   </head>
   <body>
     <main class="page">
       <header class="app-header">
-        <div>
+        <div class="hero-main">
           <p class="eyebrow">Mock-first FSMA 204 simulator</p>
           <h1>RegEngine Inflow Lab</h1>
-          <p class="hero-copy">Configure an inflow source, run a mock delivery, trace lot lineage, and package export-ready evidence.</p>
+          <p class="hero-copy">
+            Configure an inflow source, run a mock delivery, trace lot lineage, and package export-ready evidence.
+          </p>
+          <div class="hero-actions">
+            <button class="button" id="loadFixtureBtn" type="button">Load demo scenario</button>
+            <button class="button secondary" id="stepBtn" type="button">Run pipeline</button>
+            <button class="button secondary" id="lineageBtn" type="button">Trace latest lot</button>
+            <a class="button secondary" id="exportDownloadLink" href="/api/mock/regengine/export/fda-request" target="_blank" rel="noreferrer">
+              Prepare FDA package
+            </a>
+          </div>
         </div>
-        <div class="header-actions">
-          <a class="button secondary" href="/docs" target="_blank" rel="noreferrer">Open API docs</a>
-          <a class="button secondary" href="/api/mock/regengine/export/fda-request" target="_blank" rel="noreferrer">Download mock FDA export</a>
+        <div class="hero-side" aria-label="Current environment">
+          <div>
+            <span>Tenant</span>
+            <strong id="tenantBadge">local-demo</strong>
+          </div>
+          <div>
+            <span>Delivery</span>
+            <strong id="deliveryModePill">mock</strong>
+          </div>
+          <div>
+            <span>Build</span>
+            <strong id="buildBadge">0.1.0</strong>
+          </div>
         </div>
       </header>
 
-      <section class="status-strip" aria-label="Current demo state">
-        <div>
+      <section class="status-strip" aria-label="Pipeline summary">
+        <div class="status-card">
           <span>Next action</span>
           <strong id="nextActionText">Load a fixture or run a batch</strong>
         </div>
-        <div>
-          <span>Tenant</span>
-          <strong id="tenantBadge">local-demo</strong>
+        <div class="status-card">
+          <span>Records</span>
+          <strong>5 CTE types</strong>
         </div>
-        <div>
+        <div class="status-card">
           <span>Delivery</span>
-          <strong id="deliveryModePill">mock</strong>
+          <strong>Mock adapter</strong>
         </div>
-        <div>
-          <span>Build</span>
-          <strong id="buildBadge">0.1.0</strong>
+        <div class="status-card">
+          <span>Evidence</span>
+          <strong>CSV + EPCIS</strong>
         </div>
       </section>
 
-      <div class="console-layout">
-        <section class="panel setup-panel">
-          <div class="section-head">
-            <div>
-              <p class="section-kicker">1. Setup</p>
-              <h2>Demo setup</h2>
+      <section class="workflow-rail" aria-label="Inflow pipeline stages">
+        <article>
+          <span>Demo data</span>
+          <strong>Leafy greens supplier</strong>
+          <small>Scenario fixture</small>
+        </article>
+        <article>
+          <span>Generate</span>
+          <strong>Harvest to receipt</strong>
+          <small>CTE records</small>
+        </article>
+        <article>
+          <span>Deliver</span>
+          <strong>Local simulation</strong>
+          <small>Mock posted</small>
+        </article>
+        <article>
+          <span>Validate</span>
+          <strong>FSMA KDE checks</strong>
+          <small>Warnings visible</small>
+        </article>
+        <article>
+          <span>Trace</span>
+          <strong>Lot lineage</strong>
+          <small>Chain review</small>
+        </article>
+        <article>
+          <span>Export</span>
+          <strong>FDA + EPCIS</strong>
+          <small>Evidence package</small>
+        </article>
+      </section>
+
+      <section class="workspace-heading">
+        <div>
+          <p class="section-kicker">Operational workspace</p>
+          <h2>Review generated records, trace lots, and prepare evidence exports from the active demo scenario.</h2>
+        </div>
+        <div class="quick-trace">
+          <input id="lotLookup" placeholder="Traceability Lot Code" />
+          <button class="button secondary" type="button" onclick="document.getElementById('lineageBtn').click()">Trace lot</button>
+        </div>
+      </section>
+
+      <div class="workspace-layout">
+        <aside class="left-stack">
+          <section class="panel compact-panel">
+            <div class="section-head">
+              <div>
+                <p class="section-kicker">Scenario setup</p>
+                <h2>Inflow source</h2>
+              </div>
+              <span class="mode-alert" id="liveDeliveryWarning" hidden>Live delivery enabled</span>
             </div>
-            <span class="mode-alert" id="liveDeliveryWarning" hidden>Live delivery enabled</span>
-          </div>
+            <form id="config-form" class="setup-grid">
+              <label>
+                Tenant
+                <input id="tenantId" name="tenantId" autocomplete="off" placeholder="local-demo" />
+              </label>
+              <label>
+                Scenario preset
+                <select id="scenario" name="scenario">
+                  <option value="leafy_greens_supplier" selected>Leafy greens supplier</option>
+                  <option value="fresh_cut_processor">Fresh-cut processor</option>
+                  <option value="retailer_readiness_demo">Retailer readiness demo</option>
+                </select>
+              </label>
+              <label>
+                Fixture
+                <select id="demoFixture" name="demoFixture">
+                  <option value="leafy_greens_trace" selected>Leafy greens trace</option>
+                </select>
+              </label>
+              <label>
+                Delivery mode
+                <select id="deliveryMode" name="deliveryMode">
+                  <option value="mock" selected>Mock RegEngine</option>
+                  <option value="live">Live RegEngine</option>
+                  <option value="none">Generate only</option>
+                </select>
+              </label>
+              <label class="wide-field">
+                Source
+                <input id="source" name="source" value="codex-simulator" />
+              </label>
+            </form>
+            <p class="note" id="demoFixtureDescription">Harvest through cooling, packout, shipment, and DC receipt for one leafy greens lot.</p>
+          </section>
 
-          <form id="config-form" class="setup-grid">
-            <label>
-              Scenario preset
-              <select id="scenario" name="scenario">
-                <option value="leafy_greens_supplier" selected>Leafy greens supplier</option>
-                <option value="fresh_cut_processor">Fresh-cut processor</option>
-                <option value="retailer_readiness_demo">Retailer readiness demo</option>
-              </select>
-            </label>
-            <label>
-              Fixture
-              <select id="demoFixture" name="demoFixture">
-                <option value="leafy_greens_trace" selected>Leafy greens trace</option>
-              </select>
-            </label>
-            <label>
-              Delivery mode
-              <select id="deliveryMode" name="deliveryMode">
-                <option value="mock" selected>Mock RegEngine</option>
-                <option value="live">Live RegEngine</option>
-                <option value="none">Generate only</option>
-              </select>
-            </label>
-            <label>
-              Source
-              <input id="source" name="source" value="codex-simulator" />
-            </label>
-          </form>
+          <section class="panel compact-panel run-panel">
+            <div class="section-head">
+              <div>
+                <p class="section-kicker">Run command center</p>
+                <h2>Simulator</h2>
+              </div>
+              <span class="status-pill" id="runStatePill">Stopped</span>
+            </div>
+            <p class="note status-message" id="statusMessage">Ready.</p>
+            <div class="action-row">
+              <button class="button" id="startBtn" type="button">Start loop</button>
+              <button class="button secondary" id="stopBtn" type="button">Stop</button>
+              <button class="button secondary" id="replayBtn" type="button">Replay log</button>
+              <button class="button danger" id="resetBtn" type="button">Reset state</button>
+            </div>
+            <div class="stats-grid" id="statsGrid" aria-label="Simulator metrics"></div>
+          </section>
 
-          <p class="note" id="demoFixtureDescription">Harvest through cooling, packout, shipment, and DC receipt for one leafy greens lot.</p>
-
-          <div class="action-row primary-row">
-            <button class="button" id="loadFixtureBtn" type="button">Load fixture</button>
-            <button class="button secondary" id="stepBtn" type="button">Single batch</button>
-          </div>
-
-          <details class="advanced-panel" id="advancedConfig">
+          <details class="panel advanced-panel" id="advancedConfig">
             <summary>Advanced timing, credentials, and saved states</summary>
             <div class="advanced-content">
               <div class="grid two-up compact-fields">
@@ -102,10 +183,6 @@
                   Seed
                   <input id="seed" name="seed" type="number" value="204" />
                 </label>
-                <label>
-                  Tenant ID
-                  <input id="tenantId" name="tenantId" autocomplete="off" />
-                </label>
                 <label class="wide-field">
                   Live endpoint override
                   <input id="endpoint" name="endpoint" placeholder="https://www.regengine.co/api/v1/webhooks/ingest" />
@@ -115,7 +192,6 @@
                   <input id="apiKey" name="apiKey" type="password" autocomplete="off" />
                 </label>
               </div>
-
               <div class="split-row">
                 <label>
                   Saved scenario
@@ -131,91 +207,107 @@
               <p class="note" id="scenarioSaveDescription">No saved scenario selected.</p>
             </div>
           </details>
-        </section>
-
-        <aside class="panel run-panel">
-          <div class="section-head">
-            <div>
-              <p class="section-kicker">2. Run</p>
-              <h2>Simulator</h2>
-            </div>
-            <span class="status-pill" id="runStatePill">Stopped</span>
-          </div>
-          <p class="note status-message" id="statusMessage">Ready.</p>
-          <div class="action-row">
-            <button class="button" id="startBtn" type="button">Start loop</button>
-            <button class="button secondary" id="stopBtn" type="button">Stop</button>
-            <button class="button secondary" id="replayBtn" type="button">Replay current log</button>
-            <button class="button danger" id="resetBtn" type="button">Reset state</button>
-          </div>
-          <section class="stats-grid" id="statsGrid" aria-label="Simulator metrics"></section>
         </aside>
-      </div>
 
-      <section class="panel delivery-monitor">
-        <div class="section-head">
-          <div>
-            <p class="section-kicker">3. Monitor</p>
-            <h2>Delivery monitor</h2>
+        <section class="center-stack">
+          <div class="tab-strip" aria-label="Workspace sections">
+            <span>Lots</span>
+            <span>Lineage</span>
+            <span>Exports</span>
+            <span>Event log</span>
+            <span>Diagnostics</span>
           </div>
-          <button class="button secondary" id="retryFailedBtn" type="button">Retry failed deliveries</button>
-        </div>
-        <div id="deliverySummary" class="delivery-summary"></div>
-      </section>
 
-      <div class="evidence-layout">
-        <section class="panel lineage-panel">
-          <div class="section-head">
-            <div>
-              <p class="section-kicker">4. Trace</p>
-              <h2>Lot lineage</h2>
+          <section class="panel lineage-panel">
+            <div class="section-head">
+              <div>
+                <p class="section-kicker">Selected lot lineage</p>
+                <h2>Trace path</h2>
+              </div>
             </div>
-          </div>
-          <div class="inline-form">
-            <input id="lotLookup" placeholder="Traceability Lot Code" />
-            <button class="button secondary" id="lineageBtn" type="button">Trace lot</button>
-          </div>
-          <div id="lineageResults" class="lineage-results"></div>
+            <div id="lineageResults" class="lineage-results"></div>
+          </section>
+
+          <section class="panel events-panel">
+            <div class="section-head">
+              <div>
+                <p class="section-kicker">Event log</p>
+                <h2>Recent events</h2>
+              </div>
+              <button class="button secondary" id="refreshBtn" type="button">Refresh</button>
+            </div>
+            <div class="table-wrap">
+              <table>
+                <thead>
+                  <tr>
+                    <th>#</th>
+                    <th>CTE</th>
+                    <th>Lot code</th>
+                    <th>Product</th>
+                    <th>Location</th>
+                    <th>Timestamp</th>
+                    <th>Mode</th>
+                    <th>Attempts</th>
+                    <th>Status</th>
+                  </tr>
+                </thead>
+                <tbody id="eventsBody"></tbody>
+              </table>
+            </div>
+          </section>
         </section>
 
-        <section class="panel evidence-panel">
-          <div class="section-head">
-            <div>
-              <p class="section-kicker">5. Export</p>
-              <h2>Evidence exports</h2>
-            </div>
-            <div class="section-actions">
-              <a class="button secondary" id="exportDownloadLink" href="/api/mock/regengine/export/fda-request" target="_blank" rel="noreferrer">Download CSV</a>
-              <a class="button secondary" id="epcisDownloadLink" href="/api/mock/regengine/export/epcis" target="_blank" rel="noreferrer">Download EPCIS</a>
-            </div>
-          </div>
-          <div class="grid two-up">
-            <label>
-              Export preset
-              <select id="exportPreset" name="exportPreset">
-                <option value="all_records" selected>All records</option>
-              </select>
-            </label>
-            <label>
-              Traceability Lot Code
-              <input id="exportLot" name="exportLot" placeholder="Optional unless preset requires one" />
-            </label>
-            <label>
-              Start date
-              <input id="exportStartDate" name="exportStartDate" type="date" />
-            </label>
-            <label>
-              End date
-              <input id="exportEndDate" name="exportEndDate" type="date" />
-            </label>
-          </div>
-          <p class="note" id="exportPresetDescription">Full FDA-request export for the selected date range. EPCIS uses the same lot and date filters.</p>
-
-          <div class="import-block">
+        <aside class="right-stack">
+          <section class="panel delivery-monitor">
             <div class="section-head">
-              <h3>CSV import</h3>
+              <div>
+                <p class="section-kicker">Delivery monitor</p>
+                <h2>Mock adapter</h2>
+              </div>
+              <button class="button secondary" id="retryFailedBtn" type="button">Retry failed</button>
             </div>
-            <div class="grid two-up">
+            <div id="deliverySummary" class="delivery-summary"></div>
+          </section>
+
+          <section class="panel evidence-panel">
+            <div class="section-head">
+              <div>
+                <p class="section-kicker">Evidence package</p>
+                <h2>Export filters</h2>
+              </div>
+              <a class="button secondary" id="epcisDownloadLink" href="/api/mock/regengine/export/epcis" target="_blank" rel="noreferrer">EPCIS JSON</a>
+            </div>
+            <div class="grid export-grid">
+              <label>
+                Preset
+                <select id="exportPreset" name="exportPreset">
+                  <option value="all_records" selected>All records</option>
+                </select>
+              </label>
+              <label>
+                Traceability Lot Code
+                <input id="exportLot" name="exportLot" placeholder="Optional unless preset requires one" />
+              </label>
+              <label>
+                Start date
+                <input id="exportStartDate" name="exportStartDate" type="date" />
+              </label>
+              <label>
+                End date
+                <input id="exportEndDate" name="exportEndDate" type="date" />
+              </label>
+            </div>
+            <p class="note" id="exportPresetDescription">Full FDA-request export for the selected date range. EPCIS uses the same lot and date filters.</p>
+          </section>
+
+          <section class="panel import-block">
+            <div class="section-head">
+              <div>
+                <p class="section-kicker">CSV import</p>
+                <h2>Stage records</h2>
+              </div>
+            </div>
+            <div class="grid export-grid">
               <label>
                 CSV type
                 <select id="csvImportType" name="csvImportType">
@@ -232,38 +324,15 @@
               <button class="button secondary" id="importCsvBtn" type="button">Import CSV</button>
             </div>
             <div id="importResults" class="import-results"></div>
-          </div>
-        </section>
-      </div>
+          </section>
 
-      <section class="panel events-panel">
-        <div class="section-head">
-          <div>
-            <p class="section-kicker">Event log</p>
-            <h2>Recent events</h2>
-          </div>
-          <button class="button secondary" id="refreshBtn" type="button">Refresh</button>
-        </div>
-        <div class="table-wrap">
-          <table>
-            <thead>
-              <tr>
-                <th>#</th>
-                <th>CTE</th>
-                <th>Lot code</th>
-                <th>Product</th>
-                <th>Location</th>
-                <th>Timestamp</th>
-                <th>Mode</th>
-                <th>Attempts</th>
-                <th>Status</th>
-              </tr>
-            </thead>
-            <tbody id="eventsBody"></tbody>
-          </table>
-        </div>
-      </section>
+          <nav class="resource-links" aria-label="Resources">
+            <a href="/docs" target="_blank" rel="noreferrer">Open API docs</a>
+            <a href="/api/mock/regengine/export/fda-request" target="_blank" rel="noreferrer">Download mock FDA export</a>
+          </nav>
+        </aside>
+      </div>
     </main>
-    <script src="/static/app.js" defer></script>
+    <script src="/static/app.js?v=2" defer></script>
   </body>
 </html>

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -33,9 +33,7 @@
 body {
   margin: 0;
   font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-  background:
-    radial-gradient(circle at 12% -10%, rgba(5, 150, 105, 0.12), transparent 28rem),
-    linear-gradient(180deg, #f8faf7 0%, var(--bg) 38%, #f7faf7 100%);
+  background: linear-gradient(180deg, #f8faf7 0%, var(--bg) 38%, #f7faf7 100%);
   color: var(--text);
 }
 
@@ -63,19 +61,19 @@ summary:focus-visible {
 }
 
 .page {
-  width: min(1480px, 100%);
+  width: min(1600px, 100%);
   margin: 0 auto;
-  padding: 28px 24px 56px;
+  padding: 24px 24px 56px;
 }
 
 .app-header {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  align-items: end;
-  gap: 28px;
-  padding: 28px;
+  grid-template-columns: minmax(0, 1fr) minmax(260px, 360px);
+  align-items: stretch;
+  gap: 24px;
+  padding: 30px;
   border: 1px solid rgba(6, 78, 59, 0.22);
-  border-radius: 18px 18px 0 0;
+  border-radius: 18px;
   background: var(--surface-strong);
   color: #ffffff;
   box-shadow: var(--shadow-strong);
@@ -128,6 +126,7 @@ h3 {
 }
 
 .header-actions,
+.hero-actions,
 .action-row,
 .inline-form,
 .section-head,
@@ -158,19 +157,20 @@ h3 {
 
 .status-strip {
   display: grid;
-  grid-template-columns: 1.6fr repeat(3, minmax(150px, 1fr));
-  gap: 1px;
-  overflow: hidden;
-  margin-bottom: 20px;
-  border-top: 0;
-  border-radius: 0 0 18px 18px;
-  box-shadow: var(--shadow-strong);
+  grid-template-columns: 1.4fr repeat(3, minmax(150px, 1fr));
+  gap: 12px;
+  margin: 16px 0;
+  border: 0;
+  background: transparent;
+  box-shadow: none;
 }
 
 .status-strip div {
   min-width: 0;
   padding: 16px 18px;
   background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 8px;
 }
 
 .status-strip span,
@@ -275,6 +275,9 @@ input::placeholder {
 }
 
 .button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   min-height: 42px;
   border: 1px solid transparent;
   border-radius: 8px;
@@ -468,6 +471,177 @@ input::placeholder {
   cursor: not-allowed;
   filter: grayscale(0.45);
   opacity: 0.55;
+}
+
+.hero-main {
+  display: grid;
+  align-content: end;
+}
+
+.hero-actions {
+  margin-top: 22px;
+}
+
+.hero-side {
+  display: grid;
+  gap: 10px;
+  align-content: end;
+}
+
+.hero-side div {
+  min-width: 0;
+  padding: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.hero-side span,
+.workflow-rail span,
+.workflow-rail small,
+.resource-links a {
+  color: var(--muted);
+}
+
+.hero-side span {
+  display: block;
+  color: #a7f3d0;
+  font-size: 0.78rem;
+  font-weight: 750;
+  text-transform: uppercase;
+}
+
+.hero-side strong {
+  display: block;
+  margin-top: 6px;
+  color: #ffffff;
+  overflow-wrap: anywhere;
+}
+
+.workflow-rail {
+  display: grid;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  gap: 1px;
+  margin-bottom: 18px;
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--border);
+  box-shadow: var(--shadow);
+}
+
+.workflow-rail article {
+  min-width: 0;
+  padding: 15px;
+  background: #ffffff;
+}
+
+.workflow-rail span,
+.workflow-rail small {
+  display: block;
+  font-size: 0.78rem;
+  font-weight: 750;
+}
+
+.workflow-rail span {
+  color: var(--accent-strong);
+  text-transform: uppercase;
+}
+
+.workflow-rail strong {
+  display: block;
+  margin: 6px 0 4px;
+  overflow-wrap: anywhere;
+}
+
+.workspace-heading {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(300px, 460px);
+  gap: 20px;
+  align-items: end;
+  margin: 28px 0 14px;
+}
+
+.workspace-heading h2 {
+  max-width: 860px;
+  color: var(--text);
+  font-size: 1.18rem;
+  font-weight: 700;
+}
+
+.quick-trace {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 10px;
+}
+
+.workspace-layout {
+  display: grid;
+  grid-template-columns: minmax(280px, 360px) minmax(0, 1fr) minmax(300px, 380px);
+  gap: 18px;
+  align-items: start;
+}
+
+.left-stack,
+.center-stack,
+.right-stack {
+  display: grid;
+  gap: 18px;
+  min-width: 0;
+}
+
+.compact-panel {
+  margin-bottom: 0;
+}
+
+.tab-strip {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 8px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: #ffffff;
+  box-shadow: var(--shadow);
+}
+
+.tab-strip span {
+  min-height: 34px;
+  padding: 8px 11px;
+  border-radius: 8px;
+  background: var(--surface-muted);
+  color: var(--muted);
+  font-size: 0.85rem;
+  font-weight: 800;
+}
+
+.tab-strip span:first-child {
+  background: var(--accent-soft);
+  color: var(--accent-strong);
+}
+
+.export-grid {
+  grid-template-columns: 1fr;
+  gap: 14px;
+}
+
+.resource-links {
+  display: grid;
+  gap: 8px;
+}
+
+.resource-links a {
+  padding: 12px 14px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: #ffffff;
+  color: var(--text);
+  font-weight: 750;
+  text-decoration: none;
+}
+
+.resource-links a:hover {
+  border-color: var(--border-strong);
 }
 
 .table-wrap {
@@ -688,12 +862,19 @@ th {
 @media (max-width: 1100px) {
   .console-layout,
   .evidence-layout,
-  .status-strip {
+  .status-strip,
+  .workspace-layout,
+  .workspace-heading,
+  .app-header {
     grid-template-columns: 1fr;
   }
 
   .run-panel {
     position: static;
+  }
+
+  .workflow-rail {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
   }
 }
 
@@ -705,6 +886,7 @@ th {
   .app-header,
   .section-head,
   .header-actions,
+  .hero-actions,
   .section-actions,
   .action-row {
     align-items: stretch;
@@ -722,12 +904,30 @@ th {
   .delivery-details,
   .lineage-overview,
   .split-row,
-  .inline-form {
+  .inline-form,
+  .quick-trace,
+  .workflow-rail {
     grid-template-columns: 1fr;
   }
 
   .button {
     width: 100%;
     white-space: normal;
+  }
+
+  .hero-side {
+    align-content: start;
+  }
+
+  .workflow-rail {
+    gap: 8px;
+    border: 0;
+    background: transparent;
+    box-shadow: none;
+  }
+
+  .workflow-rail article {
+    border: 1px solid var(--border);
+    border-radius: 8px;
   }
 }


### PR DESCRIPTION
## Summary\n- Replaces the standalone simulator's old numbered wizard shell with the planned control-room workspace\n- Keeps the existing simulator JavaScript IDs wired for fixture load, pipeline run, lineage, exports, CSV import, and monitor actions\n- Adds cache-busted static asset links and responsive polish for narrow in-app browser layouts\n\n## Validation\n- .venv/bin/python -m pytest -q\n- .venv/bin/python scripts/browser_smoke.py