### PR TITLE
chore: harden Inflow Lab guardrails

### DIFF
--- a/.agents/skills/regengine-api-contract/SKILL.md
+++ b/.agents/skills/regengine-api-contract/SKILL.md
@@ -12,53 +12,28 @@ description: Use this skill when working on RegEngine ingest payloads, FSMA 204 
 - you are changing ingest payload fields, simulator outputs, or lineage behavior
 - you are adding a new delivery target or export path
 
-## Core contract
+## Contract source of truth
 
-Live delivery targets the documented RegEngine ingest webhook:
+Before changing any live-ingest behavior, read
+`references/contract.md`. That file is the local mirror of the RegEngine
+webhook contract and covers:
 
-- endpoint: `https://www.regengine.co/api/v1/webhooks/ingest`
-- required headers:
-  - `X-RegEngine-API-Key`
-  - `X-Tenant-ID`
-  - `Content-Type: application/json`
+- live ingest endpoint and required headers
+- tenant resolution and `X-Tenant-ID`
+- required `Idempotency-Key` behavior
+- optional HMAC signing with `X-Webhook-Signature`
+- accepted CTE types, including `first_land_based_receiving`
+- strict RegEngine KDE requirements by CTE
 
-Expected top-level payload:
-
-```json
-{
-  "source": "erp",
-  "events": [
-    {
-      "cte_type": "receiving",
-      "traceability_lot_code": "00012345678901-LOT-2026-001",
-      "product_description": "Romaine Lettuce",
-      "quantity": 500,
-      "unit_of_measure": "cases",
-      "location_name": "Distribution Center #4",
-      "timestamp": "2026-02-05T08:30:00Z",
-      "kdes": {
-        "receive_date": "2026-02-05",
-        "receiving_location": "Distribution Center #4",
-        "ship_from_location": "Valley Fresh Farms"
-      }
-    }
-  ]
-}
-```
-
-## Supported CTEs in this repo
-
-- `harvesting`
-- `cooling`
-- `initial_packing`
-- `shipping`
-- `receiving`
-- `transformation`
+Do not duplicate the detailed contract shape here. Keeping one detailed
+reference avoids stale skill guidance when RegEngine's webhook handler changes.
 
 ## Guardrails
 
-- Never break the public ingest shape without updating the mock service, tests, README, and frontend.
-- If you add new KDEs, keep them additive and preserve existing keys.
+- Never break the public ingest shape without updating the mock service, tests,
+  README, frontend, and `references/contract.md`.
+- If you add new KDEs, keep them additive and preserve existing keys unless the
+  RegEngine contract reference explicitly changes.
 - When extending the engine, maintain valid lineage between upstream and downstream lots.
 - Prefer mock-first development. Live delivery should stay opt-in.
 

--- a/.github/workflows/codex-autopilot.yml
+++ b/.github/workflows/codex-autopilot.yml
@@ -2,12 +2,6 @@ name: Codex Autopilot
 
 on:
   workflow_dispatch:
-    inputs:
-      auto_merge:
-        description: Enable auto-merge for the generated PR after checks pass.
-        required: false
-        type: boolean
-        default: false
   schedule:
     - cron: '17 14 * * 1-5'
 
@@ -123,6 +117,8 @@ jobs:
             - Prompt file: `.github/codex/prompts/autobuild.md`
             - Guidance files: `AGENTS.md` and `.agents/skills/regengine-api-contract/SKILL.md`
             - Transcript + patch: download the workflow artifact from this run
+            - Merge policy: this workflow only opens or updates a PR. A human review
+              and required status checks must land the change.
           add-paths: |
             .github/**
             .agents/**
@@ -135,11 +131,3 @@ jobs:
             tests/**
             pyproject.toml
             uv.lock
-
-      - name: Enable auto-merge
-        if: >-
-          steps.cpr.outputs.pull-request-number != '' &&
-          (github.event.inputs.auto_merge == 'true' || vars.CODEX_AUTO_MERGE == 'true')
-        run: gh pr merge --squash --auto "${{ steps.cpr.outputs.pull-request-url }}"
-        env:
-          GH_TOKEN: ${{ secrets.CODEX_PR_TOKEN || github.token }}

--- a/app/scenarios.py
+++ b/app/scenarios.py
@@ -60,35 +60,45 @@ class ScenarioPreset:
         return min(self.transform_input_choices)
 
 
+def _gln(location_id: int) -> str:
+    body = f"0850000{location_id:05d}"
+    total = sum(
+        int(digit) * (1 if index % 2 else 3)
+        for index, digit in enumerate(reversed(body))
+    )
+    check_digit = (10 - (total % 10)) % 10
+    return f"{body}{check_digit}"
+
+
 SCENARIO_PRESETS: dict[ScenarioId, ScenarioPreset] = {
     ScenarioId.LEAFY_GREENS_SUPPLIER: ScenarioPreset(
         id=ScenarioId.LEAFY_GREENS_SUPPLIER,
         label="Leafy greens supplier",
         description="Farm-origin leafy greens flowing through cooling, packout, and outbound cold-chain shipments.",
         farms=(
-            Location("Valley Fresh Farms", "farm", "0850000001001", {"gps": "36.6777,-121.6555"}),
-            Location("Desert Bloom Farm", "farm", "0850000001002", {"gps": "32.8473,-115.5671"}),
-            Location("Riverbend Organics", "farm", "0850000001003", {"gps": "38.3149,-121.9018"}),
+            Location("Valley Fresh Farms", "farm", _gln(1001), {"gps": "36.6777,-121.6555"}),
+            Location("Desert Bloom Farm", "farm", _gln(1002), {"gps": "32.8473,-115.5671"}),
+            Location("Riverbend Organics", "farm", _gln(1003), {"gps": "38.3149,-121.9018"}),
         ),
         coolers=(
-            Location("Salinas Cooling Hub", "cooler", "0850000002001"),
-            Location("Imperial Pre-Cool Facility", "cooler", "0850000002002"),
+            Location("Salinas Cooling Hub", "cooler", _gln(2001)),
+            Location("Imperial Pre-Cool Facility", "cooler", _gln(2002)),
         ),
         packers=(
-            Location("FreshPack Central", "packer", "0850000003001"),
-            Location("GreenLeaf Packing House", "packer", "0850000003002"),
+            Location("FreshPack Central", "packer", _gln(3001)),
+            Location("GreenLeaf Packing House", "packer", _gln(3002)),
         ),
         processors=(
-            Location("ReadyFresh Processing Plant", "processor", "0850000004001"),
-            Location("DeliMix Plant", "processor", "0850000004002"),
+            Location("ReadyFresh Processing Plant", "processor", _gln(4001)),
+            Location("DeliMix Plant", "processor", _gln(4002)),
         ),
         dcs=(
-            Location("Distribution Center #4", "dc", "0850000005001"),
-            Location("Distribution Center #7", "dc", "0850000005002"),
+            Location("Distribution Center #4", "dc", _gln(5001)),
+            Location("Distribution Center #7", "dc", _gln(5002)),
         ),
         retailers=(
-            Location("Retail Store #4521", "retail", "0850000006001"),
-            Location("Retail Store #3189", "retail", "0850000006002"),
+            Location("Retail Store #4521", "retail", _gln(6001)),
+            Location("Retail Store #3189", "retail", _gln(6002)),
         ),
         products=(
             ProductSpec("Romaine Lettuce", "cases", "leafy_greens", {"plu": "4640"}),
@@ -121,29 +131,29 @@ SCENARIO_PRESETS: dict[ScenarioId, ScenarioPreset] = {
         label="Fresh-cut processor",
         description="Ingredient lots routed into processor inventory, transformed into fresh-cut outputs, then shipped onward.",
         farms=(
-            Location("Valley Fresh Farms", "farm", "0850000001001", {"gps": "36.6777,-121.6555"}),
-            Location("Coastal Leaf Farm", "farm", "0850000001011", {"gps": "36.6039,-121.8947"}),
-            Location("Desert Bloom Farm", "farm", "0850000001002", {"gps": "32.8473,-115.5671"}),
+            Location("Valley Fresh Farms", "farm", _gln(1001), {"gps": "36.6777,-121.6555"}),
+            Location("Coastal Leaf Farm", "farm", _gln(1011), {"gps": "36.6039,-121.8947"}),
+            Location("Desert Bloom Farm", "farm", _gln(1002), {"gps": "32.8473,-115.5671"}),
         ),
         coolers=(
-            Location("Salinas Cooling Hub", "cooler", "0850000002001"),
-            Location("Coastal Cold Chain", "cooler", "0850000002011"),
+            Location("Salinas Cooling Hub", "cooler", _gln(2001)),
+            Location("Coastal Cold Chain", "cooler", _gln(2011)),
         ),
         packers=(
-            Location("Processor Intake Packout", "packer", "0850000003011"),
-            Location("GreenLeaf Packing House", "packer", "0850000003002"),
+            Location("Processor Intake Packout", "packer", _gln(3011)),
+            Location("GreenLeaf Packing House", "packer", _gln(3002)),
         ),
         processors=(
-            Location("ReadyFresh Processing Plant", "processor", "0850000004001"),
-            Location("Urban Greens Fresh-Cut", "processor", "0850000004011"),
+            Location("ReadyFresh Processing Plant", "processor", _gln(4001)),
+            Location("Urban Greens Fresh-Cut", "processor", _gln(4011)),
         ),
         dcs=(
-            Location("Foodservice DC #12", "dc", "0850000005011"),
-            Location("Regional Cold DC #3", "dc", "0850000005012"),
+            Location("Foodservice DC #12", "dc", _gln(5011)),
+            Location("Regional Cold DC #3", "dc", _gln(5012)),
         ),
         retailers=(
-            Location("Cafe Commissary #88", "retail", "0850000006011"),
-            Location("Retail Store #4521", "retail", "0850000006001"),
+            Location("Cafe Commissary #88", "retail", _gln(6011)),
+            Location("Retail Store #4521", "retail", _gln(6001)),
         ),
         products=(
             ProductSpec("Romaine Lettuce", "cases", "leafy_greens", {"plu": "4640"}),
@@ -178,30 +188,30 @@ SCENARIO_PRESETS: dict[ScenarioId, ScenarioPreset] = {
         label="Retailer readiness demo",
         description="Retail-ready produce flows quickly through DC receiving and store-level downstream receipts.",
         farms=(
-            Location("SunCoast Produce Ranch", "farm", "0850000001021", {"gps": "34.1231,-119.1802"}),
-            Location("Valley Fresh Farms", "farm", "0850000001001", {"gps": "36.6777,-121.6555"}),
-            Location("Riverbend Organics", "farm", "0850000001003", {"gps": "38.3149,-121.9018"}),
+            Location("SunCoast Produce Ranch", "farm", _gln(1021), {"gps": "34.1231,-119.1802"}),
+            Location("Valley Fresh Farms", "farm", _gln(1001), {"gps": "36.6777,-121.6555"}),
+            Location("Riverbend Organics", "farm", _gln(1003), {"gps": "38.3149,-121.9018"}),
         ),
         coolers=(
-            Location("Retail Cold Dock West", "cooler", "0850000002021"),
-            Location("Salinas Cooling Hub", "cooler", "0850000002001"),
+            Location("Retail Cold Dock West", "cooler", _gln(2021)),
+            Location("Salinas Cooling Hub", "cooler", _gln(2001)),
         ),
         packers=(
-            Location("Retail Ready Packout", "packer", "0850000003021"),
-            Location("FreshPack Central", "packer", "0850000003001"),
+            Location("Retail Ready Packout", "packer", _gln(3021)),
+            Location("FreshPack Central", "packer", _gln(3001)),
         ),
         processors=(
-            Location("ReadyFresh Processing Plant", "processor", "0850000004001"),
-            Location("Meal Kit Prep Center", "processor", "0850000004021"),
+            Location("ReadyFresh Processing Plant", "processor", _gln(4001)),
+            Location("Meal Kit Prep Center", "processor", _gln(4021)),
         ),
         dcs=(
-            Location("Retail DC West", "dc", "0850000005021"),
-            Location("Retail DC East", "dc", "0850000005022"),
+            Location("Retail DC West", "dc", _gln(5021)),
+            Location("Retail DC East", "dc", _gln(5022)),
         ),
         retailers=(
-            Location("Retail Store #4521", "retail", "0850000006001"),
-            Location("Retail Store #3189", "retail", "0850000006002"),
-            Location("Urban Market #22", "retail", "0850000006021"),
+            Location("Retail Store #4521", "retail", _gln(6001)),
+            Location("Retail Store #3189", "retail", _gln(6002)),
+            Location("Urban Market #22", "retail", _gln(6021)),
         ),
         products=(
             ProductSpec("Romaine Hearts Retail Pack", "cases", "retail_ready", {"plu": "3097"}),
@@ -236,24 +246,24 @@ SCENARIO_PRESETS: dict[ScenarioId, ScenarioPreset] = {
         description="Wild-caught seafood landed at the dock, first land-based received, portioned, and shipped with vessel-linked records.",
         farms=(),
         coolers=(
-            Location("Kodiak First Receiver Dock", "first_receiver", "0850000002101", {"harbor": "Kodiak"}),
-            Location("Monterey Harbor Seafood Dock", "first_receiver", "0850000002102", {"harbor": "Monterey"}),
+            Location("Kodiak First Receiver Dock", "first_receiver", _gln(2101), {"harbor": "Kodiak"}),
+            Location("Monterey Harbor Seafood Dock", "first_receiver", _gln(2102), {"harbor": "Monterey"}),
         ),
         packers=(
-            Location("North Pacific Seafood Packhouse", "packer", "0850000003101"),
-            Location("Harbor Portioning Line", "packer", "0850000003102"),
+            Location("North Pacific Seafood Packhouse", "packer", _gln(3101)),
+            Location("Harbor Portioning Line", "packer", _gln(3102)),
         ),
         processors=(
-            Location("ColdWave Fillet Plant", "processor", "0850000004101"),
-            Location("Pacific Smokehouse", "processor", "0850000004102"),
+            Location("ColdWave Fillet Plant", "processor", _gln(4101)),
+            Location("Pacific Smokehouse", "processor", _gln(4102)),
         ),
         dcs=(
-            Location("Seafood DC West", "dc", "0850000005101"),
-            Location("Seafood Export Consolidation Hub", "dc", "0850000005102"),
+            Location("Seafood DC West", "dc", _gln(5101)),
+            Location("Seafood Export Consolidation Hub", "dc", _gln(5102)),
         ),
         retailers=(
-            Location("Harbor Market Seafood Counter", "retail", "0850000006101"),
-            Location("Chef Supply Seafood Depot", "retail", "0850000006102"),
+            Location("Harbor Market Seafood Counter", "retail", _gln(6101)),
+            Location("Chef Supply Seafood Depot", "retail", _gln(6102)),
         ),
         products=(
             ProductSpec("Sockeye Salmon", "totes", "seafood", {"species_code": "SAL-SOC"}),
@@ -288,25 +298,25 @@ SCENARIO_PRESETS: dict[ScenarioId, ScenarioPreset] = {
         label="Dairy continuous flow",
         description="Raw milk flows from farm silos into processing vats, is blended in continuous runs, and ships as production-ready dairy inventory.",
         farms=(
-            Location("North Valley Dairy", "farm", "0850000001101", {"gps": "37.4322,-120.7605"}),
-            Location("Sierra Crest Creamery", "farm", "0850000001102", {"gps": "36.9811,-119.7094"}),
+            Location("North Valley Dairy", "farm", _gln(1101), {"gps": "37.4322,-120.7605"}),
+            Location("Sierra Crest Creamery", "farm", _gln(1102), {"gps": "36.9811,-119.7094"}),
         ),
         coolers=(),
         packers=(
-            Location("Creamery Fill Hall", "packer", "0850000003201"),
-            Location("Cultured Dairy Packaging", "packer", "0850000003202"),
+            Location("Creamery Fill Hall", "packer", _gln(3201)),
+            Location("Cultured Dairy Packaging", "packer", _gln(3202)),
         ),
         processors=(
-            Location("Central Pasteurization Plant", "processor", "0850000004201"),
-            Location("Aged Cheese Vat Room", "processor", "0850000004202"),
+            Location("Central Pasteurization Plant", "processor", _gln(4201)),
+            Location("Aged Cheese Vat Room", "processor", _gln(4202)),
         ),
         dcs=(
-            Location("Dairy Cold Storage North", "dc", "0850000005201"),
-            Location("Foodservice Dairy DC", "dc", "0850000005202"),
+            Location("Dairy Cold Storage North", "dc", _gln(5201)),
+            Location("Foodservice Dairy DC", "dc", _gln(5202)),
         ),
         retailers=(
-            Location("Regional Grocery Dairy Depot", "retail", "0850000006201"),
-            Location("Ingredient Buyer Warehouse", "retail", "0850000006202"),
+            Location("Regional Grocery Dairy Depot", "retail", _gln(6201)),
+            Location("Ingredient Buyer Warehouse", "retail", _gln(6202)),
         ),
         products=(
             ProductSpec("Raw Whole Milk", "gallons", "dairy", {"fat_test": "3.7"}),

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -14,7 +14,7 @@ def test_validate_event_kdes_uses_top_level_contract_fields():
         quantity=42.0,
         unit_of_measure="cases",
         location_name="Valley Fresh Farms",
-        location_gln="0850000001001",
+        location_gln="0850000010017",
         timestamp=datetime(2026, 5, 9, 12, 0, tzinfo=UTC),
         kdes={
             "harvest_date": "2026-05-09",
@@ -69,7 +69,7 @@ def test_dairy_audit_uses_shared_rules_for_checks_and_warnings():
             quantity=1000.0,
             unit_of_measure="gallons",
             location_name="Creamline Vat Hall",
-            location_gln="0850000003201",
+            location_gln="0850000032012",
             timestamp=datetime(2026, 5, 9, 12, 0, tzinfo=UTC),
             kdes={
                 "packing_date": "2026-05-09",

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,6 +1,7 @@
 from datetime import UTC, datetime, timedelta
 
 from app.engine import LegitFlowEngine
+from app.scenarios import SCENARIO_PRESETS
 from app.schemas.domain import CTEType
 
 
@@ -70,7 +71,20 @@ def test_engine_emits_all_supported_ctes_and_lineage():
 
 def test_location_gln_lookup():
     engine = LegitFlowEngine(seed=204)
-    assert engine.location_gln("Valley Fresh Farms") == "0850000001001"
+    assert_valid_gln(engine.location_gln("Valley Fresh Farms"))
+
+
+def test_all_scenario_locations_use_valid_gs1_glns():
+    for scenario in SCENARIO_PRESETS.values():
+        for location in [
+            *scenario.farms,
+            *scenario.coolers,
+            *scenario.packers,
+            *scenario.processors,
+            *scenario.dcs,
+            *scenario.retailers,
+        ]:
+            assert_valid_gln(location.gln)
 
 
 def test_location_gln_or_none_returns_none_for_unknown_location():
@@ -186,3 +200,16 @@ def test_events_emit_location_gln_for_known_locations():
     for _ in range(120):
         event, _ = engine.next_event()
         assert event.location_gln == engine.location_gln(event.location_name)
+        assert_valid_gln(event.location_gln)
+
+
+def assert_valid_gln(gln: str | None) -> None:
+    assert gln is not None
+    assert len(gln) == 13
+    assert gln.isdigit()
+    total = sum(
+        int(digit) * (1 if index % 2 else 3)
+        for index, digit in enumerate(reversed(gln[:-1]))
+    )
+    expected = str((10 - (total % 10)) % 10)
+    assert gln[-1] == expected


### PR DESCRIPTION
## Summary
- Make the RegEngine contract skill point to the detailed contract reference instead of duplicating stale payload details
- Remove Codex Autopilot auto-merge inputs and merge step so the workflow only opens/updates PRs
- Generate GS1-valid scenario GLNs and add coverage so live ingest contract checks catch drift locally

## Verification
- actionlint .github/workflows/codex-autopilot.yml
- uv run --frozen --group dev pytest
- uv run python scripts/smoke_regression.py