### PR TITLE
feat: emit location_gln on RegEngine events

### DIFF
--- a/app/cte_rules.py
+++ b/app/cte_rules.py
@@ -106,6 +106,7 @@ def validate_event_kdes(event: RegEngineEvent) -> list[CTEValidationWarning]:
     # event.kdes so a required key satisfied at top level isn't flagged.
     available: dict[str, Any] = {
         "location_name": event.location_name,
+        "location_gln": event.location_gln,
         "traceability_lot_code": event.traceability_lot_code,
         "product_description": event.product_description,
         "quantity": event.quantity,

--- a/app/engine.py
+++ b/app/engine.py
@@ -162,6 +162,7 @@ class LegitFlowEngine:
             quantity=lot.quantity,
             unit_of_measure=lot.unit_of_measure,
             location_name=farm.name,
+            location_gln=self._location_gln_or_none(farm.name),
             timestamp=timestamp,
             kdes={
                 "harvest_date": timestamp.date().isoformat(),
@@ -191,6 +192,7 @@ class LegitFlowEngine:
             quantity=lot.quantity,
             unit_of_measure=lot.unit_of_measure,
             location_name=cooler.name,
+            location_gln=self._location_gln_or_none(cooler.name),
             timestamp=timestamp,
             kdes={
                 "cooling_date": timestamp.date().isoformat(),
@@ -234,6 +236,7 @@ class LegitFlowEngine:
             quantity=packed_lot.quantity,
             unit_of_measure=packed_lot.unit_of_measure,
             location_name=packer.name,
+            location_gln=self._location_gln_or_none(packer.name),
             timestamp=timestamp,
             kdes={
                 "packing_date": timestamp.date().isoformat(),
@@ -294,6 +297,7 @@ class LegitFlowEngine:
             quantity=lot.quantity,
             unit_of_measure=lot.unit_of_measure,
             location_name=shipment.from_location,
+            location_gln=self._location_gln_or_none(shipment.from_location),
             timestamp=timestamp,
             kdes={
                 "ship_date": timestamp.date().isoformat(),
@@ -332,6 +336,7 @@ class LegitFlowEngine:
             quantity=lot.quantity,
             unit_of_measure=lot.unit_of_measure,
             location_name=shipment.to_location,
+            location_gln=self._location_gln_or_none(shipment.to_location),
             timestamp=timestamp,
             kdes={
                 "receive_date": timestamp.date().isoformat(),
@@ -380,6 +385,7 @@ class LegitFlowEngine:
             quantity=output_lot.quantity,
             unit_of_measure=output_lot.unit_of_measure,
             location_name=processor.name,
+            location_gln=self._location_gln_or_none(processor.name),
             timestamp=timestamp,
             kdes={
                 "transformation_date": timestamp.date().isoformat(),
@@ -396,6 +402,16 @@ class LegitFlowEngine:
     def location_gln(self, location_name: str) -> str:
         location = self.location_index.get(location_name)
         return location.gln if location else ""
+
+    def _location_gln_or_none(self, location_name: str) -> str | None:
+        """Same as location_gln() but returns None for unknown/empty.
+
+        RegEngine's IngestEvent validator treats empty strings as missing
+        and rejects them; emit None instead so the optional field stays
+        truly optional on the wire.
+        """
+        gln = self.location_gln(location_name)
+        return gln or None
 
     def _make_lot_code(self, prefix: str) -> str:
         return f"{prefix}-{self._time_cursor.strftime('%Y%m%d')}-{next(self._lot_counter):06d}"

--- a/app/schemas/domain.py
+++ b/app/schemas/domain.py
@@ -57,6 +57,11 @@ class RegEngineEvent(BaseModel):
     quantity: float
     unit_of_measure: str
     location_name: str
+    # Optional GS1 GLN for the emitting location. RegEngine's IngestEvent
+    # accepts this as a top-level field with mod-10 validation. Existing
+    # JSONL stores predate this field; Pydantic's Optional default keeps
+    # them backward-compatible on read.
+    location_gln: str | None = None
     timestamp: datetime
     kdes: dict[str, Any] = Field(default_factory=dict)
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1498,6 +1498,7 @@ receiving,TLC-CSV-BAD,Romaine Lettuce,,cases,Distribution Center #4,2026-02-05T1
         "quantity",
         "unit_of_measure",
         "location_name",
+        "location_gln",
         "timestamp",
         "kdes",
     }

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -198,6 +198,56 @@ def test_emitted_events_satisfy_regengine_required_kdes():
     assert seen_ctes == set(REGENGINE_REQUIRED_KDES.keys())
 
 
+def test_emitted_events_carry_location_gln_for_known_locations():
+    """Every event for a known scenario location must emit location_gln.
+
+    The simulator's locations all have GLNs configured in scenarios.py,
+    so every event the engine produces should carry a non-None
+    location_gln populated from engine.location_gln(name).
+    """
+    engine = LegitFlowEngine(seed=204)
+    seen_ctes: set[CTEType] = set()
+
+    for _ in range(200):
+        event, _ = engine.next_event()
+        seen_ctes.add(event.cte_type)
+        # location_name should always resolve in the scenario index, so
+        # location_gln must be populated and match the engine lookup.
+        assert event.location_gln is not None
+        assert event.location_gln == engine.location_gln(event.location_name)
+
+    # We exercised every CTE type the engine actively emits.
+    assert {
+        CTEType.HARVESTING,
+        CTEType.COOLING,
+        CTEType.INITIAL_PACKING,
+        CTEType.SHIPPING,
+        CTEType.RECEIVING,
+        CTEType.TRANSFORMATION,
+    } <= seen_ctes
+
+
+def test_location_gln_or_none_returns_none_for_unknown_location():
+    engine = LegitFlowEngine(seed=204)
+    assert engine._location_gln_or_none("Unknown Place") is None
+
+
+def test_regengine_event_back_compat_loads_old_jsonl_without_location_gln():
+    """Old persisted events lack location_gln; field is Optional so they
+    must still deserialize cleanly with location_gln=None.
+    """
+    from app.schemas.domain import RegEngineEvent
+
+    legacy_payload = (
+        '{"cte_type":"harvesting","traceability_lot_code":"TLC-1",'
+        '"product_description":"Romaine","quantity":100.0,'
+        '"unit_of_measure":"cases","location_name":"Valley Fresh Farms",'
+        '"timestamp":"2026-01-01T00:00:00Z","kdes":{}}'
+    )
+    event = RegEngineEvent.model_validate_json(legacy_payload)
+    assert event.location_gln is None
+
+
 def _has_kde_value(value) -> bool:
     if value is None:
         return False

--- a/tests/test_regengine_client.py
+++ b/tests/test_regengine_client.py
@@ -146,6 +146,7 @@ def test_live_client_sends_required_headers_and_contract_payload(monkeypatch: An
         "quantity",
         "unit_of_measure",
         "location_name",
+        "location_gln",
         "timestamp",
         "kdes",
     }
@@ -156,6 +157,7 @@ def test_live_client_sends_required_headers_and_contract_payload(monkeypatch: An
         "quantity": 500.0,
         "unit_of_measure": "cases",
         "location_name": "Distribution Center #4",
+        "location_gln": None,
         "timestamp": "2026-02-05T08:30:00Z",
         "kdes": {
             "receive_date": "2026-02-05",


### PR DESCRIPTION
## Summary
- Adds optional `location_gln: str | None` to `RegEngineEvent` (top-level, after `location_name`).
- Populates it in every CTE emission block in `app/engine.py` (HARVESTING, COOLING, INITIAL_PACKING, SHIPPING, RECEIVING, TRANSFORMATION) using the existing `engine.location_gln(name)` lookup. Empty-string returns become `None` so RegEngine's IngestEvent validator (which treats `""` as missing) sees a clean optional value.
- Updates `app/cte_rules.py` merged-view so future CTEs that require `location_gln` will find it satisfied at the top level.

## Backward compatibility
- The field is Optional with `default=None`, so existing `data/events.jsonl` rows deserialize cleanly via `StoredEventRecord.model_validate_json`. **No migration code needed.** A regression test loads a legacy-shape JSONL row to lock this guarantee in.

## Wire contract
- RegEngine's `IngestEvent.location_gln` (`services/ingestion/app/webhook_models.py`) accepts an optional GS1 mod-10–validated GLN at the top level — this PR populates exactly that field. Validation stays upstream; we just emit.

## Tests
- New: `test_emitted_events_carry_location_gln_for_known_locations` — every emitted CTE has a populated `location_gln` matching `engine.location_gln(name)`.
- New: `test_location_gln_or_none_returns_none_for_unknown_location`.
- New: `test_regengine_event_back_compat_loads_old_jsonl_without_location_gln`.
- Updated payload-shape asserts in `test_api.py` and `test_regengine_client.py`.
- Full suite: 80 passed (excluding browser/remote/live_trial).

## Out of scope
- `ship_from_gln` / `ship_to_gln` (separate scope per issue).
- Plumbing GLN through EPCIS/FDA exports — they already perform their own GLN lookup; the new event field is additive on the wire.

Closes #48

## Test plan
- [x] `uv run pytest tests/ --ignore=tests/test_browser_smoke.py --ignore=tests/test_remote_smoke.py --ignore=tests/test_live_trial.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)