### PR TITLE
[codex] Fix live retry idempotency keys

### DIFF
--- a/.agents/skills/regengine-api-contract/references/contract.md
+++ b/.agents/skills/regengine-api-contract/references/contract.md
@@ -116,11 +116,13 @@ satisfies them as typed fields too, so the distinction is invisible.
 `Idempotency-Key` is required (`webhook_router_v2.py` line 933,
 `IdempotencyDependency(strict=True)`). The middleware caches 2xx
 responses for 24h, scoped per tenant. The simulator generates a fresh
-`uuid4().hex` per call.
+`uuid4().hex` for each new live delivery request and stores it in each record's
+`delivery_metadata`.
 
-**Known limitation:** if the simulator retries after a 5xx with a fresh
-UUID, RegEngine treats it as a new event. Keep the same idempotency
-key across retries of the same logical event.
+Live delivery retries reuse the stored `delivery_metadata.idempotency_key`
+when present and group failed records by `(source, idempotency_key)` so
+RegEngine can identify the retry and return the cached 2xx response.
+Records without prior idempotency metadata fall back to a fresh key.
 
 ## Mock export columns expected by this repo
 

--- a/app/controller.py
+++ b/app/controller.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import uuid
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any
@@ -132,7 +133,11 @@ class SimulationController:
                 lineages.append(parent_lot_codes)
 
             payload = IngestPayload(source=self.config.source, events=events)
-            outcome = await self._deliver_payload(payload, self.config)
+            outcome = await self._deliver_payload(
+                payload,
+                self.config,
+                idempotency_key=uuid.uuid4().hex,
+            )
 
             stored_records: list[StoredEventRecord] = []
             response_events = (outcome.response or {}).get("events", []) if outcome.response else []
@@ -463,12 +468,17 @@ class SimulationController:
                 failed = 0
                 updated_records: list[StoredEventRecord] = []
                 responses: list[dict[str, Any]] = []
-                grouped_records: dict[str, list[StoredEventRecord]] = {}
+                grouped_records: dict[tuple[str, str | None], list[StoredEventRecord]] = {}
                 for record in candidates:
                     source = request.source or record.payload_source
-                    grouped_records.setdefault(source, []).append(record)
+                    idempotency_key = (
+                        _stored_idempotency_key(record)
+                        if delivery.mode == DestinationMode.LIVE
+                        else None
+                    )
+                    grouped_records.setdefault((source, idempotency_key), []).append(record)
 
-                for source, records in grouped_records.items():
+                for (source, idempotency_key), records in grouped_records.items():
                     retry_config = self.config.model_copy(
                         update={
                             "source": source,
@@ -477,7 +487,11 @@ class SimulationController:
                         deep=True,
                     )
                     payload = IngestPayload(source=source, events=[record.event for record in records])
-                    outcome = await self._deliver_payload(payload, retry_config)
+                    outcome = await self._deliver_payload(
+                        payload,
+                        retry_config,
+                        idempotency_key=idempotency_key,
+                    )
                     response_events = (outcome.response or {}).get("events", []) if outcome.response else []
                     responses.append(
                         {
@@ -539,12 +553,20 @@ class SimulationController:
         await self._publish_update()
         return result
 
-    async def _deliver_payload(self, payload: IngestPayload, config: SimulationConfig) -> DeliveryOutcome:
+    async def _deliver_payload(
+        self,
+        payload: IngestPayload,
+        config: SimulationConfig,
+        idempotency_key: str | None = None,
+    ) -> DeliveryOutcome:
         if config.delivery.mode == DestinationMode.NONE:
             return DeliveryOutcome()
 
         api_key = config.delivery.api_key
         attempted_at = datetime.now(UTC)
+        delivery_idempotency_key = idempotency_key
+        if config.delivery.mode == DestinationMode.LIVE and delivery_idempotency_key is None:
+            delivery_idempotency_key = uuid.uuid4().hex
         try:
             if config.delivery.mode == DestinationMode.MOCK:
                 response = self.mock_service.ingest(payload).model_dump(mode="json")
@@ -561,7 +583,11 @@ class SimulationController:
                     },
                 )
             if config.delivery.mode == DestinationMode.LIVE:
-                result = await self.live_client.ingest(payload, config)
+                result = await self.live_client.ingest(
+                    payload,
+                    config,
+                    idempotency_key=delivery_idempotency_key,
+                )
                 return DeliveryOutcome(
                     response=mask_secret_in_payload(result.response, api_key),
                     delivery_status="posted",
@@ -573,25 +599,31 @@ class SimulationController:
                 )
             return DeliveryOutcome()
         except LiveRegEngineDeliveryError as exc:
+            metadata = exc.metadata | {"attempted_event_count": len(payload.events)}
+            if delivery_idempotency_key and "idempotency_key" not in metadata:
+                metadata["idempotency_key"] = delivery_idempotency_key
             return DeliveryOutcome(
                 delivery_status="failed",
                 failed=len(payload.events),
                 delivery_attempts=1,
                 attempted_at=attempted_at,
                 error_message=mask_secret_in_string(str(exc), api_key),
-                metadata=exc.metadata | {"attempted_event_count": len(payload.events)},
+                metadata=metadata,
             )
         except Exception as exc:  # pragma: no cover - exercised by live integration, not unit tests
+            metadata = {
+                "delivery_mode": config.delivery.mode.value,
+                "attempted_event_count": len(payload.events),
+            }
+            if delivery_idempotency_key:
+                metadata["idempotency_key"] = delivery_idempotency_key
             return DeliveryOutcome(
                 delivery_status="failed",
                 failed=len(payload.events),
                 delivery_attempts=1,
                 attempted_at=attempted_at,
                 error_message=mask_secret_in_string(str(exc), api_key),
-                metadata={
-                    "delivery_mode": config.delivery.mode.value,
-                    "attempted_event_count": len(payload.events),
-                },
+                metadata=metadata,
             )
 
     async def _run_loop(self) -> None:
@@ -677,3 +709,11 @@ class SimulationController:
 def _validate_live_delivery(delivery: DeliveryConfig) -> None:
     if delivery.mode == DestinationMode.LIVE and (not delivery.api_key or not delivery.tenant_id):
         raise ValueError("Live delivery requires both api_key and tenant_id")
+
+
+def _stored_idempotency_key(record: StoredEventRecord) -> str | None:
+    metadata = record.delivery_metadata or {}
+    value = metadata.get("idempotency_key")
+    if isinstance(value, str) and value:
+        return value
+    return None

--- a/app/regengine_client.py
+++ b/app/regengine_client.py
@@ -40,14 +40,19 @@ class LiveRegEngineDeliveryError(RuntimeError):
 
 
 class LiveRegEngineClient:
-    async def ingest(self, payload: IngestPayload, config: SimulationConfig) -> LiveIngestResult:
+    async def ingest(
+        self,
+        payload: IngestPayload,
+        config: SimulationConfig,
+        idempotency_key: str | None = None,
+    ) -> LiveIngestResult:
         endpoint = str(config.delivery.endpoint) if config.delivery.endpoint else DEFAULT_LIVE_INGEST_ENDPOINT
         api_key = config.delivery.api_key
         tenant_id = config.delivery.tenant_id
         if not api_key or not tenant_id:
             raise ValueError("Live delivery requires both api_key and tenant_id")
 
-        idempotency_key = uuid.uuid4().hex
+        idempotency_key = idempotency_key or uuid.uuid4().hex
         # Serialize the body exactly once so the bytes we sign are the same
         # bytes httpx puts on the wire. If we passed json=payload.model_dump()
         # to httpx, it would re-serialize and any whitespace/key-order drift

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1045,7 +1045,7 @@ def test_reset_applies_configured_persist_path_for_next_step(tmp_path):
 
 def test_failed_live_delivery_surfaces_retry_feedback_and_can_retry_to_mock(tmp_path):
     class FailingLiveClient:
-        async def ingest(self, payload, config):  # noqa: ANN001
+        async def ingest(self, payload, config, idempotency_key=None):  # noqa: ANN001
             raise LiveRegEngineDeliveryError(
                 "temporary outage",
                 {
@@ -1125,9 +1125,80 @@ def test_failed_live_delivery_surfaces_retry_feedback_and_can_retry_to_mock(tmp_
     assert retried_record["error"] is None
 
 
+def test_live_delivery_retry_reuses_original_idempotency_key(monkeypatch, tmp_path):
+    class FlakyLiveClient:
+        def __init__(self) -> None:
+            self.idempotency_keys = []
+
+        async def ingest(self, payload, config, idempotency_key=None):  # noqa: ANN001
+            assert idempotency_key
+            self.idempotency_keys.append(idempotency_key)
+            metadata = {
+                "delivery_mode": "live",
+                "endpoint_host": "www.regengine.co",
+                "endpoint_path": "/api/v1/webhooks/ingest",
+                "idempotency_key": idempotency_key,
+                "status_code": 503 if len(self.idempotency_keys) == 1 else 200,
+            }
+            if len(self.idempotency_keys) == 1:
+                raise LiveRegEngineDeliveryError("connection dropped after upstream receive", metadata)
+            return LiveIngestResult(
+                response={
+                    "accepted": len(payload.events),
+                    "events": [
+                        {
+                            "traceability_lot_code": event.traceability_lot_code,
+                            "status": "accepted",
+                        }
+                        for event in payload.events
+                    ],
+                },
+                metadata=metadata,
+            )
+
+    flaky_client = FlakyLiveClient()
+    monkeypatch.setattr(controller, "live_client", flaky_client)
+    reset_response = client.post(
+        "/api/simulate/reset",
+        json={
+            "batch_size": 1,
+            "seed": 204,
+            "persist_path": str(tmp_path / "live-retry-events.jsonl"),
+            "delivery": {
+                "mode": "live",
+                "api_key": "live-api-secret",
+                "tenant_id": "live-tenant-secret",
+            },
+        },
+    )
+    assert reset_response.status_code == 200
+
+    step_response = client.post("/api/simulate/step")
+
+    assert step_response.status_code == 200
+    assert step_response.json()["delivery_status"] == "failed"
+    failed_record = client.get("/api/events?limit=1").json()["events"][0]
+    original_key = failed_record["delivery_metadata"]["idempotency_key"]
+    assert original_key == flaky_client.idempotency_keys[0]
+
+    retry_response = client.post("/api/delivery/retry")
+
+    assert retry_response.status_code == 200
+    retry_body = retry_response.json()
+    assert retry_body["status"] == "posted"
+    assert retry_body["posted"] == 1
+    assert retry_body["failed"] == 0
+    assert flaky_client.idempotency_keys == [original_key, original_key]
+
+    retried_record = client.get("/api/events?limit=1").json()["events"][0]
+    assert retried_record["delivery_status"] == "posted"
+    assert retried_record["delivery_attempts"] == 2
+    assert retried_record["delivery_metadata"]["idempotency_key"] == original_key
+
+
 def test_successful_live_delivery_records_sanitized_audit_metadata(monkeypatch, tmp_path):
     class FakeLiveClient:
-        async def ingest(self, payload, config):  # noqa: ANN001
+        async def ingest(self, payload, config, idempotency_key=None):  # noqa: ANN001
             return LiveIngestResult(
                 response={
                     "accepted": len(payload.events),
@@ -1185,7 +1256,7 @@ def test_failed_live_delivery_masks_api_key_in_error_message(tmp_path):
     api_key = "live-api-secret-leak"
 
     class LeakyLiveClient:
-        async def ingest(self, payload, config):  # noqa: ANN001
+        async def ingest(self, payload, config, idempotency_key=None):  # noqa: ANN001
             raise LiveRegEngineDeliveryError(
                 f"upstream rejected request with key={api_key} for tenant",
                 {
@@ -1231,7 +1302,7 @@ def test_successful_live_delivery_masks_api_key_echoed_in_response(monkeypatch, 
     api_key = "live-api-secret-echo"
 
     class EchoLiveClient:
-        async def ingest(self, payload, config):  # noqa: ANN001
+        async def ingest(self, payload, config, idempotency_key=None):  # noqa: ANN001
             return LiveIngestResult(
                 response={
                     "accepted": len(payload.events),

--- a/tests/test_regengine_client.py
+++ b/tests/test_regengine_client.py
@@ -165,6 +165,24 @@ def test_live_client_sends_required_headers_and_contract_payload(monkeypatch: An
     }
 
 
+def test_live_client_uses_provided_idempotency_key(monkeypatch: Any) -> None:
+    idempotency_key = "retry-idem-123"
+    RecordingAsyncClient.calls = []
+    monkeypatch.setattr("app.regengine_client.httpx.AsyncClient", RecordingAsyncClient)
+
+    result = asyncio.run(
+        LiveRegEngineClient().ingest(
+            make_payload(),
+            make_live_config(),
+            idempotency_key=idempotency_key,
+        )
+    )
+
+    assert len(RecordingAsyncClient.calls) == 1
+    assert RecordingAsyncClient.calls[0]["headers"]["Idempotency-Key"] == idempotency_key
+    assert result.metadata["idempotency_key"] == idempotency_key
+
+
 # ---------------------------------------------------------------------------
 # Webhook HMAC signing — RegEngine #1243 contract alignment
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Thread an optional idempotency key through live RegEngine ingestion.
- Generate and persist a key for normal live simulator steps.
- Reuse stored idempotency keys when retrying failed live deliveries, grouped by source and key.
- Update the RegEngine API contract note and add regression coverage.

## Why
A failed live attempt could previously be retried with a fresh `Idempotency-Key`. If RegEngine had received the first request but the simulator missed the success response, the retry could be treated as a distinct ingestion.

## Impact
Retries of the same logical live delivery now preserve the original idempotency key, allowing RegEngine to return its cached 2xx response instead of ingesting duplicate data.

## Validation
- `pytest -q` passed: 89 tests.